### PR TITLE
fix: avoid redundant scroll restore after sync

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/png" href="/icon.png" />
+    <link rel="apple-touch-icon" href="/icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>GitHub Stars Manager - AI-Powered Repository Management</title>
     <meta name="description" content="Intelligent management of your GitHub starred repositories with AI-powered analysis and release tracking" />

--- a/nginx.conf
+++ b/nginx.conf
@@ -5,6 +5,7 @@ events {
 http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
+    resolver      127.0.0.11 ipv6=off valid=30s;
 
     # Hide nginx version
     server_tokens off;
@@ -32,7 +33,8 @@ http {
         server_name  localhost;
         # Backend API proxy
         location /api/ {
-            proxy_pass http://backend:3000/api/;
+            set $backend_upstream backend:3000;
+            proxy_pass http://$backend_upstream;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { LoginScreen } from './components/LoginScreen';
 import { Header } from './components/Header';
 import { SearchBar } from './components/SearchBar';
@@ -16,12 +16,12 @@ function App() {
   const { 
     isAuthenticated, 
     currentView, 
+    selectedCategory,
     theme,
     searchResults,
-    repositories 
+    repositories,
+    setSelectedCategory,
   } = useAppStore();
-
-  const [selectedCategory, setSelectedCategory] = useState('all');
 
   // 自动检查更新
   useAutoUpdateCheck();

--- a/src/components/LoginScreen.tsx
+++ b/src/components/LoginScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Star, Github, Key, ArrowRight, AlertCircle } from 'lucide-react';
+import { Github, Key, ArrowRight, AlertCircle } from 'lucide-react';
 import { useAppStore } from '../store/useAppStore';
 import { GitHubApiService } from '../services/githubApi';
 
@@ -67,8 +67,12 @@ export const LoginScreen: React.FC = () => {
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">
       <div className="max-w-md w-full">
         <div className="text-center mb-8">
-          <div className="flex items-center justify-center w-16 h-16 bg-blue-600 rounded-2xl mx-auto mb-4 shadow-lg">
-            <Star className="w-8 h-8 text-white" />
+          <div className="flex items-center justify-center w-16 h-16 bg-white rounded-2xl mx-auto mb-4 shadow-lg ring-1 ring-blue-100 overflow-hidden">
+            <img
+              src="./icon.png"
+              alt="GitHub Stars Manager"
+              className="w-full h-full object-cover"
+            />
           </div>
           <h1 className="text-3xl font-bold text-gray-900 mb-2">
             GitHub Stars Manager

--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -174,6 +174,10 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
 
       const targetScrollY = savedScrollYRef.current;
       if (targetScrollY === null) return;
+      if (window.scrollY === targetScrollY) {
+        savedScrollYRef.current = null;
+        return;
+      }
 
       restoreScrollFrameRef.current = window.requestAnimationFrame(() => {
         restoreScrollFrameRef.current = window.requestAnimationFrame(() => {

--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -34,6 +34,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
   const [showDropdown, setShowDropdown] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
   const [disableCardAnimations, setDisableCardAnimations] = useState(false);
+  const previousCategoryRef = useRef(selectedCategory);
   const savedScrollYRef = useRef<number | null>(null);
   const restoreScrollFrameRef = useRef<number | null>(null);
   
@@ -117,6 +118,13 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
   useEffect(() => {
     setVisibleCount(LOAD_BATCH);
   }, [filterResetKey]);
+
+  useEffect(() => {
+    if (previousCategoryRef.current !== selectedCategory) {
+      window.scrollTo({ top: 0, behavior: 'auto' });
+      previousCategoryRef.current = selectedCategory;
+    }
+  }, [selectedCategory]);
 
   // Clamp visible count when result set becomes smaller, but do not collapse
   // back to the initial batch during backend sync refreshes.

--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -34,6 +34,8 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
   const [showDropdown, setShowDropdown] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
   const [disableCardAnimations, setDisableCardAnimations] = useState(false);
+  const savedScrollYRef = useRef<number | null>(null);
+  const restoreScrollFrameRef = useRef<number | null>(null);
   
   // 使用 useRef 来管理停止状态，确保在异步操作中能正确访问最新值
   const shouldStopRef = useRef(false);
@@ -150,11 +152,35 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
   useEffect(() => {
     const handleSyncVisualState = (event: Event) => {
       const customEvent = event as CustomEvent<{ isSyncing?: boolean }>;
-      setDisableCardAnimations(!!customEvent.detail?.isSyncing);
+      const isSyncing = !!customEvent.detail?.isSyncing;
+      setDisableCardAnimations(isSyncing);
+
+      if (isSyncing) {
+        savedScrollYRef.current = window.scrollY;
+        if (restoreScrollFrameRef.current !== null) {
+          cancelAnimationFrame(restoreScrollFrameRef.current);
+          restoreScrollFrameRef.current = null;
+        }
+        return;
+      }
+
+      const targetScrollY = savedScrollYRef.current;
+      if (targetScrollY === null) return;
+
+      restoreScrollFrameRef.current = window.requestAnimationFrame(() => {
+        restoreScrollFrameRef.current = window.requestAnimationFrame(() => {
+          window.scrollTo({ top: targetScrollY, behavior: 'auto' });
+          restoreScrollFrameRef.current = null;
+          savedScrollYRef.current = null;
+        });
+      });
     };
 
     window.addEventListener('gsm:repository-sync-visual-state', handleSyncVisualState as EventListener);
     return () => {
+      if (restoreScrollFrameRef.current !== null) {
+        cancelAnimationFrame(restoreScrollFrameRef.current);
+      }
       window.removeEventListener('gsm:repository-sync-visual-state', handleSyncVisualState as EventListener);
     };
   }, []);

--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useMemo } from 'react';
 import { Bot, ChevronDown, Pause, Play } from 'lucide-react';
 import { RepositoryCard } from './RepositoryCard';
 
@@ -85,12 +85,45 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
   const startIndex = filteredRepositories.length === 0 ? 0 : 1;
   const endIndex = Math.min(visibleCount, filteredRepositories.length);
   const visibleRepositories = filteredRepositories.slice(0, visibleCount);
+  const filterResetKey = useMemo(() => JSON.stringify({
+    selectedCategory,
+    query: searchFilters.query,
+    languages: searchFilters.languages,
+    tags: searchFilters.tags,
+    platforms: searchFilters.platforms,
+    sortBy: searchFilters.sortBy,
+    sortOrder: searchFilters.sortOrder,
+    minStars: searchFilters.minStars,
+    maxStars: searchFilters.maxStars,
+    isAnalyzed: searchFilters.isAnalyzed,
+    isSubscribed: searchFilters.isSubscribed,
+  }), [
+    selectedCategory,
+    searchFilters.query,
+    searchFilters.languages,
+    searchFilters.tags,
+    searchFilters.platforms,
+    searchFilters.sortBy,
+    searchFilters.sortOrder,
+    searchFilters.minStars,
+    searchFilters.maxStars,
+    searchFilters.isAnalyzed,
+    searchFilters.isSubscribed,
+  ]);
 
-  // Reset visible count when filters or data change
+  // Reset visible count only when filter context changes.
   useEffect(() => {
     setVisibleCount(LOAD_BATCH);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedCategory, repositories, filteredRepositories.length]);
+  }, [filterResetKey]);
+
+  // Clamp visible count when result set becomes smaller, but do not collapse
+  // back to the initial batch during backend sync refreshes.
+  useEffect(() => {
+    setVisibleCount((count) => {
+      if (filteredRepositories.length === 0) return LOAD_BATCH;
+      return Math.min(count, filteredRepositories.length);
+    });
+  }, [filteredRepositories.length]);
 
   // IntersectionObserver to load more on demand
   useEffect(() => {

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -71,6 +71,7 @@ interface AppActions {
   // UI actions
   setTheme: (theme: 'light' | 'dark') => void;
   setCurrentView: (view: 'repositories' | 'releases' | 'settings') => void;
+  setSelectedCategory: (category: string) => void;
   setLanguage: (language: 'zh' | 'en') => void;
   
   // Update actions
@@ -112,6 +113,8 @@ type PersistedAppState = Partial<
     | 'customCategories'
     | 'assetFilters'
     | 'theme'
+    | 'currentView'
+    | 'selectedCategory'
     | 'language'
     | 'searchFilters'
   >
@@ -276,6 +279,7 @@ export const useAppStore = create<AppState & AppActions>()(
       assetFilters: [],
       theme: 'light',
       currentView: 'repositories',
+      selectedCategory: 'all',
       language: 'zh',
       updateNotification: null,
       analysisProgress: { current: 0, total: 0 },
@@ -429,6 +433,7 @@ export const useAppStore = create<AppState & AppActions>()(
       // UI actions
       setTheme: (theme) => set({ theme }),
       setCurrentView: (currentView) => set({ currentView }),
+      setSelectedCategory: (selectedCategory) => set({ selectedCategory }),
       setLanguage: (language) => set({ language }),
       
       // Update actions
@@ -476,6 +481,8 @@ export const useAppStore = create<AppState & AppActions>()(
 
         // 持久化UI设置
         theme: state.theme,
+        currentView: state.currentView,
+        selectedCategory: state.selectedCategory,
         language: state.language,
 
         // backendApiSecret: 保留在内存中，不持久化（安全考虑）

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -155,6 +155,7 @@ export interface AppState {
   // UI
   theme: 'light' | 'dark';
   currentView: 'repositories' | 'releases' | 'settings';
+  selectedCategory: string;
   language: 'zh' | 'en';
   
   // Update


### PR DESCRIPTION
Problem: During sync visual state restore, scroll is always forced back to the saved position even when the scroll position never changed. This can cause a subtle jitter after sync. Fix: Only restore scroll when window.scrollY actually differs from the saved position, and clear the saved value otherwise. Testing: not run (UI change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent category selection—your chosen category filters are now saved across sessions.

* **Bug Fixes**
  * Improved scroll position restoration when syncing data in the background.
  * Fixed view reset behavior when applying new filters.

* **Style**
  * Updated login screen icon from SVG graphic to a custom image.
  * Refreshed favicon and added Apple touch icon support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->