### PR TITLE
fix(aiService): improve deepseek-reasoner compatibility

### DIFF
--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -21,6 +21,10 @@ export class AIService {
     return effort ? { effort } : undefined;
   }
 
+  private isDeepSeekReasonerModel(): boolean {
+    return this.getApiType() === 'openai' && this.config.model.trim() === 'deepseek-reasoner';
+  }
+
   private buildApiUrl(pathWithVersion: string): string {
     const baseUrlWithSlash = this.config.baseUrl.endsWith('/')
       ? this.config.baseUrl
@@ -65,6 +69,7 @@ export class AIService {
           : []),
         { role: 'user', content: options.user },
       ];
+      const isDeepSeekReasoner = this.isDeepSeekReasonerModel();
 
       const requestBody = apiType === 'openai-responses'
         ? {
@@ -77,9 +82,9 @@ export class AIService {
         : {
             model: this.config.model,
             messages,
-            temperature: options.temperature,
             max_tokens: options.maxTokens,
-            ...(reasoning ? { reasoning } : {}),
+            ...(!isDeepSeekReasoner ? { temperature: options.temperature } : {}),
+            ...(!isDeepSeekReasoner && reasoning ? { reasoning } : {}),
           };
 
       let data: any;


### PR DESCRIPTION
## Closes
Fixes #70

## Overview
This PR fixes compatibility issues when using DeepSeek's official `deepseek-reasoner` model through the OpenAI-compatible chat completions path.

## Changes
- detect `deepseek-reasoner` specifically in the OpenAI-compatible branch
- omit unsupported `temperature` for that model
- omit OpenAI-specific `reasoning` payload for that model
- keep all existing behavior unchanged for other model channels

## Why this is safe
This change is scoped only to `apiType === "openai"` with model name exactly `deepseek-reasoner`. It does not affect:
- other OpenAI-compatible models
- `openai-responses`
- Claude
- Gemini

## Validation
- local frontend build passed with `npm run build`
