### PR TITLE
feat(ai): 新增 OpenAI Responses API 支持（保持现有兼容）

### DIFF
--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -100,8 +100,8 @@ router.post('/api/proxy/ai', async (req, res) => {
       'Accept': 'application/json',
     };
 
-    if (apiType === 'openai') {
-      targetUrl = buildApiUrl(baseUrl, 'v1/chat/completions');
+    if (apiType === 'openai' || apiType === 'openai-responses') {
+      targetUrl = buildApiUrl(baseUrl, apiType === 'openai-responses' ? 'v1/responses' : 'v1/chat/completions');
       headers['Authorization'] = `Bearer ${apiKey}`;
     } else if (apiType === 'claude') {
       targetUrl = buildApiUrl(baseUrl, 'v1/messages');

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -94,7 +94,7 @@ export const SettingsPanel: React.FC = () => {
 
   type AIFormState = {
     name: string;
-    apiType: 'openai' | 'claude' | 'gemini';
+    apiType: 'openai' | 'openai-responses' | 'claude' | 'gemini';
     baseUrl: string;
     apiKey: string;
     model: string;
@@ -728,10 +728,11 @@ Focus on practicality and accurate categorization to help users quickly understa
                 </label>
                 <select
                   value={aiForm.apiType}
-                  onChange={(e) => setAIForm(prev => ({ ...prev, apiType: e.target.value as 'openai' | 'claude' | 'gemini' }))}
+                  onChange={(e) => setAIForm(prev => ({ ...prev, apiType: e.target.value as 'openai' | 'openai-responses' | 'claude' | 'gemini' }))}
                   className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
                 >
-                  <option value="openai">OpenAI</option>
+                  <option value="openai">OpenAI (Chat Completions)</option>
+                  <option value="openai-responses">OpenAI (Responses)</option>
                   <option value="claude">Claude</option>
                   <option value="gemini">Gemini</option>
                 </select>
@@ -747,7 +748,7 @@ Focus on practicality and accurate categorization to help users quickly understa
                   onChange={(e) => setAIForm(prev => ({ ...prev, baseUrl: e.target.value }))}
                   className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
                   placeholder={
-                    aiForm.apiType === 'openai'
+                    aiForm.apiType === 'openai' || aiForm.apiType === 'openai-responses'
                       ? 'https://api.openai.com/v1'
                       : aiForm.apiType === 'claude'
                         ? 'https://api.anthropic.com/v1'
@@ -756,8 +757,8 @@ Focus on practicality and accurate categorization to help users quickly understa
                 />
                 <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                   {t(
-                    '只填到版本号即可（如 .../v1 或 .../v1beta），不要包含 /chat/completions、/messages 或 :generateContent',
-                    'Only include the version prefix (e.g. .../v1 or .../v1beta). Do not include /chat/completions, /messages, or :generateContent.'
+                    '只填到版本号即可（如 .../v1 或 .../v1beta），不要包含 /chat/completions、/responses、/messages 或 :generateContent',
+                    'Only include the version prefix (e.g. .../v1 or .../v1beta). Do not include /chat/completions, /responses, /messages, or :generateContent.'
                   )}
                 </p>
               </div>

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -10,8 +10,8 @@ export class AIService {
     this.language = language;
   }
 
-  private getApiType(): 'openai' | 'claude' | 'gemini' {
-    return this.config.apiType || 'openai';
+  private getApiType(): 'openai' | 'openai-responses' | 'claude' | 'gemini' {
+    return (this.config.apiType as 'openai' | 'openai-responses' | 'claude' | 'gemini') || 'openai';
   }
 
   private buildApiUrl(pathWithVersion: string): string {
@@ -50,25 +50,33 @@ export class AIService {
   }): Promise<string> {
     const apiType = this.getApiType();
 
-    if (apiType === 'openai') {
+    if (apiType === 'openai' || apiType === 'openai-responses') {
       const messages = [
         ...(options.system.trim()
           ? [{ role: 'system', content: options.system }]
           : []),
         { role: 'user', content: options.user },
       ];
-      const requestBody = {
-        model: this.config.model,
-        messages,
-        temperature: options.temperature,
-        max_tokens: options.maxTokens,
-      };
+
+      const requestBody = apiType === 'openai-responses'
+        ? {
+            model: this.config.model,
+            input: messages,
+            temperature: options.temperature,
+            max_output_tokens: options.maxTokens,
+          }
+        : {
+            model: this.config.model,
+            messages,
+            temperature: options.temperature,
+            max_tokens: options.maxTokens,
+          };
 
       let data: any;
       if (backend.isAvailable && this.config.id) {
         data = await backend.proxyAIRequest(this.config.id, requestBody);
       } else {
-        const url = this.buildApiUrl('v1/chat/completions');
+        const url = this.buildApiUrl(apiType === 'openai-responses' ? 'v1/responses' : 'v1/chat/completions');
         const response = await fetch(url, {
           method: 'POST',
           headers: {
@@ -85,11 +93,24 @@ export class AIService {
         data = await response.json();
       }
 
-      const content = data.choices?.[0]?.message?.content;
-      if (!content) {
-        throw new Error('No content received from AI service');
+      if (apiType === 'openai-responses') {
+        const outputText = typeof data?.output_text === 'string' ? data.output_text : '';
+        if (outputText) return outputText;
+
+        const output = data?.output;
+        if (Array.isArray(output)) {
+          const text = output
+            .flatMap((item: any) => Array.isArray(item?.content) ? item.content : [])
+            .map((part: any) => (typeof part?.text === 'string' ? part.text : ''))
+            .join('');
+          if (text) return text;
+        }
+      } else {
+        const content = data?.choices?.[0]?.message?.content;
+        if (content) return content;
       }
-      return content;
+
+      throw new Error('No content received from AI service');
     }
 
     if (apiType === 'claude') {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,7 +69,7 @@ export interface GitHubUser {
 export interface AIConfig {
   id: string;
   name: string;
-  apiType?: 'openai' | 'claude' | 'gemini'; // API 格式/兼容协议（默认 openai）
+  apiType?: 'openai' | 'openai-responses' | 'claude' | 'gemini'; // API 格式/兼容协议（默认 openai）
   baseUrl: string;
   apiKey: string;
   model: string;


### PR DESCRIPTION
## 变更说明

为 AI 配置新增可选的 OpenAI Responses 调用通道，**不影响现有 OpenAI Chat Completions / Claude / Gemini**。

### 具体改动

1. 前端 AI 配置新增 API 格式选项：
   - OpenAI (Chat Completions)
   - OpenAI (Responses)
   - Claude
   - Gemini

2. `AIService` 新增 `openai-responses` 分支：
   - 请求地址：`/v1/responses`
   - 请求体：`input + max_output_tokens`
   - 响应解析：优先 `output_text`，回退解析 `output[].content[].text`

3. 后端代理 `server/src/routes/proxy.ts` 同步支持：
   - `api_type === openai-responses` 时转发到 `/v1/responses`

4. 类型更新：
   - `AIConfig.apiType` 扩展为 `'openai' | 'openai-responses' | 'claude' | 'gemini'`

### 兼容性

- 默认仍是 `openai`（chat completions），已有配置无需修改。
- 本改动是新增能力，不改变旧行为。

### 验证

- 前端构建通过：`npm run build`

---

Closes #36


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for OpenAI Responses API endpoint as an alternative configuration option in AI settings, allowing users to select between standard OpenAI and OpenAI Responses endpoints for their integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->