### PR TITLE
fix(config): surface secret decryption failures

### DIFF
--- a/server/src/routes/configs.ts
+++ b/server/src/routes/configs.ts
@@ -5,6 +5,35 @@ import { config } from '../config.js';
 
 const router = Router();
 
+type SecretStatus = 'ok' | 'empty' | 'decrypt_failed';
+
+function getMaskedSecretResult(params: {
+  encryptedValue: unknown;
+  encryptionKey: string;
+  kind: 'AI API key' | 'WebDAV password' | 'GitHub token';
+  configId?: unknown;
+  configName?: unknown;
+}): { decryptedValue: string; status: SecretStatus } {
+  const { encryptedValue, encryptionKey, kind, configId, configName } = params;
+
+  if (!encryptedValue || typeof encryptedValue !== 'string') {
+    return { decryptedValue: '', status: 'empty' };
+  }
+
+  try {
+    return {
+      decryptedValue: decrypt(encryptedValue, encryptionKey),
+      status: 'ok',
+    };
+  } catch (error) {
+    const detail = [configId ? `id=${String(configId)}` : '', configName ? `name=${String(configName)}` : '']
+      .filter(Boolean)
+      .join(', ');
+    console.warn(`[configs] Failed to decrypt ${kind}${detail ? ` (${detail})` : ''}:`, error);
+    return { decryptedValue: '', status: 'decrypt_failed' };
+  }
+}
+
 // ── AI Configs ──
 
 function maskApiKey(key: string | null | undefined): string {
@@ -20,19 +49,21 @@ router.get('/api/configs/ai', (req, res) => {
     const shouldDecrypt = req.query.decrypt === 'true';
     const rows = db.prepare('SELECT * FROM ai_configs ORDER BY id ASC').all() as Record<string, unknown>[];
     const configs = rows.map((row) => {
-      let decryptedKey = '';
-      try {
-        if (row.api_key_encrypted && typeof row.api_key_encrypted === 'string') {
-          decryptedKey = decrypt(row.api_key_encrypted, config.encryptionKey);
-        }
-      } catch { /* leave empty */ }
+      const { decryptedValue, status } = getMaskedSecretResult({
+        encryptedValue: row.api_key_encrypted,
+        encryptionKey: config.encryptionKey,
+        kind: 'AI API key',
+        configId: row.id,
+        configName: row.name,
+      });
       return {
         id: row.id,
         name: row.name,
         apiType: row.api_type,
         model: row.model,
         baseUrl: row.base_url,
-        apiKey: shouldDecrypt ? decryptedKey : maskApiKey(decryptedKey),
+        apiKey: shouldDecrypt ? decryptedValue : maskApiKey(decryptedValue),
+        apiKeyStatus: status,
         isActive: !!row.is_active,
         customPrompt: row.custom_prompt ?? null,
         useCustomPrompt: !!row.use_custom_prompt,
@@ -199,18 +230,20 @@ router.get('/api/configs/webdav', (req, res) => {
     const shouldDecrypt = req.query.decrypt === 'true';
     const rows = db.prepare('SELECT * FROM webdav_configs ORDER BY id ASC').all() as Record<string, unknown>[];
     const configs = rows.map((row) => {
-      let decryptedPwd = '';
-      try {
-        if (row.password_encrypted && typeof row.password_encrypted === 'string') {
-          decryptedPwd = decrypt(row.password_encrypted, config.encryptionKey);
-        }
-      } catch { /* leave empty */ }
+      const { decryptedValue, status } = getMaskedSecretResult({
+        encryptedValue: row.password_encrypted,
+        encryptionKey: config.encryptionKey,
+        kind: 'WebDAV password',
+        configId: row.id,
+        configName: row.name,
+      });
       return {
         id: row.id,
         name: row.name,
         url: row.url,
         username: row.username,
-        password: shouldDecrypt ? decryptedPwd : maskPassword(decryptedPwd),
+        password: shouldDecrypt ? decryptedValue : maskPassword(decryptedValue),
+        passwordStatus: status,
         path: row.path,
         isActive: !!row.is_active,
       };
@@ -367,12 +400,13 @@ router.get('/api/settings', (_req, res) => {
       let value = row.value as string | null;
 
       if (key === 'github_token' && value) {
-        try {
-          const decrypted = decrypt(value, config.encryptionKey);
-          value = maskApiKey(decrypted);
-        } catch {
-          value = '****';
-        }
+        const { decryptedValue, status } = getMaskedSecretResult({
+          encryptedValue: value,
+          encryptionKey: config.encryptionKey,
+          kind: 'GitHub token',
+        });
+        value = status === 'empty' ? '' : maskApiKey(decryptedValue);
+        settings.github_token_status = status;
       }
 
       settings[key] = value;

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -943,6 +943,14 @@ Focus on practicality and accurate categorization to help users quickly understa
                       {(config.apiType || 'openai').toUpperCase()} • {config.baseUrl} • {config.model} • {t('并发数', 'Concurrency')}: {config.concurrency || 1}
                       {config.reasoningEffort ? ` • reasoning: ${config.reasoningEffort}` : ''}
                     </p>
+                    {config.apiKeyStatus === 'decrypt_failed' && (
+                      <p className="mt-1 text-sm text-amber-600 dark:text-amber-400">
+                        {t(
+                          '存储的 API Key 无法解密，请重新输入并保存该配置。',
+                          'The stored API key could not be decrypted. Please re-enter and save this configuration.'
+                        )}
+                      </p>
+                    )}
                   </div>
                 </div>
                 
@@ -1135,6 +1143,14 @@ Focus on practicality and accurate categorization to help users quickly understa
                     <p className="text-sm text-gray-500 dark:text-gray-400">
                       {config.url} • {config.path}
                     </p>
+                    {config.passwordStatus === 'decrypt_failed' && (
+                      <p className="mt-1 text-sm text-amber-600 dark:text-amber-400">
+                        {t(
+                          '存储的 WebDAV 密码无法解密，请重新输入并保存该配置。',
+                          'The stored WebDAV password could not be decrypted. Please re-enter and save this configuration.'
+                        )}
+                      </p>
+                    )}
                   </div>
                 </div>
                 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -70,6 +70,8 @@ export interface GitHubUser {
 export type AIApiType = 'openai' | 'openai-responses' | 'claude' | 'gemini';
 export type AIReasoningEffort = 'none' | 'low' | 'medium' | 'high' | 'xhigh';
 
+export type SecretStatus = 'ok' | 'empty' | 'decrypt_failed';
+
 export interface AIConfig {
   id: string;
   name: string;
@@ -82,6 +84,7 @@ export interface AIConfig {
   useCustomPrompt?: boolean; // 是否使用自定义提示词
   concurrency?: number; // AI分析并发数，默认为1
   reasoningEffort?: AIReasoningEffort; // OpenAI GPT-5/Responses 可选 reasoning 强度
+  apiKeyStatus?: SecretStatus;
 }
 
 export interface WebDAVConfig {
@@ -92,6 +95,7 @@ export interface WebDAVConfig {
   password: string;
   path: string;
   isActive: boolean;
+  passwordStatus?: SecretStatus;
 }
 
 export interface SearchFilters {


### PR DESCRIPTION
## Summary
- add observable secret decryption failure handling for AI configs, WebDAV configs, and GitHub token settings
- keep config APIs responsive instead of failing the entire response when one stored secret cannot be decrypted
- expose per-config secret status to the frontend and show a clear re-enter/save warning in Settings

## What changed
- Added backend logging when decrypting stored AI API keys, WebDAV passwords, or GitHub tokens fails.
- Returned secret status metadata (`ok`, `empty`, `decrypt_failed`) for config reads.
- Preserved graceful degradation: config lists still load even if one stored secret is invalid.
- Added frontend warnings telling users to re-enter and save configs whose stored secret can no longer be decrypted.

## Why
Issue #64 correctly pointed out that decryption errors were previously swallowed, which could make secrets appear empty without any explanation.

This PR fixes that without making the whole settings page fail just because one stored secret is broken.

## Validation
- `npm run build` ✅

Closes #64


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration responses now include credential status indicators for AI keys and WebDAV passwords
  * Settings panel displays warning alerts when stored credentials fail to decrypt
  * Users are prompted to re-enter and save affected configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->