### PR TITLE
fix: 修复空分类场景白屏（Hook 调用顺序问题）

### DIFF
--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -26,7 +26,8 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
     language,
     customCategories,
     analysisProgress,
-    setAnalysisProgress
+    setAnalysisProgress,
+    searchFilters
   } = useAppStore();
 
   const [showAISummary, setShowAISummary] = useState(true);
@@ -295,7 +296,6 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
   if (filteredRepositories.length === 0) {
     const selectedCategoryObj = allCategories.find(cat => cat.id === selectedCategory);
     const categoryName = selectedCategoryObj?.name || selectedCategory;
-    const { searchFilters } = useAppStore();
     
     return (
       <div className="text-center py-12">


### PR DESCRIPTION
## 根因分析

Issue #38（分类数量为 0 时白屏）的根因是 `RepositoryList` 中存在 **条件分支内调用 Hook**：

- 当 `filteredRepositories.length === 0` 时，代码路径里调用了 `useAppStore()`
- 当列表非空时，这个 Hook 不会被调用

这违反了 React Hook 规则（Hooks 必须在组件顶层且每次渲染顺序一致），会导致运行时异常，表现为白屏。

## 修复方案

- 将 `searchFilters` 从组件顶层一次性通过 `useAppStore()` 解构出来
- 删除空列表分支内的 `useAppStore()` 调用

这样无论分类是否为空，Hook 调用顺序都一致，避免白屏。

## 影响范围

- 仅修改 `src/components/RepositoryList.tsx`
- 不改变业务逻辑，只修复 Hook 调用位置

## 验证

- 前端构建通过：`npm run build`
- 逻辑上可覆盖“分类数量为 0”场景，不再触发 Hook 顺序错误

---

Closes #38


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search query integration to repository cards for improved search result display.

* **Refactor**
  * Updated repository list component to leverage centralized search state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->