### PR TITLE
fix: restore macOS quit/close shortcuts

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -281,7 +281,7 @@ jobs:
           '  mainWindow.once(\\'ready-to-show\\', () => {\\n' +
           '    mainWindow.show();\\n' +
           '  });\\n\\n' +
-          '            '  // 提供稳定的菜单与编辑快捷键（生产环境）\n' +
+          '            '            '  // 提供稳定的菜单与编辑快捷键（生产环境）\n' +
           '  const menuTemplate = process.platform === \'darwin\' ? [\n' +
           '    {\n' +
           '      label: app.name,\n' +
@@ -366,6 +366,7 @@ jobs:
           '    }\n' +
           '  ];\n' +
           '  Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));\n' +
+          '\n' +
           '\n' +
 
           '  mainWindow.webContents.setWindowOpenHandler(({ url }) => {\\n' +

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -281,36 +281,93 @@ jobs:
           '  mainWindow.once(\\'ready-to-show\\', () => {\\n' +
           '    mainWindow.show();\\n' +
           '  });\\n\\n' +
-          '  // 提供稳定的菜单与编辑快捷键（生产环境）\\n' +
-          '  const menuTemplate = [\\n' +
-          '    {\\n' +
-          '      label: \\'Edit\\',\\n' +
-          '      submenu: [\\n' +
-          '        { role: \\'undo\\' },\\n' +
-          '        { role: \\'redo\\' },\\n' +
-          '        { type: \\'separator\\' },\\n' +
-          '        { role: \\'cut\\' },\\n' +
-          '        { role: \\'copy\\' },\\n' +
-          '        { role: \\'paste\\' },\\n' +
-          '        { role: \\'selectAll\\' }\\n' +
-          '      ]\\n' +
-          '    },\\n' +
-          '    {\\n' +
-          '      label: \\'View\\',\\n' +
-          '      submenu: [\\n' +
-          '        { role: \\'reload\\' },\\n' +
-          '        { role: \\'forceReload\\' },\\n' +
-          '        { type: \\'separator\\' },\\n' +
-          '        { role: \\'toggleDevTools\\' },\\n' +
-          '        { type: \\'separator\\' },\\n' +
-          '        { role: \\'resetZoom\\' },\\n' +
-          '        { role: \\'zoomIn\\' },\\n' +
-          '        { role: \\'zoomOut\\' },\\n' +
-          '        { role: \\'togglefullscreen\\' }\\n' +
-          '      ]\\n' +
-          '    }\\n' +
-          '  ];\\n' +
-          '  Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));\\n\\n' +
+          '            '  // 提供稳定的菜单与编辑快捷键（生产环境）\n' +
+          '  const menuTemplate = process.platform === \'darwin\' ? [\n' +
+          '    {\n' +
+          '      label: app.name,\n' +
+          '      submenu: [\n' +
+          '        { role: \'about\' },\n' +
+          '        { type: \'separator\' },\n' +
+          '        { role: \'services\' },\n' +
+          '        { type: \'separator\' },\n' +
+          '        { role: \'hide\' },\n' +
+          '        { role: \'hideOthers\' },\n' +
+          '        { role: \'unhide\' },\n' +
+          '        { type: \'separator\' },\n' +
+          '        { role: \'quit\' }\n' +
+          '      ]\n' +
+          '    },\n' +
+          '    {\n' +
+          '      label: \'Edit\',\n' +
+          '      submenu: [\n' +
+          '        { role: \'undo\' },\n' +
+          '        { role: \'redo\' },\n' +
+          '        { type: \'separator\' },\n' +
+          '        { role: \'cut\' },\n' +
+          '        { role: \'copy\' },\n' +
+          '        { role: \'paste\' },\n' +
+          '        { role: \'selectAll\' }\n' +
+          '      ]\n' +
+          '    },\n' +
+          '    {\n' +
+          '      label: \'View\',\n' +
+          '      submenu: [\n' +
+          '        { role: \'reload\' },\n' +
+          '        { role: \'forceReload\' },\n' +
+          '        { type: \'separator\' },\n' +
+          '        { role: \'toggleDevTools\' },\n' +
+          '        { type: \'separator\' },\n' +
+          '        { role: \'resetZoom\' },\n' +
+          '        { role: \'zoomIn\' },\n' +
+          '        { role: \'zoomOut\' },\n' +
+          '        { role: \'togglefullscreen\' }\n' +
+          '      ]\n' +
+          '    },\n' +
+          '    {\n' +
+          '      label: \'Window\',\n' +
+          '      submenu: [\n' +
+          '        { role: \'minimize\' },\n' +
+          '        { role: \'close\' }\n' +
+          '      ]\n' +
+          '    }\n' +
+          '  ] : [\n' +
+          '    {\n' +
+          '      label: \'Edit\',\n' +
+          '      submenu: [\n' +
+          '        { role: \'undo\' },\n' +
+          '        { role: \'redo\' },\n' +
+          '        { type: \'separator\' },\n' +
+          '        { role: \'cut\' },\n' +
+          '        { role: \'copy\' },\n' +
+          '        { role: \'paste\' },\n' +
+          '        { role: \'selectAll\' }\n' +
+          '      ]\n' +
+          '    },\n' +
+          '    {\n' +
+          '      label: \'View\',\n' +
+          '      submenu: [\n' +
+          '        { role: \'reload\' },\n' +
+          '        { role: \'forceReload\' },\n' +
+          '        { type: \'separator\' },\n' +
+          '        { role: \'toggleDevTools\' },\n' +
+          '        { type: \'separator\' },\n' +
+          '        { role: \'resetZoom\' },\n' +
+          '        { role: \'zoomIn\' },\n' +
+          '        { role: \'zoomOut\' },\n' +
+          '        { role: \'togglefullscreen\' }\n' +
+          '      ]\n' +
+          '    },\n' +
+          '    {\n' +
+          '      label: \'Window\',\n' +
+          '      submenu: [\n' +
+          '        { role: \'minimize\' },\n' +
+          '        { role: \'close\' }\n' +
+          '      ]\n' +
+          '    }\n' +
+          '  ];\n' +
+          '  Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));\n' +
+          '\n' +
+
           '  mainWindow.webContents.setWindowOpenHandler(({ url }) => {\\n' +
           '    shell.openExternal(url);\\n' +
           '    return { action: \\'deny\\' };\\n' +

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -281,94 +281,92 @@ jobs:
           '  mainWindow.once(\\'ready-to-show\\', () => {\\n' +
           '    mainWindow.show();\\n' +
           '  });\\n\\n' +
-          '            '            '  // 提供稳定的菜单与编辑快捷键（生产环境）\n' +
-          '  const menuTemplate = process.platform === \'darwin\' ? [\n' +
-          '    {\n' +
-          '      label: app.name,\n' +
-          '      submenu: [\n' +
-          '        { role: \'about\' },\n' +
-          '        { type: \'separator\' },\n' +
-          '        { role: \'services\' },\n' +
-          '        { type: \'separator\' },\n' +
-          '        { role: \'hide\' },\n' +
-          '        { role: \'hideOthers\' },\n' +
-          '        { role: \'unhide\' },\n' +
-          '        { type: \'separator\' },\n' +
-          '        { role: \'quit\' }\n' +
-          '      ]\n' +
-          '    },\n' +
-          '    {\n' +
-          '      label: \'Edit\',\n' +
-          '      submenu: [\n' +
-          '        { role: \'undo\' },\n' +
-          '        { role: \'redo\' },\n' +
-          '        { type: \'separator\' },\n' +
-          '        { role: \'cut\' },\n' +
-          '        { role: \'copy\' },\n' +
-          '        { role: \'paste\' },\n' +
-          '        { role: \'selectAll\' }\n' +
-          '      ]\n' +
-          '    },\n' +
-          '    {\n' +
-          '      label: \'View\',\n' +
-          '      submenu: [\n' +
-          '        { role: \'reload\' },\n' +
-          '        { role: \'forceReload\' },\n' +
-          '        { type: \'separator\' },\n' +
-          '        { role: \'toggleDevTools\' },\n' +
-          '        { type: \'separator\' },\n' +
-          '        { role: \'resetZoom\' },\n' +
-          '        { role: \'zoomIn\' },\n' +
-          '        { role: \'zoomOut\' },\n' +
-          '        { role: \'togglefullscreen\' }\n' +
-          '      ]\n' +
-          '    },\n' +
-          '    {\n' +
-          '      label: \'Window\',\n' +
-          '      submenu: [\n' +
-          '        { role: \'minimize\' },\n' +
-          '        { role: \'close\' }\n' +
-          '      ]\n' +
-          '    }\n' +
-          '  ] : [\n' +
-          '    {\n' +
-          '      label: \'Edit\',\n' +
-          '      submenu: [\n' +
-          '        { role: \'undo\' },\n' +
-          '        { role: \'redo\' },\n' +
-          '        { type: \'separator\' },\n' +
-          '        { role: \'cut\' },\n' +
-          '        { role: \'copy\' },\n' +
-          '        { role: \'paste\' },\n' +
-          '        { role: \'selectAll\' }\n' +
-          '      ]\n' +
-          '    },\n' +
-          '    {\n' +
-          '      label: \'View\',\n' +
-          '      submenu: [\n' +
-          '        { role: \'reload\' },\n' +
-          '        { role: \'forceReload\' },\n' +
-          '        { type: \'separator\' },\n' +
-          '        { role: \'toggleDevTools\' },\n' +
-          '        { type: \'separator\' },\n' +
-          '        { role: \'resetZoom\' },\n' +
-          '        { role: \'zoomIn\' },\n' +
-          '        { role: \'zoomOut\' },\n' +
-          '        { role: \'togglefullscreen\' }\n' +
-          '      ]\n' +
-          '    },\n' +
-          '    {\n' +
-          '      label: \'Window\',\n' +
-          '      submenu: [\n' +
-          '        { role: \'minimize\' },\n' +
-          '        { role: \'close\' }\n' +
-          '      ]\n' +
-          '    }\n' +
-          '  ];\n' +
-          '  Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));\n' +
-          '\n' +
-          '\n' +
-
+          "  // \u63d0\u4f9b\u7a33\u5b9a\u7684\u83dc\u5355\u4e0e\u7f16\u8f91\u5feb\u6377\u952e\uff08\u751f\u4ea7\u73af\u5883\uff09\\n" +
+          "  const menuTemplate = process.platform === 'darwin' ? [\\n" +
+          "    {\\n" +
+          "      label: app.name,\\n" +
+          "      submenu: [\\n" +
+          "        { role: 'about' },\\n" +
+          "        { type: 'separator' },\\n" +
+          "        { role: 'services' },\\n" +
+          "        { type: 'separator' },\\n" +
+          "        { role: 'hide' },\\n" +
+          "        { role: 'hideOthers' },\\n" +
+          "        { role: 'unhide' },\\n" +
+          "        { type: 'separator' },\\n" +
+          "        { role: 'quit' }\\n" +
+          "      ]\\n" +
+          "    },\\n" +
+          "    {\\n" +
+          "      label: 'Edit',\\n" +
+          "      submenu: [\\n" +
+          "        { role: 'undo' },\\n" +
+          "        { role: 'redo' },\\n" +
+          "        { type: 'separator' },\\n" +
+          "        { role: 'cut' },\\n" +
+          "        { role: 'copy' },\\n" +
+          "        { role: 'paste' },\\n" +
+          "        { role: 'selectAll' }\\n" +
+          "      ]\\n" +
+          "    },\\n" +
+          "    {\\n" +
+          "      label: 'View',\\n" +
+          "      submenu: [\\n" +
+          "        { role: 'reload' },\\n" +
+          "        { role: 'forceReload' },\\n" +
+          "        { type: 'separator' },\\n" +
+          "        { role: 'toggleDevTools' },\\n" +
+          "        { type: 'separator' },\\n" +
+          "        { role: 'resetZoom' },\\n" +
+          "        { role: 'zoomIn' },\\n" +
+          "        { role: 'zoomOut' },\\n" +
+          "        { role: 'togglefullscreen' }\\n" +
+          "      ]\\n" +
+          "    },\\n" +
+          "    {\\n" +
+          "      label: 'Window',\\n" +
+          "      submenu: [\\n" +
+          "        { role: 'minimize' },\\n" +
+          "        { role: 'close' }\\n" +
+          "      ]\\n" +
+          "    }\\n" +
+          "  ] : [\\n" +
+          "    {\\n" +
+          "      label: 'Edit',\\n" +
+          "      submenu: [\\n" +
+          "        { role: 'undo' },\\n" +
+          "        { role: 'redo' },\\n" +
+          "        { type: 'separator' },\\n" +
+          "        { role: 'cut' },\\n" +
+          "        { role: 'copy' },\\n" +
+          "        { role: 'paste' },\\n" +
+          "        { role: 'selectAll' }\\n" +
+          "      ]\\n" +
+          "    },\\n" +
+          "    {\\n" +
+          "      label: 'View',\\n" +
+          "      submenu: [\\n" +
+          "        { role: 'reload' },\\n" +
+          "        { role: 'forceReload' },\\n" +
+          "        { type: 'separator' },\\n" +
+          "        { role: 'toggleDevTools' },\\n" +
+          "        { type: 'separator' },\\n" +
+          "        { role: 'resetZoom' },\\n" +
+          "        { role: 'zoomIn' },\\n" +
+          "        { role: 'zoomOut' },\\n" +
+          "        { role: 'togglefullscreen' }\\n" +
+          "      ]\\n" +
+          "    },\\n" +
+          "    {\\n" +
+          "      label: 'Window',\\n" +
+          "      submenu: [\\n" +
+          "        { role: 'minimize' },\\n" +
+          "        { role: 'close' }\\n" +
+          "      ]\\n" +
+          "    }\\n" +
+          "  ];\\n" +
+          "  Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));\\n" +
+          "\\n" +
           '  mainWindow.webContents.setWindowOpenHandler(({ url }) => {\\n' +
           '    shell.openExternal(url);\\n' +
           '    return { action: \\'deny\\' };\\n' +

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -281,92 +281,92 @@ jobs:
           '  mainWindow.once(\\'ready-to-show\\', () => {\\n' +
           '    mainWindow.show();\\n' +
           '  });\\n\\n' +
-          "  // \u63d0\u4f9b\u7a33\u5b9a\u7684\u83dc\u5355\u4e0e\u7f16\u8f91\u5feb\u6377\u952e\uff08\u751f\u4ea7\u73af\u5883\uff09\\n" +
-          "  const menuTemplate = process.platform === 'darwin' ? [\\n" +
-          "    {\\n" +
-          "      label: app.name,\\n" +
-          "      submenu: [\\n" +
-          "        { role: 'about' },\\n" +
-          "        { type: 'separator' },\\n" +
-          "        { role: 'services' },\\n" +
-          "        { type: 'separator' },\\n" +
-          "        { role: 'hide' },\\n" +
-          "        { role: 'hideOthers' },\\n" +
-          "        { role: 'unhide' },\\n" +
-          "        { type: 'separator' },\\n" +
-          "        { role: 'quit' }\\n" +
-          "      ]\\n" +
-          "    },\\n" +
-          "    {\\n" +
-          "      label: 'Edit',\\n" +
-          "      submenu: [\\n" +
-          "        { role: 'undo' },\\n" +
-          "        { role: 'redo' },\\n" +
-          "        { type: 'separator' },\\n" +
-          "        { role: 'cut' },\\n" +
-          "        { role: 'copy' },\\n" +
-          "        { role: 'paste' },\\n" +
-          "        { role: 'selectAll' }\\n" +
-          "      ]\\n" +
-          "    },\\n" +
-          "    {\\n" +
-          "      label: 'View',\\n" +
-          "      submenu: [\\n" +
-          "        { role: 'reload' },\\n" +
-          "        { role: 'forceReload' },\\n" +
-          "        { type: 'separator' },\\n" +
-          "        { role: 'toggleDevTools' },\\n" +
-          "        { type: 'separator' },\\n" +
-          "        { role: 'resetZoom' },\\n" +
-          "        { role: 'zoomIn' },\\n" +
-          "        { role: 'zoomOut' },\\n" +
-          "        { role: 'togglefullscreen' }\\n" +
-          "      ]\\n" +
-          "    },\\n" +
-          "    {\\n" +
-          "      label: 'Window',\\n" +
-          "      submenu: [\\n" +
-          "        { role: 'minimize' },\\n" +
-          "        { role: 'close' }\\n" +
-          "      ]\\n" +
-          "    }\\n" +
-          "  ] : [\\n" +
-          "    {\\n" +
-          "      label: 'Edit',\\n" +
-          "      submenu: [\\n" +
-          "        { role: 'undo' },\\n" +
-          "        { role: 'redo' },\\n" +
-          "        { type: 'separator' },\\n" +
-          "        { role: 'cut' },\\n" +
-          "        { role: 'copy' },\\n" +
-          "        { role: 'paste' },\\n" +
-          "        { role: 'selectAll' }\\n" +
-          "      ]\\n" +
-          "    },\\n" +
-          "    {\\n" +
-          "      label: 'View',\\n" +
-          "      submenu: [\\n" +
-          "        { role: 'reload' },\\n" +
-          "        { role: 'forceReload' },\\n" +
-          "        { type: 'separator' },\\n" +
-          "        { role: 'toggleDevTools' },\\n" +
-          "        { type: 'separator' },\\n" +
-          "        { role: 'resetZoom' },\\n" +
-          "        { role: 'zoomIn' },\\n" +
-          "        { role: 'zoomOut' },\\n" +
-          "        { role: 'togglefullscreen' }\\n" +
-          "      ]\\n" +
-          "    },\\n" +
-          "    {\\n" +
-          "      label: 'Window',\\n" +
-          "      submenu: [\\n" +
-          "        { role: 'minimize' },\\n" +
-          "        { role: 'close' }\\n" +
-          "      ]\\n" +
-          "    }\\n" +
-          "  ];\\n" +
-          "  Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));\\n" +
-          "\\n" +
+          '  // 提供稳定的菜单与编辑快捷键（生产环境）\n' +
+          '  const menuTemplate = process.platform === \'darwin\' ? [\n' +
+          '    {\n' +
+          '      label: app.name,\n' +
+          '      submenu: [\n' +
+          '        { role: \'about\' },\n' +
+          '        { type: \'separator\' },\n' +
+          '        { role: \'services\' },\n' +
+          '        { type: \'separator\' },\n' +
+          '        { role: \'hide\' },\n' +
+          '        { role: \'hideOthers\' },\n' +
+          '        { role: \'unhide\' },\n' +
+          '        { type: \'separator\' },\n' +
+          '        { role: \'quit\' }\n' +
+          '      ]\n' +
+          '    },\n' +
+          '    {\n' +
+          '      label: \'Edit\',\n' +
+          '      submenu: [\n' +
+          '        { role: \'undo\' },\n' +
+          '        { role: \'redo\' },\n' +
+          '        { type: \'separator\' },\n' +
+          '        { role: \'cut\' },\n' +
+          '        { role: \'copy\' },\n' +
+          '        { role: \'paste\' },\n' +
+          '        { role: \'selectAll\' }\n' +
+          '      ]\n' +
+          '    },\n' +
+          '    {\n' +
+          '      label: \'View\',\n' +
+          '      submenu: [\n' +
+          '        { role: \'reload\' },\n' +
+          '        { role: \'forceReload\' },\n' +
+          '        { type: \'separator\' },\n' +
+          '        { role: \'toggleDevTools\' },\n' +
+          '        { type: \'separator\' },\n' +
+          '        { role: \'resetZoom\' },\n' +
+          '        { role: \'zoomIn\' },\n' +
+          '        { role: \'zoomOut\' },\n' +
+          '        { role: \'togglefullscreen\' }\n' +
+          '      ]\n' +
+          '    },\n' +
+          '    {\n' +
+          '      label: \'Window\',\n' +
+          '      submenu: [\n' +
+          '        { role: \'minimize\' },\n' +
+          '        { role: \'close\' }\n' +
+          '      ]\n' +
+          '    }\n' +
+          '  ] : [\n' +
+          '    {\n' +
+          '      label: \'Edit\',\n' +
+          '      submenu: [\n' +
+          '        { role: \'undo\' },\n' +
+          '        { role: \'redo\' },\n' +
+          '        { type: \'separator\' },\n' +
+          '        { role: \'cut\' },\n' +
+          '        { role: \'copy\' },\n' +
+          '        { role: \'paste\' },\n' +
+          '        { role: \'selectAll\' }\n' +
+          '      ]\n' +
+          '    },\n' +
+          '    {\n' +
+          '      label: \'View\',\n' +
+          '      submenu: [\n' +
+          '        { role: \'reload\' },\n' +
+          '        { role: \'forceReload\' },\n' +
+          '        { type: \'separator\' },\n' +
+          '        { role: \'toggleDevTools\' },\n' +
+          '        { type: \'separator\' },\n' +
+          '        { role: \'resetZoom\' },\n' +
+          '        { role: \'zoomIn\' },\n' +
+          '        { role: \'zoomOut\' },\n' +
+          '        { role: \'togglefullscreen\' }\n' +
+          '      ]\n' +
+          '    },\n' +
+          '    {\n' +
+          '      label: \'Window\',\n' +
+          '      submenu: [\n' +
+          '        { role: \'minimize\' },\n' +
+          '        { role: \'close\' }\n' +
+          '      ]\n' +
+          '    }\n' +
+          '  ];\n' +
+          '  Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));\n' +
+          '\n' +
           '  mainWindow.webContents.setWindowOpenHandler(({ url }) => {\\n' +
           '    shell.openExternal(url);\\n' +
           '    return { action: \\'deny\\' };\\n' +


### PR DESCRIPTION
Restore macOS App/Window menus in desktop build so Command+Q and Command+W work again. Fixes #58.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop app menus now adapt to your platform: macOS gets a native app-name menu plus a Window menu, while Windows/Linux receive menus tailored to their conventions for a more native look and behavior.
  * Existing Edit and View menus are preserved and public APIs remain unchanged for backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->