### PR TITLE
feat(categories): improve category management and drag-to-assign

### DIFF
--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -37,6 +37,7 @@ export function initializeSchema(db: Database.Database): void {
       custom_description TEXT,
       custom_tags TEXT,
       custom_category TEXT,
+      category_locked INTEGER DEFAULT 0,
       last_edited TEXT,
       subscribed_to_releases INTEGER DEFAULT 0
     );
@@ -102,4 +103,5 @@ export function initializeSchema(db: Database.Database): void {
   `);
 
   addColumnIfMissing(db, 'ai_configs', 'reasoning_effort', 'TEXT');
+  addColumnIfMissing(db, 'repositories', 'category_locked', 'INTEGER DEFAULT 0');
 }

--- a/server/src/routes/repositories.ts
+++ b/server/src/routes/repositories.ts
@@ -36,6 +36,7 @@ function transformRepo(row: Record<string, unknown>) {
     custom_description: row.custom_description,
     custom_tags: parseJsonColumn(row.custom_tags),
     custom_category: row.custom_category,
+    category_locked: !!row.category_locked,
     last_edited: row.last_edited,
     subscribed_to_releases: !!row.subscribed_to_releases,
   };
@@ -95,9 +96,9 @@ router.put('/api/repositories', (req, res) => {
         created_at, updated_at, pushed_at, starred_at,
         owner_login, owner_avatar_url, topics,
         ai_summary, ai_tags, ai_platforms, analyzed_at, analysis_failed,
-        custom_description, custom_tags, custom_category, last_edited,
+        custom_description, custom_tags, custom_category, category_locked, last_edited,
         subscribed_to_releases
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     const deleteAllReleases = db.prepare('DELETE FROM releases');
@@ -142,7 +143,7 @@ router.put('/api/repositories', (req, res) => {
           repo.analyzed_at ?? null, (repo.analysis_failed === true || repo.analysis_failed === 1) ? 1 : 0,
           repo.custom_description ?? null,
           JSON.stringify(Array.isArray(repo.custom_tags) ? repo.custom_tags : []),
-          repo.custom_category ?? null, repo.last_edited ?? null,
+          repo.custom_category ?? null, (repo.category_locked === true || repo.category_locked === 1) ? 1 : 0, repo.last_edited ?? null,
           (repo.subscribed_to_releases === true || repo.subscribed_to_releases === 1) ? 1 : 0
         );
         count++;
@@ -174,6 +175,7 @@ router.patch('/api/repositories/:id', (req, res) => {
       custom_description: (v) => v,
       custom_tags: (v) => JSON.stringify(Array.isArray(v) ? v : []),
       custom_category: (v) => v,
+      category_locked: (v) => (v === true || v === 1) ? 1 : 0,
       last_edited: (v) => v,
       subscribed_to_releases: (v) => (v === true || v === 1) ? 1 : 0,
       description: (v) => v,

--- a/server/src/routes/sync.ts
+++ b/server/src/routes/sync.ts
@@ -101,9 +101,9 @@ router.post('/api/sync/import', (req, res) => {
             created_at, updated_at, pushed_at, starred_at,
             owner_login, owner_avatar_url, topics,
             ai_summary, ai_tags, ai_platforms, analyzed_at, analysis_failed,
-            custom_description, custom_tags, custom_category, last_edited,
+            custom_description, custom_tags, custom_category, category_locked, last_edited,
             subscribed_to_releases
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `);
         for (const r of repos) {
           repoStmt.run(
@@ -119,7 +119,7 @@ router.post('/api/sync/import', (req, res) => {
             r.analyzed_at ?? null, r.analysis_failed ? 1 : 0,
             r.custom_description ?? null,
             typeof r.custom_tags === 'string' ? r.custom_tags : JSON.stringify(r.custom_tags ?? []),
-            r.custom_category ?? null, r.last_edited ?? null,
+            r.custom_category ?? null, (r.category_locked === true || r.category_locked === 1) ? 1 : 0, r.last_edited ?? null,
             r.subscribed_to_releases ? 1 : 0
           );
         }

--- a/src/components/CategorySidebar.tsx
+++ b/src/components/CategorySidebar.tsx
@@ -1,32 +1,20 @@
-import React, { useState } from 'react';
-import { 
-  Folder, 
-  Code, 
-  Globe, 
-  Smartphone, 
-  Database, 
-  Shield, 
-  Gamepad2, 
-  Palette, 
-  Bot, 
-  Wrench,
-  BookOpen,
-  Zap,
-  Users,
-  BarChart3,
+import React, { useMemo, useState } from 'react';
+import {
   Plus,
-  Edit3
+  Edit3,
+  Trash2,
+  EyeOff,
 } from 'lucide-react';
-import { Repository, Category } from '../types';
+import { Category, Repository } from '../types';
 import { useAppStore, getAllCategories } from '../store/useAppStore';
 import { CategoryEditModal } from './CategoryEditModal';
+import { forceSyncToBackend } from '../services/autoSync';
 
 interface CategorySidebarProps {
   repositories: Repository[];
   selectedCategory: string;
   onCategorySelect: (category: string) => void;
 }
-
 
 export const CategorySidebar: React.FC<CategorySidebarProps> = ({
   repositories,
@@ -35,37 +23,38 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
 }) => {
   const {
     customCategories,
+    hiddenDefaultCategoryIds,
     deleteCustomCategory,
-    language
+    hideDefaultCategory,
+    language,
+    updateRepository,
   } = useAppStore();
 
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [editingCategory, setEditingCategory] = useState<Category | null>(null);
   const [isCreatingCategory, setIsCreatingCategory] = useState(false);
+  const [dragOverCategoryId, setDragOverCategoryId] = useState<string | null>(null);
 
-  const allCategories = getAllCategories(customCategories, language);
+  const allCategories = getAllCategories(customCategories, language, hiddenDefaultCategoryIds);
+  const repositoryMap = useMemo(() => new Map(repositories.map(repo => [String(repo.id), repo])), [repositories]);
 
-  // Calculate repository count for each category
   const getCategoryCount = (category: Category) => {
     if (category.id === 'all') return repositories.length;
-    
+
     return repositories.filter(repo => {
-      // Check custom category first
       if (repo.custom_category === category.name) {
         return true;
       }
-      
-      // 优先使用AI标签进行匹配
+
       if (repo.ai_tags && repo.ai_tags.length > 0) {
-        return repo.ai_tags.some(tag => 
-          category.keywords.some(keyword => 
+        return repo.ai_tags.some(tag =>
+          category.keywords.some(keyword =>
             tag.toLowerCase().includes(keyword.toLowerCase()) ||
             keyword.toLowerCase().includes(tag.toLowerCase())
           )
         );
       }
-      
-      // 如果没有AI标签，使用传统方式匹配
+
       const repoText = [
         repo.name,
         repo.description || '',
@@ -73,8 +62,8 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
         ...(repo.topics || []),
         repo.ai_summary || ''
       ].join(' ').toLowerCase();
-      
-      return category.keywords.some(keyword => 
+
+      return category.keywords.some(keyword =>
         repoText.includes(keyword.toLowerCase())
       );
     }).length;
@@ -92,10 +81,59 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
     setEditModalOpen(true);
   };
 
+  const handleDeleteCategory = async (category: Category) => {
+    const confirmed = confirm(
+      t(
+        `确定删除自定义分类“${category.name}”吗？\n\n仓库会保留，Star 不会取消，只会清空它们的手动分类归属。`,
+        `Delete custom category "${category.name}"?\n\nRepositories will stay starred. Only their manual category assignment will be cleared.`
+      )
+    );
+
+    if (!confirmed) return;
+
+    deleteCustomCategory(category.id);
+    await forceSyncToBackend();
+  };
+
+  const handleHideDefaultCategory = async (category: Category) => {
+    const confirmed = confirm(
+      t(
+        `隐藏默认分类“${category.name}”？\n\n这不会删除任何仓库，只是在左侧隐藏这个预设分类。`,
+        `Hide default category "${category.name}"?\n\nThis will not delete any repositories. It only hides this built-in category from the sidebar.`
+      )
+    );
+
+    if (!confirmed) return;
+
+    hideDefaultCategory(category.id);
+    await forceSyncToBackend();
+  };
+
   const handleCloseModal = () => {
     setEditModalOpen(false);
     setEditingCategory(null);
     setIsCreatingCategory(false);
+  };
+
+  const handleDropOnCategory = async (event: React.DragEvent<HTMLButtonElement>, category: Category) => {
+    event.preventDefault();
+    setDragOverCategoryId(null);
+
+    if (category.id === 'all') return;
+
+    const repoId = event.dataTransfer.getData('application/x-gsm-repository-id');
+    const repository = repositoryMap.get(repoId);
+    if (!repository) return;
+
+    const nextRepo = {
+      ...repository,
+      custom_category: category.name,
+      category_locked: true,
+      last_edited: new Date().toISOString(),
+    };
+
+    updateRepository(nextRepo);
+    await forceSyncToBackend();
   };
 
   const t = (zh: string, en: string) => language === 'zh' ? zh : en;
@@ -115,21 +153,36 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
             <Plus className="w-4 h-4" />
           </button>
         </div>
-        
+
         <div className="flex gap-2 overflow-x-auto pb-1 lg:block lg:space-y-1 lg:overflow-visible">
           {allCategories.map(category => {
             const count = getCategoryCount(category);
             const isSelected = selectedCategory === category.id;
-            
+            const isDragTarget = dragOverCategoryId === category.id;
+
             return (
               <div key={category.id} className="group shrink-0 lg:shrink">
                 <button
                   onClick={() => onCategorySelect(category.id)}
+                  onDragOver={(event) => {
+                    if (category.id === 'all') return;
+                    event.preventDefault();
+                    setDragOverCategoryId(category.id);
+                  }}
+                  onDragLeave={() => {
+                    if (dragOverCategoryId === category.id) {
+                      setDragOverCategoryId(null);
+                    }
+                  }}
+                  onDrop={(event) => handleDropOnCategory(event, category)}
                   className={`flex min-w-[140px] items-center justify-between px-3 py-2.5 rounded-lg text-left transition-colors lg:w-full ${
                     isSelected
                       ? 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300'
-                      : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
+                      : isDragTarget
+                        ? 'bg-green-100 text-green-700 ring-2 ring-green-400 dark:bg-green-900 dark:text-green-300'
+                        : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700'
                   }`}
+                  title={category.id !== 'all' ? t('可将仓库卡片拖到这里快速改分类', 'Drag repository cards here to quickly change category') : undefined}
                 >
                   <div className="flex items-center space-x-3 min-w-0 flex-1">
                     <span className="text-base flex-shrink-0">{category.icon}</span>
@@ -139,36 +192,59 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
                     <div className={`relative text-xs px-2 py-1 rounded-full ${
                       isSelected
                         ? 'bg-blue-200 text-blue-800 dark:bg-blue-800 dark:text-blue-200'
-                        : 'bg-gray-200 text-gray-600 dark:bg-gray-600 dark:text-gray-400'
+                        : isDragTarget
+                          ? 'bg-green-200 text-green-800 dark:bg-green-800 dark:text-green-200'
+                          : 'bg-gray-200 text-gray-600 dark:bg-gray-600 dark:text-gray-400'
                     }`}>
-                      {/* Count badge - shown by default */}
-                      <span className="group-hover:opacity-0 transition-opacity duration-200">
-                        {count}
-                      </span>
-                      
-                      {/* Edit button - shown on hover, only for non-"All Categories" */}
-                      {category.id !== 'all' && (
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleEditCategory(category);
-                          }}
-                          className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-200 hover:bg-black hover:bg-opacity-10 rounded-full"
-                          title={t('编辑分类', 'Edit category')}
-                        >
-                          <Edit3 className="w-3 h-3" />
-                        </button>
-                      )}
+                      <span>{count}</span>
                     </div>
-                    </div>
+
+                    {category.id !== 'all' && (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleEditCategory(category);
+                        }}
+                        className="p-1 rounded-md opacity-0 group-hover:opacity-100 transition-opacity hover:bg-gray-200 dark:hover:bg-gray-600"
+                        title={t('编辑分类', 'Edit category')}
+                      >
+                        <Edit3 className="w-3 h-3" />
+                      </button>
+                    )}
+
+                    {category.id !== 'all' && category.isCustom && (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          void handleDeleteCategory(category);
+                        }}
+                        className="p-1 rounded-md opacity-0 group-hover:opacity-100 transition-opacity text-red-500 hover:bg-red-100 dark:hover:bg-red-900/40"
+                        title={t('删除分类', 'Delete category')}
+                      >
+                        <Trash2 className="w-3 h-3" />
+                      </button>
+                    )}
+
+                    {category.id !== 'all' && !category.isCustom && (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          void handleHideDefaultCategory(category);
+                        }}
+                        className="p-1 rounded-md opacity-0 group-hover:opacity-100 transition-opacity text-gray-500 hover:bg-gray-200 dark:hover:bg-gray-600"
+                        title={t('隐藏默认分类', 'Hide default category')}
+                      >
+                        <EyeOff className="w-3 h-3" />
+                      </button>
+                    )}
+                  </div>
                 </button>
               </div>
             );
           })}
         </div>
       </div>
-      
-      {/* Category Edit Modal */}
+
       <CategoryEditModal
         isOpen={editModalOpen}
         onClose={handleCloseModal}

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Star, GitFork, Eye, ExternalLink, Calendar, Tag, Bell, BellOff, Bot, Monitor, Smartphone, Globe, Terminal, Package, Edit3, BookOpen, Apple, Zap } from 'lucide-react';
-import { Repository } from '../types';
+import { Category, Repository } from '../types';
 import { useAppStore, getAllCategories } from '../store/useAppStore';
+import { resolveCategoryAssignment } from '../utils/categoryUtils';
 import { GitHubApiService } from '../services/githubApi';
 import { AIService } from '../services/aiService';
 import { forceSyncToBackend } from '../services/autoSync';
@@ -29,6 +30,7 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
     setLoading,
     language,
     customCategories,
+    hiddenDefaultCategoryIds,
     updateRepository,
     deleteRepository
   } = useAppStore();
@@ -39,6 +41,7 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
   const [unstarring, setUnstarring] = useState(false);
 
   const descriptionRef = useRef<HTMLParagraphElement>(null);
+  const allCategories = getAllCategories(customCategories, language, hiddenDefaultCategoryIds);
 
   const isSubscribed = releaseSubscriptions.has(repository.id);
 
@@ -188,11 +191,12 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
       const [owner, name] = repository.full_name.split('/');
       const readmeContent = await githubApi.getRepositoryReadme(owner, name);
 
-      // 获取自定义分类名称列表
-      const customCategoryNames = customCategories.map(cat => cat.name);
+      // 获取可用分类名称列表
+      const categoryNames = allCategories.filter(cat => cat.id !== 'all').map(cat => cat.name);
 
       // AI分析
-      const analysis = await aiService.analyzeRepository(repository, readmeContent, customCategoryNames);
+      const analysis = await aiService.analyzeRepository(repository, readmeContent, categoryNames);
+      const resolvedCategory = resolveCategoryAssignment(repository, analysis.tags, allCategories);
 
       // 更新仓库信息
       const updatedRepo = {
@@ -200,6 +204,7 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
         ai_summary: analysis.summary,
         ai_tags: analysis.tags,
         ai_platforms: analysis.platforms,
+        custom_category: resolvedCategory,
         analyzed_at: new Date().toISOString(),
         analysis_failed: false // 分析成功，清除失败标记
       };
@@ -350,8 +355,17 @@ export const RepositoryCard: React.FC<RepositoryCardProps> = ({
     }
   };
 
+  const handleDragStart = (event: React.DragEvent<HTMLDivElement>) => {
+    event.dataTransfer.setData('application/x-gsm-repository-id', String(repository.id));
+    event.dataTransfer.effectAllowed = 'move';
+  };
+
   return (
-    <div className="repository-card bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6 hover:shadow-lg transition-all duration-200 hover:border-blue-300 dark:hover:border-blue-600 flex flex-col h-full">
+    <div
+      className="repository-card bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6 hover:shadow-lg transition-all duration-200 hover:border-blue-300 dark:hover:border-blue-600 flex flex-col h-full"
+      draggable
+      onDragStart={handleDragStart}
+    >
       {/* Header - Repository Info */}
       <div className="flex items-center space-x-3 mb-3">
         <img

--- a/src/components/RepositoryEditModal.tsx
+++ b/src/components/RepositoryEditModal.tsx
@@ -3,6 +3,7 @@ import { Save, X, Plus, Lock, Unlock } from 'lucide-react';
 import { Modal } from './Modal';
 import { Repository } from '../types';
 import { useAppStore, getAllCategories } from '../store/useAppStore';
+import { forceSyncToBackend } from '../services/autoSync';
 
 interface RepositoryEditModalProps {
   isOpen: boolean;
@@ -15,7 +16,7 @@ export const RepositoryEditModal: React.FC<RepositoryEditModalProps> = ({
   onClose,
   repository
 }) => {
-  const { updateRepository, language, customCategories, repositories } = useAppStore();
+  const { updateRepository, language, customCategories, hiddenDefaultCategoryIds } = useAppStore();
   
   const [formData, setFormData] = useState({
     description: '',
@@ -25,7 +26,7 @@ export const RepositoryEditModal: React.FC<RepositoryEditModalProps> = ({
   });
   const [newTag, setNewTag] = useState('');
 
-  const allCategories = getAllCategories(customCategories, language);
+  const allCategories = getAllCategories(customCategories, language, hiddenDefaultCategoryIds);
 
   // 获取仓库当前所属的分类
   const getCurrentCategory = (repo: Repository) => {
@@ -83,7 +84,7 @@ export const RepositoryEditModal: React.FC<RepositoryEditModalProps> = ({
     }
   }, [repository, isOpen]);
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (!repository) return;
 
     const originalCategory = getCurrentCategory(repository);
@@ -100,6 +101,7 @@ export const RepositoryEditModal: React.FC<RepositoryEditModalProps> = ({
     };
     
     updateRepository(updatedRepo);
+    await forceSyncToBackend();
     onClose();
   };
 
@@ -298,7 +300,7 @@ export const RepositoryEditModal: React.FC<RepositoryEditModalProps> = ({
             <span>{t('取消', 'Cancel')}</span>
           </button>
           <button
-            onClick={handleSave}
+            onClick={() => void handleSave()}
             className="flex items-center space-x-2 px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors"
           >
             <Save className="w-4 h-4" />

--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -6,6 +6,7 @@ import { Repository } from '../types';
 import { useAppStore, getAllCategories } from '../store/useAppStore';
 import { GitHubApiService } from '../services/githubApi';
 import { AIService } from '../services/aiService';
+import { resolveCategoryAssignment } from '../utils/categoryUtils';
 
 interface RepositoryListProps {
   repositories: Repository[];
@@ -25,6 +26,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
     updateRepository,
     language,
     customCategories,
+    hiddenDefaultCategoryIds,
     analysisProgress,
     setAnalysisProgress,
     searchFilters
@@ -42,7 +44,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
   const shouldStopRef = useRef(false);
   const isAnalyzingRef = useRef(false);
 
-  const allCategories = getAllCategories(customCategories, language);
+  const allCategories = getAllCategories(customCategories, language, hiddenDefaultCategoryIds);
 
   // Filter repositories by selected category
   const filteredRepositories = repositories.filter(repo => {
@@ -246,8 +248,8 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
       const githubApi = new GitHubApiService(githubToken);
       const aiService = new AIService(activeConfig, language);
       
-      // 获取自定义分类名称列表
-      const customCategoryNames = customCategories.map(cat => cat.name);
+      // 获取可用分类名称列表
+      const categoryNames = allCategories.filter(cat => cat.id !== 'all').map(cat => cat.name);
       
       let analyzed = 0;
       const concurrency = activeConfig.concurrency || 1;
@@ -275,7 +277,8 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
           const readmeContent = await githubApi.getRepositoryReadme(owner, name);
           
           // AI分析
-          const analysis = await aiService.analyzeRepository(repo, readmeContent, customCategoryNames);
+          const analysis = await aiService.analyzeRepository(repo, readmeContent, categoryNames);
+          const resolvedCategory = resolveCategoryAssignment(repo, analysis.tags, allCategories);
           
           // 更新仓库信息
           const updatedRepo = {
@@ -283,6 +286,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
             ai_summary: analysis.summary,
             ai_tags: analysis.tags,
             ai_platforms: analysis.platforms,
+            custom_category: resolvedCategory,
             analyzed_at: new Date().toISOString(),
             analysis_failed: false // 分析成功，清除失败标记
           };

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -23,7 +23,7 @@ import {
   Server,
 } from 'lucide-react';
 import { AIConfig, WebDAVConfig, AIApiType, AIReasoningEffort } from '../types';
-import { useAppStore } from '../store/useAppStore';
+import { useAppStore, getAllCategories } from '../store/useAppStore';
 import { AIService } from '../services/aiService';
 import { WebDAVService } from '../services/webdavService';
 import { UpdateChecker } from './UpdateChecker';
@@ -522,6 +522,8 @@ Focus on practicality and accurate categorization to help users quickly understa
   };
 
   const t = (zh: string, en: string) => language === 'zh' ? zh : en;
+  const hiddenDefaultCategories = getAllCategories([], language, []).filter(category => hiddenDefaultCategoryIds.includes(category.id));
+
 
   const handleTestBackendConnection = async () => {
     setBackendStatus('checking');
@@ -586,6 +588,7 @@ Focus on practicality and accurate categorization to help users quickly understa
       const releaseData = await backend.fetchReleases();
       const aiConfigData = await backend.fetchAIConfigs();
       const webdavConfigData = await backend.fetchWebDAVConfigs();
+      const settingsData = await backend.fetchSettings();
       
       if (repoData.repositories.length > 0) {
         setRepositories(repoData.repositories);
@@ -598,6 +601,16 @@ Focus on practicality and accurate categorization to help users quickly understa
       }
       if (webdavConfigData.length > 0) {
         setWebDAVConfigs(webdavConfigData);
+      }
+      if (Array.isArray(hiddenDefaultCategoryIds)) {
+        for (const categoryId of hiddenDefaultCategoryIds) {
+          if (typeof categoryId === 'string') showDefaultCategory(categoryId);
+        }
+      }
+      if (Array.isArray(settingsData.hiddenDefaultCategoryIds)) {
+        for (const categoryId of settingsData.hiddenDefaultCategoryIds) {
+          if (typeof categoryId === 'string') hideDefaultCategory(categoryId);
+        }
       }
       
       alert(t(
@@ -695,13 +708,13 @@ Focus on practicality and accurate categorization to help users quickly understa
               {t('以下默认分类已被隐藏，你可以在这里恢复显示。', 'The following built-in categories are hidden. You can restore them here.')}
             </p>
             <div className="flex flex-wrap gap-2">
-              {hiddenDefaultCategoryIds.map((categoryId) => (
+              {hiddenDefaultCategories.map((category) => (
                 <button
-                  key={categoryId}
-                  onClick={() => showDefaultCategory(categoryId)}
+                  key={category.id}
+                  onClick={() => showDefaultCategory(category.id)}
                   className="px-3 py-1.5 rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300 hover:bg-amber-200 dark:hover:bg-amber-800 transition-colors text-sm"
                 >
-                  {t('恢复', 'Restore')} {categoryId}
+                  {t('恢复', 'Restore')} {category.icon} {category.name}
                 </button>
               ))}
             </div>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -39,6 +39,7 @@ export const SettingsPanel: React.FC = () => {
     repositories,
     releases,
     customCategories,
+    hiddenDefaultCategoryIds,
     theme,
     language,
     addAIConfig,
@@ -55,6 +56,8 @@ export const SettingsPanel: React.FC = () => {
     setReleases,
     addCustomCategory,
     deleteCustomCategory,
+    hideDefaultCategory,
+    showDefaultCategory,
     backendApiSecret,
     setBackendApiSecret,
     setAIConfigs,
@@ -290,6 +293,7 @@ export const SettingsPanel: React.FC = () => {
         repositories,
         releases,
         customCategories,
+        hiddenDefaultCategoryIds,
         aiConfigs: aiConfigs.map(config => ({
           ...config,
           apiKey: '***' // Don't backup API keys for security
@@ -372,6 +376,20 @@ export const SettingsPanel: React.FC = () => {
             for (const cat of backupData.customCategories) {
               if (cat && cat.id && cat.name) {
                 addCustomCategory({ ...cat, isCustom: true });
+              }
+            }
+          }
+          if (Array.isArray(hiddenDefaultCategoryIds)) {
+            for (const categoryId of hiddenDefaultCategoryIds) {
+              if (typeof categoryId === 'string') {
+                showDefaultCategory(categoryId);
+              }
+            }
+          }
+          if (Array.isArray(backupData.hiddenDefaultCategoryIds)) {
+            for (const categoryId of backupData.hiddenDefaultCategoryIds) {
+              if (typeof categoryId === 'string') {
+                hideDefaultCategory(categoryId);
               }
             }
           }
@@ -538,6 +556,7 @@ Focus on practicality and accurate categorization to help users quickly understa
       await backend.syncReleases(releases);
       await backend.syncAIConfigs(aiConfigs);
       await backend.syncWebDAVConfigs(webdavConfigs);
+      await backend.syncSettings({ hiddenDefaultCategoryIds });
       alert(t(
         `已同步到后端：仓库 ${repositories.length}，发布 ${releases.length}，AI配置 ${aiConfigs.length}，WebDAV配置 ${webdavConfigs.length}`,
         `Synced to backend: repos ${repositories.length}, releases ${releases.length}, AI configs ${aiConfigs.length}, WebDAV configs ${webdavConfigs.length}`
@@ -655,6 +674,39 @@ Focus on practicality and accurate categorization to help users quickly understa
             </span>
           </label>
         </div>
+      </div>
+
+      {/* Language Settings */}
+      <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6">
+        <div className="flex items-center space-x-3 mb-4">
+          <Package className="w-6 h-6 text-amber-600 dark:text-amber-400" />
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+            {t('分类显示管理', 'Category Visibility')}
+          </h3>
+        </div>
+
+        {hiddenDefaultCategoryIds.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {t('当前没有隐藏的默认分类。', 'No default categories are hidden right now.')}
+          </p>
+        ) : (
+          <div className="space-y-3">
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              {t('以下默认分类已被隐藏，你可以在这里恢复显示。', 'The following built-in categories are hidden. You can restore them here.')}
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {hiddenDefaultCategoryIds.map((categoryId) => (
+                <button
+                  key={categoryId}
+                  onClick={() => showDefaultCategory(categoryId)}
+                  className="px-3 py-1.5 rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300 hover:bg-amber-200 dark:hover:bg-amber-800 transition-colors text-sm"
+                >
+                  {t('恢复', 'Restore')} {categoryId}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Contact Information */}

--- a/src/services/autoSync.ts
+++ b/src/services/autoSync.ts
@@ -149,6 +149,20 @@ export async function syncFromBackend(): Promise<void> {
       if (typeof settings.activeWebDAVConfig === 'string' || settings.activeWebDAVConfig === null) {
         state.setActiveWebDAVConfig(settings.activeWebDAVConfig as string | null);
       }
+      if (Array.isArray(settings.hiddenDefaultCategoryIds)) {
+        const nextHiddenIds = settings.hiddenDefaultCategoryIds.filter((id): id is string => typeof id === 'string');
+        const currentHiddenIds = state.hiddenDefaultCategoryIds || [];
+        for (const id of currentHiddenIds) {
+          if (!nextHiddenIds.includes(id)) {
+            state.showDefaultCategory(id);
+          }
+        }
+        for (const id of nextHiddenIds) {
+          if (!currentHiddenIds.includes(id)) {
+            state.hideDefaultCategory(id);
+          }
+        }
+      }
       _lastHash.settings = hashes.settings;
     }
 
@@ -195,6 +209,7 @@ export async function syncToBackend(): Promise<void> {
       backend.syncSettings({
         activeAIConfig: state.activeAIConfig,
         activeWebDAVConfig: state.activeWebDAVConfig,
+        hiddenDefaultCategoryIds: state.hiddenDefaultCategoryIds,
       }),
     ]);
     const [reposSync, releasesSync, aiSync, webdavSync, settingsSync] = results;
@@ -217,6 +232,7 @@ export async function syncToBackend(): Promise<void> {
       _lastHash.settings = quickHash({
         activeAIConfig: state.activeAIConfig,
         activeWebDAVConfig: state.activeWebDAVConfig,
+        hiddenDefaultCategoryIds: state.hiddenDefaultCategoryIds,
       });
     }
   } catch (err) {

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -62,6 +62,8 @@ interface AppActions {
   addCustomCategory: (category: Category) => void;
   updateCustomCategory: (id: string, updates: Partial<Category>) => void;
   deleteCustomCategory: (id: string) => void;
+  hideDefaultCategory: (id: string) => void;
+  showDefaultCategory: (id: string) => void;
   
   // Asset Filter actions
   addAssetFilter: (filter: AssetFilter) => void;
@@ -111,6 +113,7 @@ type PersistedAppState = Partial<
     | 'lastBackup'
     | 'releases'
     | 'customCategories'
+    | 'hiddenDefaultCategoryIds'
     | 'assetFilters'
     | 'theme'
     | 'currentView'
@@ -162,6 +165,7 @@ const normalizePersistedState = (
     },
     webdavConfigs: Array.isArray(safePersisted.webdavConfigs) ? safePersisted.webdavConfigs : [],
     customCategories: Array.isArray(safePersisted.customCategories) ? safePersisted.customCategories : [],
+    hiddenDefaultCategoryIds: Array.isArray((safePersisted as any).hiddenDefaultCategoryIds) ? (safePersisted as any).hiddenDefaultCategoryIds.filter((id: unknown): id is string => typeof id === 'string') : [],
     assetFilters: Array.isArray(safePersisted.assetFilters) ? safePersisted.assetFilters : [],
     language: safePersisted.language || 'zh',
     isAuthenticated: !!(safePersisted.user && safePersisted.githubToken),
@@ -276,6 +280,7 @@ export const useAppStore = create<AppState & AppActions>()(
       releaseSubscriptions: new Set<number>(),
       readReleases: new Set<number>(),
       customCategories: [],
+      hiddenDefaultCategoryIds: [],
       assetFilters: [],
       theme: 'light',
       currentView: 'repositories',
@@ -408,13 +413,68 @@ export const useAppStore = create<AppState & AppActions>()(
       addCustomCategory: (category) => set((state) => ({
         customCategories: [...state.customCategories, { ...category, isCustom: true }]
       })),
-      updateCustomCategory: (id, updates) => set((state) => ({
-        customCategories: state.customCategories.map(category => 
+      updateCustomCategory: (id, updates) => set((state) => {
+        const targetCategory = state.customCategories.find(category => category.id === id);
+        const nextCategories = state.customCategories.map(category => 
           category.id === id ? { ...category, ...updates } : category
-        )
+        );
+
+        if (!targetCategory || !updates.name || updates.name === targetCategory.name) {
+          return { customCategories: nextCategories };
+        }
+
+        const nextRepositories = state.repositories.map(repo =>
+          repo.custom_category === targetCategory.name
+            ? { ...repo, custom_category: updates.name, last_edited: new Date().toISOString() }
+            : repo
+        );
+
+        return {
+          customCategories: nextCategories,
+          repositories: nextRepositories,
+          searchResults: state.searchResults.map(repo =>
+            repo.custom_category === targetCategory.name
+              ? { ...repo, custom_category: updates.name, last_edited: new Date().toISOString() }
+              : repo
+          )
+        };
+      }),
+      deleteCustomCategory: (id) => set((state) => {
+        const targetCategory = state.customCategories.find(category => category.id === id);
+        const nextSelectedCategory = state.selectedCategory === id ? 'all' : state.selectedCategory;
+
+        if (!targetCategory) {
+          return {
+            customCategories: state.customCategories.filter(category => category.id !== id),
+            selectedCategory: nextSelectedCategory
+          };
+        }
+
+        const clearedRepositories = state.repositories.map(repo =>
+          repo.custom_category === targetCategory.name
+            ? { ...repo, custom_category: undefined, last_edited: new Date().toISOString() }
+            : repo
+        );
+
+        return {
+          customCategories: state.customCategories.filter(category => category.id !== id),
+          repositories: clearedRepositories,
+          searchResults: state.searchResults.map(repo =>
+            repo.custom_category === targetCategory.name
+              ? { ...repo, custom_category: undefined, last_edited: new Date().toISOString() }
+              : repo
+          ),
+          selectedCategory: nextSelectedCategory
+        };
+      }),
+      hideDefaultCategory: (id) => set((state) => ({
+        hiddenDefaultCategoryIds: state.hiddenDefaultCategoryIds.includes(id)
+          ? state.hiddenDefaultCategoryIds
+          : [...state.hiddenDefaultCategoryIds, id],
+        selectedCategory: state.selectedCategory === id ? 'all' : state.selectedCategory
       })),
-      deleteCustomCategory: (id) => set((state) => ({
-        customCategories: state.customCategories.filter(category => category.id !== id)
+      showDefaultCategory: (id) => set((state) => ({
+        hiddenDefaultCategoryIds: state.hiddenDefaultCategoryIds.filter(categoryId => categoryId !== id)
       })),
 
       // Asset Filter actions
@@ -475,6 +535,7 @@ export const useAppStore = create<AppState & AppActions>()(
 
         // 持久化自定义分类
         customCategories: state.customCategories,
+        hiddenDefaultCategoryIds: state.hiddenDefaultCategoryIds,
 
         // 持久化资源过滤器
         assetFilters: state.assetFilters,
@@ -519,11 +580,17 @@ export const useAppStore = create<AppState & AppActions>()(
 );
 
 // Helper function to get all categories (default + custom)
-export const getAllCategories = (customCategories: Category[], language: 'zh' | 'en' = 'zh'): Category[] => {
-  const translatedDefaults = defaultCategories.map(cat => ({
-    ...cat,
-    name: language === 'en' ? translateCategoryName(cat.name) : cat.name
-  }));
+export const getAllCategories = (
+  customCategories: Category[],
+  language: 'zh' | 'en' = 'zh',
+  hiddenDefaultCategoryIds: string[] = []
+): Category[] => {
+  const translatedDefaults = defaultCategories
+    .filter(cat => !hiddenDefaultCategoryIds.includes(cat.id))
+    .map(cat => ({
+      ...cat,
+      name: language === 'en' ? translateCategoryName(cat.name) : cat.name
+    }));
   
   return [...translatedDefaults, ...customCategories];
 };

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -452,7 +452,7 @@ export const useAppStore = create<AppState & AppActions>()(
 
         const clearedRepositories = state.repositories.map(repo =>
           repo.custom_category === targetCategory.name
-            ? { ...repo, custom_category: undefined, last_edited: new Date().toISOString() }
+            ? { ...repo, custom_category: undefined, category_locked: false, last_edited: new Date().toISOString() }
             : repo
         );
 
@@ -461,7 +461,7 @@ export const useAppStore = create<AppState & AppActions>()(
           repositories: clearedRepositories,
           searchResults: state.searchResults.map(repo =>
             repo.custom_category === targetCategory.name
-              ? { ...repo, custom_category: undefined, last_edited: new Date().toISOString() }
+              ? { ...repo, custom_category: undefined, category_locked: false, last_edited: new Date().toISOString() }
               : repo
           ),
           selectedCategory: nextSelectedCategory

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -117,6 +117,7 @@ export interface Category {
   icon: string;
   keywords: string[];
   isCustom?: boolean;
+  isHidden?: boolean;
 }
 
 export interface AssetFilter {
@@ -156,6 +157,7 @@ export interface AppState {
   
   // Categories
   customCategories: Category[]; // 新增：自定义分类
+  hiddenDefaultCategoryIds: string[];
   
   // Asset Filters
   assetFilters: AssetFilter[]; // 新增：资源过滤器

--- a/src/utils/categoryUtils.ts
+++ b/src/utils/categoryUtils.ts
@@ -1,0 +1,37 @@
+import { Category, Repository } from '../types';
+
+export const resolveCategoryAssignment = (
+  repository: Repository,
+  aiTags: string[] | undefined,
+  allCategories: Category[]
+): string | undefined => {
+  if (repository.category_locked && repository.custom_category) {
+    return repository.custom_category;
+  }
+
+  const normalizedTags = Array.isArray(aiTags) ? aiTags.filter(Boolean) : [];
+  if (normalizedTags.length === 0) {
+    return repository.category_locked ? repository.custom_category : undefined;
+  }
+
+  const customCategories = allCategories.filter(category => category.id !== 'all' && category.isCustom);
+  const defaultCategories = allCategories.filter(category => category.id !== 'all' && !category.isCustom);
+
+  const matchCategory = (categories: Category[]) => categories.find(category =>
+    normalizedTags.some(tag =>
+      category.name.toLowerCase() === tag.toLowerCase() ||
+      category.keywords.some(keyword =>
+        tag.toLowerCase().includes(keyword.toLowerCase()) ||
+        keyword.toLowerCase().includes(tag.toLowerCase())
+      )
+    )
+  );
+
+  const customMatch = matchCategory(customCategories);
+  if (customMatch) return customMatch.name;
+
+  const defaultMatch = matchCategory(defaultCategories);
+  if (defaultMatch) return undefined;
+
+  return repository.category_locked ? repository.custom_category : undefined;
+};


### PR DESCRIPTION
Fixes #72

## Summary
This PR improves category management with a focus on the left sidebar categories users actually interact with.

## What changed
- support hiding built-in default categories instead of deleting them
- support deleting custom categories without unstarring or removing repositories
- support dragging repository cards onto sidebar categories to quickly reassign category
- preserve user-adjusted categories during sync and future AI analysis via `category_locked`
- include available custom categories in AI analysis prompts
- when AI analysis matches a custom category, assign the repository into that custom category automatically
- keep hidden default category preferences in backup/restore and backend settings sync

## Behavior details
- deleting a custom category only clears that manual category assignment, it does not unstar or delete repositories
- manually changing category, including drag-and-drop assignment, locks the category so later sync/AI analysis does not revert it
- built-in categories are hidden, not permanently removed
- hidden built-in categories can be restored from Settings

## Validation
- local `npm run build` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hide and restore built-in categories from Settings
  * Drag repositories onto categories to assign them (with visual drop targets)
  * AI suggests and auto-applies categories during analysis
  * Per-category actions in the sidebar: edit, delete (custom), hide (default)
  * Assigned categories can be locked to prevent accidental changes
  * Category changes and settings sync automatically with the backend
<!-- end of auto-generated comment: release notes by coderabbit.ai -->