### PR TITLE
fix: 修复仓库更新时间展示与排序语义（优先 pushed_at）

### DIFF
--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -544,7 +544,7 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
           <div className="flex items-center space-x-1">
             <Calendar className="w-4 h-4 flex-shrink-0" />
             <span className="truncate">
-              {language === 'zh' ? '更新于' : 'Updated'} {formatDistanceToNow(new Date(repository.updated_at), { addSuffix: true })}
+              {language === 'zh' ? '最近提交' : 'Last pushed'} {formatDistanceToNow(new Date(repository.pushed_at || repository.updated_at), { addSuffix: true })}
             </span>
           </div>
         </div>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -246,8 +246,8 @@ export const SearchBar: React.FC = () => {
           bValue = b.stargazers_count;
           break;
         case 'updated':
-          aValue = new Date(a.updated_at).getTime();
-          bValue = new Date(b.updated_at).getTime();
+          aValue = new Date(a.pushed_at || a.updated_at).getTime();
+          bValue = new Date(b.pushed_at || b.updated_at).getTime();
           break;
         case 'name':
           aValue = a.name.toLowerCase();
@@ -258,8 +258,8 @@ export const SearchBar: React.FC = () => {
           bValue = b.starred_at ? new Date(b.starred_at).getTime() : 0;
           break;
         default:
-          aValue = new Date(a.updated_at).getTime();
-          bValue = new Date(b.updated_at).getTime();
+          aValue = new Date(a.pushed_at || a.updated_at).getTime();
+          bValue = new Date(b.pushed_at || b.updated_at).getTime();
       }
 
       if (searchFilters.sortOrder === 'desc') {

--- a/src/components/SearchResultStats.tsx
+++ b/src/components/SearchResultStats.tsx
@@ -36,7 +36,7 @@ export const SearchResultStats: React.FC<SearchResultStatsProps> = ({
       : 0,
     aiAnalyzed: filteredRepositories.filter(r => r.analyzed_at).length,
     recentlyUpdated: filteredRepositories.filter(r => {
-      const updatedDate = new Date(r.updated_at);
+      const updatedDate = new Date(r.pushed_at || r.updated_at);
       const thirtyDaysAgo = new Date();
       thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
       return updatedDate > thirtyDaysAgo;


### PR DESCRIPTION
## 问题原因

Issue #22 的“更新时间不正确”主要是语义偏差导致：

- 现有 UI 与“按更新排序”使用的是 `updated_at`
- 但用户通常理解的“最近更新”是代码最近提交/推送时间，更接近 `pushed_at`

因此会出现和用户预期不一致的情况。

## 修复内容

1. 仓库卡片时间展示：
   - 从 `updated_at` 改为优先 `pushed_at`，缺失时回退 `updated_at`
   - 文案从“更新于 / Updated”调整为“最近提交 / Last pushed”

2. 搜索排序中“按更新排序”（以及默认分支）
   - 改为优先按 `pushed_at` 排序，回退 `updated_at`

3. 搜索统计里的“近期更新（30天内）”
   - 改为优先使用 `pushed_at` 判断，回退 `updated_at`

## 兼容性

- 仅调整时间字段优先级与文案，不影响数据结构和其他功能。
- 若某些仓库缺失 `pushed_at`，会自动回退到原有 `updated_at` 逻辑。

---

Closes #22


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Repository timestamps now use last push time instead of update time for more accurate recency tracking across displays and sorting.
  * Updated label from "Updated" to "Last pushed" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->