### PR TITLE
feat(filter): add category filter in search panel

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -221,13 +221,46 @@ export const SearchBar: React.FC = () => {
       });
     }
 
-    // Category filter (by manual category name first)
+    // Category filter (manual category first, then inferred matching)
     if (searchFilters.categories.length > 0) {
+      const allCategoryObjects = getAllCategories(customCategories, language).filter(cat => cat.id !== 'all');
+      const selectedCategoryObjects = allCategoryObjects.filter(cat => searchFilters.categories.includes(cat.name));
+
       filtered = filtered.filter(repo => {
-        if (repo.custom_category) {
-          return searchFilters.categories.includes(repo.custom_category);
+        // 1) manual category takes priority
+        if (repo.custom_category && searchFilters.categories.includes(repo.custom_category)) {
+          return true;
         }
-        return false;
+
+        if (selectedCategoryObjects.length === 0) {
+          return false;
+        }
+
+        // 2) infer from AI tags
+        if (repo.ai_tags && repo.ai_tags.length > 0) {
+          const matchedByTags = selectedCategoryObjects.some(category =>
+            repo.ai_tags!.some(tag =>
+              category.keywords.some(keyword =>
+                tag.toLowerCase().includes(keyword.toLowerCase()) ||
+                keyword.toLowerCase().includes(tag.toLowerCase())
+              )
+            )
+          );
+          if (matchedByTags) return true;
+        }
+
+        // 3) fallback text matching
+        const repoText = [
+          repo.name,
+          repo.description || '',
+          repo.language || '',
+          ...(repo.topics || []),
+          repo.ai_summary || ''
+        ].join(' ').toLowerCase();
+
+        return selectedCategoryObjects.some(category =>
+          category.keywords.some(keyword => repoText.includes(keyword.toLowerCase()))
+        );
       });
     }
 

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Search, Filter, X, SlidersHorizontal, Monitor, Smartphone, Globe, Terminal, Package, CheckCircle, Bell, BellOff, Apple, Bot } from 'lucide-react';
-import { useAppStore } from '../store/useAppStore';
+import { useAppStore, getAllCategories } from '../store/useAppStore';
 import { AIService } from '../services/aiService';
 
 
@@ -12,6 +12,7 @@ export const SearchBar: React.FC = () => {
     aiConfigs,
     activeAIConfig,
     language,
+    customCategories,
     setSearchFilters,
     setSearchResults,
   } = useAppStore();
@@ -22,6 +23,7 @@ export const SearchBar: React.FC = () => {
   const [availableLanguages, setAvailableLanguages] = useState<string[]>([]);
   const [availableTags, setAvailableTags] = useState<string[]>([]);
   const [availablePlatforms, setAvailablePlatforms] = useState<string[]>([]);
+  const [availableCategories, setAvailableCategories] = useState<string[]>([]);
   const [isRealTimeSearch, setIsRealTimeSearch] = useState(false);
   const [searchHistory, setSearchHistory] = useState<string[]>([]);
   const [showSearchHistory, setShowSearchHistory] = useState(false);
@@ -42,6 +44,11 @@ export const SearchBar: React.FC = () => {
     setAvailableTags(tags);
     setAvailablePlatforms(platforms);
 
+    const allCategories = getAllCategories(customCategories, language)
+      .filter(cat => cat.id !== 'all')
+      .map(cat => cat.name);
+    setAvailableCategories(allCategories);
+
     // Generate search suggestions from available data
     const suggestions = [
       ...languages.slice(0, 5),
@@ -60,7 +67,7 @@ export const SearchBar: React.FC = () => {
         console.warn('Failed to load search history:', error);
       }
     }
-  }, [repositories]);
+  }, [repositories, customCategories, language]);
 
   useEffect(() => {
     // Only perform search when filters change (not when query changes from AI search)
@@ -72,7 +79,7 @@ export const SearchBar: React.FC = () => {
     };
 
     performSearch();
-  }, [searchFilters.languages, searchFilters.tags, searchFilters.platforms, searchFilters.isAnalyzed, searchFilters.isSubscribed, searchFilters.minStars, searchFilters.maxStars, searchFilters.sortBy, searchFilters.sortOrder, repositories, releaseSubscriptions]);
+  }, [searchFilters.languages, searchFilters.tags, searchFilters.platforms, searchFilters.categories, searchFilters.isAnalyzed, searchFilters.isSubscribed, searchFilters.minStars, searchFilters.maxStars, searchFilters.sortBy, searchFilters.sortOrder, repositories, releaseSubscriptions]);
 
   // Real-time search effect for repository name matching
   useEffect(() => {
@@ -211,6 +218,16 @@ export const SearchBar: React.FC = () => {
       filtered = filtered.filter(repo => {
         const repoPlatforms = repo.ai_platforms || [];
         return searchFilters.platforms.some(platform => repoPlatforms.includes(platform));
+      });
+    }
+
+    // Category filter (by manual category name first)
+    if (searchFilters.categories.length > 0) {
+      filtered = filtered.filter(repo => {
+        if (repo.custom_category) {
+          return searchFilters.categories.includes(repo.custom_category);
+        }
+        return false;
       });
     }
 
@@ -438,6 +455,13 @@ export const SearchBar: React.FC = () => {
     setSearchFilters({ platforms: newPlatforms });
   };
 
+  const handleCategoryToggle = (category: string) => {
+    const newCategories = searchFilters.categories.includes(category)
+      ? searchFilters.categories.filter(c => c !== category)
+      : [...searchFilters.categories, category];
+    setSearchFilters({ categories: newCategories });
+  };
+
   const clearFilters = () => {
     setSearchQuery('');
     setIsRealTimeSearch(false);
@@ -446,6 +470,7 @@ export const SearchBar: React.FC = () => {
       tags: [],
       languages: [],
       platforms: [],
+      categories: [],
       sortBy: 'stars',
       sortOrder: 'desc',
       minStars: undefined,
@@ -459,6 +484,7 @@ export const SearchBar: React.FC = () => {
     searchFilters.languages.length + 
     searchFilters.tags.length + 
     searchFilters.platforms.length +
+    searchFilters.categories.length +
     (searchFilters.minStars !== undefined ? 1 : 0) +
     (searchFilters.maxStars !== undefined ? 1 : 0) +
     (searchFilters.isAnalyzed !== undefined ? 1 : 0) +
@@ -796,6 +822,30 @@ export const SearchBar: React.FC = () => {
                   >
                     {React.createElement(getPlatformIcon(platform), { className: "w-4 h-4" })}
                     <span>{getPlatformDisplayName(platform)}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Category */}
+          {availableCategories.length > 0 && (
+            <div>
+              <h4 className="text-sm font-medium text-gray-900 dark:text-white mb-3">
+                {t('分类', 'Categories')}
+              </h4>
+              <div className="flex flex-wrap gap-2">
+                {availableCategories.map(category => (
+                  <button
+                    key={category}
+                    onClick={() => handleCategoryToggle(category)}
+                    className={`px-3 py-1.5 rounded-lg text-sm transition-colors ${
+                      searchFilters.categories.includes(category)
+                        ? 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-300'
+                        : 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
+                    }`}
+                  >
+                    {category}
                   </button>
                 ))}
               </div>

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -72,6 +72,7 @@ const initialSearchFilters: SearchFilters = {
   tags: [],
   languages: [],
   platforms: [],
+  categories: [],
   sortBy: 'stars',
   sortOrder: 'desc',
   isAnalyzed: undefined,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -95,6 +95,7 @@ export interface SearchFilters {
   tags: string[];
   languages: string[];
   platforms: string[]; // 新增：平台过滤
+  categories: string[]; // 分类过滤（按分类名称）
   sortBy: 'stars' | 'updated' | 'name' | 'starred';
   sortOrder: 'desc' | 'asc';
   minStars?: number;


### PR DESCRIPTION
## Summary
Resolve #28 by adding category filter support in the filter panel.

### Changes
- Add `categories` to `SearchFilters`
- Add category options (from default + custom categories) in SearchBar filter section
- Add category toggle handler and include category filter in active filter count
- Apply category filtering logic (manual `custom_category` matching)
- Clear category filters in the "Clear all" action

## Notes
This keeps behavior intuitive for users who manually manage categories and want category-level filtering from the filter panel.

Fixes #28


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Category-based filtering added to search: a new Categories section shows available category buttons to toggle and refine results. Selections update the active filters count, can be cleared with other filters, and recompute when category or language data changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->