### PR TITLE
feat(ai): 支持多种 AI API 格式并修复连接测试

### DIFF
--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -65,8 +65,20 @@ export const SettingsPanel: React.FC = () => {
   const [isRestoring, setIsRestoring] = useState(false);
   const [showCustomPrompt, setShowCustomPrompt] = useState(false);
 
-  const [aiForm, setAIForm] = useState({
+  type AIFormState = {
+    name: string;
+    apiType: 'openai' | 'claude' | 'gemini';
+    baseUrl: string;
+    apiKey: string;
+    model: string;
+    customPrompt: string;
+    useCustomPrompt: boolean;
+    concurrency: number;
+  };
+
+  const [aiForm, setAIForm] = useState<AIFormState>({
     name: '',
+    apiType: 'openai',
     baseUrl: '',
     apiKey: '',
     model: '',
@@ -86,6 +98,7 @@ export const SettingsPanel: React.FC = () => {
   const resetAIForm = () => {
     setAIForm({
       name: '',
+      apiType: 'openai',
       baseUrl: '',
       apiKey: '',
       model: '',
@@ -119,6 +132,7 @@ export const SettingsPanel: React.FC = () => {
     const config: AIConfig = {
       id: editingAIId || Date.now().toString(),
       name: aiForm.name,
+      apiType: aiForm.apiType,
       baseUrl: aiForm.baseUrl.replace(/\/$/, ''), // Remove trailing slash
       apiKey: aiForm.apiKey,
       model: aiForm.model,
@@ -140,6 +154,7 @@ export const SettingsPanel: React.FC = () => {
   const handleEditAI = (config: AIConfig) => {
     setAIForm({
       name: config.name,
+      apiType: config.apiType || 'openai',
       baseUrl: config.baseUrl,
       apiKey: config.apiKey,
       model: config.model,
@@ -594,6 +609,21 @@ Focus on practicality and accurate categorization to help users quickly understa
                   placeholder={t('例如: OpenAI GPT-4', 'e.g., OpenAI GPT-4')}
                 />
               </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  {t('接口格式', 'API Format')} *
+                </label>
+                <select
+                  value={aiForm.apiType}
+                  onChange={(e) => setAIForm(prev => ({ ...prev, apiType: e.target.value as 'openai' | 'claude' | 'gemini' }))}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
+                >
+                  <option value="openai">OpenAI</option>
+                  <option value="claude">Claude</option>
+                  <option value="gemini">Gemini</option>
+                </select>
+              </div>
               
               <div>
                 <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
@@ -604,8 +634,20 @@ Focus on practicality and accurate categorization to help users quickly understa
                   value={aiForm.baseUrl}
                   onChange={(e) => setAIForm(prev => ({ ...prev, baseUrl: e.target.value }))}
                   className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
-                  placeholder="https://api.openai.com/v1"
+                  placeholder={
+                    aiForm.apiType === 'openai'
+                      ? 'https://api.openai.com/v1'
+                      : aiForm.apiType === 'claude'
+                        ? 'https://api.anthropic.com/v1'
+                        : 'https://generativelanguage.googleapis.com/v1beta'
+                  }
                 />
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  {t(
+                    '只填到版本号即可（如 .../v1 或 .../v1beta），不要包含 /chat/completions、/messages 或 :generateContent',
+                    'Only include the version prefix (e.g. .../v1 or .../v1beta). Do not include /chat/completions, /messages, or :generateContent.'
+                  )}
+                </p>
               </div>
               
               <div>
@@ -751,7 +793,7 @@ Focus on practicality and accurate categorization to help users quickly understa
                       )}
                     </h4>
                     <p className="text-sm text-gray-500 dark:text-gray-400">
-                      {config.baseUrl} • {config.model} • {t('并发数', 'Concurrency')}: {config.concurrency || 1}
+                      {(config.apiType || 'openai').toUpperCase()} • {config.baseUrl} • {config.model} • {t('并发数', 'Concurrency')}: {config.concurrency || 1}
                     </p>
                   </div>
                 </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,6 +69,7 @@ export interface GitHubUser {
 export interface AIConfig {
   id: string;
   name: string;
+  apiType?: 'openai' | 'claude' | 'gemini'; // API 格式/兼容协议（默认 openai）
   baseUrl: string;
   apiKey: string;
   model: string;


### PR DESCRIPTION
本次改动概览

- 新增 AI 配置字段 apiType，用于选择协议格式（OpenAI / Claude / Gemini）。
- 统一 AI 分析、AI 搜索与连接测试的请求通道，根据 apiType 走对应的请求路径与鉴权方式。
- 优化 baseUrl 拼接逻辑，兼容用户将 baseUrl 填到版本前缀（如 .../v1 或 .../v1beta），避免重复拼接版本段。
- 连接测试改为发起最小可用请求并设置超时，更能真实验证“key + model + endpoint”可用性。

影响范围

- 仅涉及 AI 配置与 AI 服务调用链，不影响仓库列表/筛选等其它业务逻辑。

改动文件

- src/types/index.ts：AIConfig 增加 apiType?: 'openai' | 'claude' | 'gemini'
- src/components/SettingsPanel.tsx：新增 API Format 选择与提示文案
- src/services/aiService.ts：按协议适配 analyze/search/testConnection 的请求实现

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-provider AI support: select between OpenAI, Claude, or Gemini in the AI configuration settings.
  * API Format dropdown now appears in the AI configuration form.
  * Base URL placeholder adapts based on the selected AI provider for clearer guidance.
  * API format is now displayed in the AI configurations list for easy identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->