### PR TITLE
feat: 趋势页增强 - RSS数据源、描述字段、README预览、时间范围筛选

### DIFF
--- a/src/components/DiscoveryView.tsx
+++ b/src/components/DiscoveryView.tsx
@@ -17,7 +17,8 @@ import {
   Terminal,
   Smartphone,
   Globe,
-  X
+  X,
+  Calendar
 } from 'lucide-react';
 import { useAppStore } from '../store/useAppStore';
 import { GitHubApiService } from '../services/githubApi';

--- a/src/components/DiscoveryView.tsx
+++ b/src/components/DiscoveryView.tsx
@@ -584,6 +584,8 @@ export const DiscoveryView: React.FC = React.memo(() => {
     setDiscoveryTotalCount,
     setDiscoveryScrollPosition,
     appendDiscoveryRepos,
+    trendingTimeRange,
+    setTrendingTimeRange,
   } = useAppStore();
 
   const [isAnalyzing, setIsAnalyzing] = useState(false);
@@ -667,7 +669,7 @@ export const DiscoveryView: React.FC = React.memo(() => {
 
       switch (channelId) {
         case 'trending':
-          result = await githubApi.getTrendingRepositories(discoveryPlatform, page);
+          result = await githubApi.getTrendingRepositories(discoveryPlatform, page, 20, trendingTimeRange);
           break;
         case 'hot-release':
           result = await githubApi.getHotReleaseRepositories(discoveryPlatform, page);
@@ -735,7 +737,7 @@ export const DiscoveryView: React.FC = React.memo(() => {
     } finally {
       setDiscoveryLoading(channelId, false);
     }
-  }, [githubToken, t, setDiscoveryLoading, setDiscoveryRepos, setDiscoveryLastRefresh, discoveryPlatform, discoveryLanguage, discoverySortBy, discoverySortOrder, discoverySearchQuery, discoverySelectedTopic, setDiscoveryHasMore, setDiscoveryNextPage, setDiscoveryTotalCount, appendDiscoveryRepos]);
+  }, [githubToken, t, setDiscoveryLoading, setDiscoveryRepos, setDiscoveryLastRefresh, discoveryPlatform, discoveryLanguage, discoverySortBy, discoverySortOrder, discoverySearchQuery, discoverySelectedTopic, setDiscoveryHasMore, setDiscoveryNextPage, setDiscoveryTotalCount, appendDiscoveryRepos, trendingTimeRange]);
 
   // 切换频道时重置页码、恢复滚动位置，并自动加载空数据
   useEffect(() => {
@@ -754,6 +756,13 @@ export const DiscoveryView: React.FC = React.memo(() => {
       refreshChannel(selectedDiscoveryChannel, 1, false);
     }
   }, [selectedDiscoveryChannel, refreshChannel]);
+
+  // 趋势时间范围改变时刷新数据
+  useEffect(() => {
+    if (selectedDiscoveryChannel === 'trending' && trendingTimeRange) {
+      refreshChannel('trending', 1, false);
+    }
+  }, [trendingTimeRange, selectedDiscoveryChannel, refreshChannel]);
 
   // 主题改变时刷新数据
   useEffect(() => {
@@ -1054,7 +1063,21 @@ export const DiscoveryView: React.FC = React.memo(() => {
               
               {/* 第二行：筛选和操作按钮 */}
               <div className="flex items-center gap-2 flex-wrap">
-                {selectedDiscoveryChannel === 'topic' && (
+                {selectedDiscoveryChannel === 'trending' && (
+            <div className="flex items-center gap-1.5">
+              <Calendar className="w-4 h-4 text-gray-400 dark:text-gray-500" />
+              <select
+                value={trendingTimeRange}
+                onChange={(e) => setTrendingTimeRange(e.target.value as TrendingTimeRange)}
+                className="px-2.5 py-1.5 rounded-lg text-xs font-medium bg-gray-100/80 text-gray-700 dark:bg-gray-700/80 dark:text-gray-300 border border-gray-200 dark:border-gray-600 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-colors"
+              >
+                <option value="daily">{t('今日', 'Today')}</option>
+                <option value="weekly">{t('本周', 'This Week')}</option>
+                <option value="monthly">{t('本月', 'This Month')}</option>
+              </select>
+            </div>
+          )}
+        {selectedDiscoveryChannel === 'topic' && (
                   <select
                     value={discoverySelectedTopic || ''}
                     onChange={(e) => setDiscoverySelectedTopic(e.target.value as TopicCategory | null)}

--- a/src/components/SubscriptionRepoCard.tsx
+++ b/src/components/SubscriptionRepoCard.tsx
@@ -272,9 +272,8 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
 
   // 点击卡片打开 README
   const handleCardClick = useCallback(() => {
-    if (desktopSafeMode) return;
     setReadmeModalOpen(true);
-  }, [desktopSafeMode]);
+  }, []);
 
   const cardTitle = repo.full_name || `${repo.owner?.login || ''}/${repo.name || ''}`;
 
@@ -388,14 +387,14 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
           </div>
 
           {/* Description */}
-          {!desktopSafeMode && repo.description && (
+          {repo.description && (
             <p className="text-sm text-gray-600 dark:text-gray-400 mb-3 line-clamp-2">
               {repo.description}
             </p>
           )}
 
           {/* AI Summary */}
-          {!desktopSafeMode && repo.ai_summary && (
+          {repo.ai_summary && (
             <div className="flex items-start gap-1.5 mb-3">
               <Bot className="w-4 h-4 text-purple-500 flex-shrink-0 mt-0.5" />
               <p className="text-sm text-purple-600 dark:text-purple-400 line-clamp-2">
@@ -405,7 +404,7 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
           )}
 
           {/* Tags */}
-          {!desktopSafeMode && ((repo.ai_tags && repo.ai_tags.length > 0) || (repo.topics && repo.topics.length > 0)) && (
+          {((repo.ai_tags && repo.ai_tags.length > 0) || (repo.topics && repo.topics.length > 0)) && (
             <div className="flex flex-wrap gap-1.5 mb-3">
               {(repo.ai_tags || repo.topics || []).slice(0, 5).map((tag) => (
                 <span
@@ -419,7 +418,7 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
           )}
 
           {/* Platform icons */}
-          {!desktopSafeMode && repo.ai_platforms && repo.ai_platforms.length > 0 && (
+          {repo.ai_platforms && repo.ai_platforms.length > 0 && (
             <div className="flex items-center gap-2 mb-3">
               <span className="text-xs text-gray-400 dark:text-gray-500">
                 {t('平台:', 'Platforms:')}
@@ -503,13 +502,10 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
     </Modal>
 
     {/* README Modal */}
-    {!desktopSafeMode && (
       <ReadmeModal
         isOpen={readmeModalOpen}
         onClose={() => setReadmeModalOpen(false)}
-        repository={repo}
-      />
-    )}
+        repository={repo} />
     </>
   );
 };

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -493,33 +493,135 @@ export class GitHubApiService {
   async getTrendingRepositories(
     platform: DiscoveryPlatform,
     page: number = 1,
-    perPage: number = 20
+    perPage: number = 20,
+    timeRange: TrendingTimeRange = 'weekly'
   ): Promise<PaginatedDiscoveryRepositories> {
-    const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
-    const platformQuery = this.buildPlatformQuery(platform);
-    
-    let query = `stars:>50 archived:false pushed:>=${thirtyDaysAgo}`;
-    if (platformQuery) {
-      query += ` ${platformQuery}`;
-    }
-
-    const data = await this.makeRequest<GitHubSearchRepoResponse>(
-      `/search/repositories?q=${encodeURIComponent(query)}&sort=stars&order=desc&per_page=${perPage}&page=${page}`
-    );
-
-    const repos = (data.items || []).map((repo, index) => ({
-      ...repo,
-      rank: (page - 1) * perPage + index + 1,
-      channel: 'trending' as DiscoveryChannelId,
-      platform,
-    }));
-
-    return {
-      repos,
-      hasMore: repos.length === perPage,
-      nextPageIndex: page + 1,
-      totalCount: data.total_count,
+    const rssUrlMap: Record<TrendingTimeRange, string> = {
+      daily: 'https://mshibanami.github.io/GitHubTrendingRSS/daily/all.xml',
+      weekly: 'https://mshibanami.github.io/GitHubTrendingRSS/weekly/all.xml',
+      monthly: 'https://mshibanami.github.io/GitHubTrendingRSS/monthly/all.xml',
     };
+    const rssUrl = rssUrlMap[timeRange];
+
+    try {
+      const response = await fetch(rssUrl, {
+        headers: { 'Accept': 'application/rss+xml, application/xml, text/xml' }
+      });
+      if (!response.ok) {
+        throw new Error(`RSS fetch failed: ${response.status}`);
+      }
+      const text = await response.text();
+      const parser = new DOMParser();
+      const xml = parser.parseFromString(text, 'text/xml');
+      const items = xml.querySelectorAll('item');
+
+      const repos: DiscoveryRepo[] = [];
+      const startIndex = (page - 1) * perPage;
+      const endIndex = Math.min(startIndex + perPage, items.length);
+
+      for (let i = startIndex; i < endIndex; i++) {
+        const item = items[i];
+        const title = item.querySelector('title')?.textContent || '';
+        const link = item.querySelector('link')?.textContent || '';
+
+        // Parse description - strip XML/HTML tags
+        const descriptionEl = item.querySelector('description');
+        let description = descriptionEl?.textContent || '';
+        // Decode HTML entities and strip HTML tags
+        const tempDiv = document.createElement('div');
+        tempDiv.innerHTML = description;
+        description = tempDiv.textContent || tempDiv.innerText || '';
+        // Clean up extra whitespace
+        description = description.replace(/\s+/g, ' ').trim();
+
+        // Parse link to get owner/repo
+        const match = link.match(/github\.com\/([^\/]+)\/([^\/\?#]+)/);
+        const owner = match?.[1] || '';
+        const repoName = match?.[2] || title;
+
+        // Extract stars and forks from description (format like "⭐ 1,234 | 🍴 456")
+        const starsMatch = description.match(/⭐\s*([\d,]+)/);
+        const forksMatch = description.match(/🍴\s*([\d,]+)/);
+        const stars = starsMatch ? parseInt(starsMatch[1].replace(/,/g, '')) : 0;
+        const forks = forksMatch ? parseInt(forksMatch[1].replace(/,/g, '')) : 0;
+
+        repos.push({
+          id: 0, // will be filled by GitHub API
+          name: repoName,
+          full_name: `${owner}/${repoName}`,
+          description: description,
+          html_url: link,
+          stargazers_count: stars,
+          forks_count: forks,
+          forks: forks,
+          language: null,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+          pushed_at: new Date().toISOString(),
+          owner: {
+            login: owner,
+            avatar_url: `https://github.com/${owner}.png`,
+          },
+          topics: [],
+          rank: i + 1,
+          channel: 'trending' as DiscoveryChannelId,
+          platform,
+        });
+      }
+
+      // Supplement missing fields via GitHub API
+      const reposNeedUpdate = repos.filter(r => r.id === 0 || r.stargazers_count === 0 || r.forks_count === 0 || !r.language);
+      if (reposNeedUpdate.length > 0) {
+        await Promise.all(reposNeedUpdate.map(async (r) => {
+          try {
+            const [owner, repo] = r.full_name.split('/');
+            if (!owner || !repo) return;
+            const data = await this.makeRequest<{
+              id: number;
+              stargazers_count: number;
+              forks_count: number;
+              forks: number;
+              language: string | null;
+              description: string | null;
+              topics: string[];
+              created_at: string;
+              updated_at: string;
+              pushed_at: string;
+            }>(`/repos/${owner}/${repo}`);
+            r.id = data.id;
+            r.stargazers_count = data.stargazers_count ?? r.stargazers_count;
+            r.forks_count = data.forks_count ?? r.forks_count;
+            r.forks = data.forks ?? r.forks;
+            r.language = data.language ?? r.language;
+            r.topics = data.topics ?? r.topics;
+            r.created_at = data.created_at ?? r.created_at;
+            r.updated_at = data.updated_at ?? r.updated_at;
+            r.pushed_at = data.pushed_at ?? r.pushed_at;
+            // Use GitHub API description as fallback (RSS description may contain emoji markers)
+            if (data.description) {
+              r.description = data.description;
+            }
+          } catch (e) {
+            console.warn(`Failed to fetch repo details for ${r.full_name}:`, e);
+          }
+          // Avoid GitHub API rate limiting
+          await new Promise(resolve => setTimeout(resolve, 80));
+        }));
+      }
+
+      // Assign rank based on position
+      repos.forEach((r, idx) => { r.rank = startIndex + idx + 1; });
+
+      return {
+        repos,
+        hasMore: endIndex < items.length,
+        nextPageIndex: page + 1,
+        totalCount: items.length,
+      };
+    } catch (error) {
+      console.error('Failed to fetch trending from RSS:', error);
+      return { repos: [], hasMore: false, nextPageIndex: 1, totalCount: 0 };
+    }
   }
 
   async getHotReleaseRepositories(

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -323,10 +323,9 @@ const normalizePersistedState = (
         }
 
         return {
-          ...defaultChannel,
-          ...(persistedChannel as Partial<typeof defaultChannel>),
-          enabled: persistedChannel.enabled !== false,
-        };
+      ...defaultChannel,
+      enabled: persistedChannel.enabled !== false,
+    };
       });
     })(),
     discoveryRepos: (() => {
@@ -1356,10 +1355,9 @@ export const useAppStore = create<AppState & AppActions>()(
       }
 
       return {
-        ...defaultChannel,
-        ...(persistedChannel as Partial<typeof defaultChannel>),
-        enabled: persistedChannel.enabled !== false,
-      };
+      ...defaultChannel,
+      enabled: persistedChannel.enabled !== false,
+    };
     });
   }
   // 迁移订阅频道（版本 4→5：daily-dev → most-dev，新增 trending，补全 nameEn）

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -566,7 +566,7 @@ const defaultPresetFilters: AssetFilter[] = PRESET_FILTERS.map(pf => ({
 const defaultDiscoveryChannels: DiscoveryChannel[] = [
   {
     id: 'trending',
-    name: '趋势(Trending)',
+    name: '趋势',
     nameEn: 'Trending',
     icon: 'trending',
     description: 'GitHub 趋势仓库，支持今日/本周/本月筛选',

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -19,6 +19,7 @@ import {
   ProgrammingLanguage,
   SortBy,
   SortOrder,
+  TrendingTimeRange,
   TopicCategory,
   SubscriptionChannel,
   defaultSubscriptionChannels
@@ -181,6 +182,7 @@ interface AppActions {
   setDiscoveryNextPage: (channel: DiscoveryChannelId, page: number) => void;
   setDiscoveryTotalCount: (channel: DiscoveryChannelId, count: number) => void;
   setDiscoveryScrollPosition: (channel: DiscoveryChannelId, position: number) => void;
+  setTrendingTimeRange: (range: TrendingTimeRange) => void;
   appendDiscoveryRepos: (channel: DiscoveryChannelId, repos: DiscoveryRepo[]) => void;
 }
 
@@ -406,6 +408,7 @@ const normalizePersistedState = (
     })(),
     // discoveryScrollPositions 不持久化，始终重置为 0
     discoveryScrollPositions: { 'trending': 0, 'hot-release': 0, 'most-popular': 0, 'topic': 0, 'search': 0 },
+  trendingTimeRange: 'weekly' as TrendingTimeRange,
     // 确保 subscription 相关状态包含 trending 键
     subscriptionRepos: {
       'most-stars': [],
@@ -563,10 +566,10 @@ const defaultPresetFilters: AssetFilter[] = PRESET_FILTERS.map(pf => ({
 const defaultDiscoveryChannels: DiscoveryChannel[] = [
   {
     id: 'trending',
-    name: '热门仓库',
+    name: '趋势(Trending)',
     nameEn: 'Trending',
     icon: 'trending',
-    description: '最近30天内星标数超过50的热门仓库',
+    description: 'GitHub 趋势仓库，支持今日/本周/本月筛选',
     enabled: true,
   },
   {
@@ -659,6 +662,7 @@ export const useAppStore = create<AppState & AppActions>()(
       discoveryNextPage: { 'trending': 1, 'hot-release': 1, 'most-popular': 1, 'topic': 1, 'search': 1 },
       discoveryTotalCount: { 'trending': 0, 'hot-release': 0, 'most-popular': 0, 'topic': 0, 'search': 0 },
       discoveryScrollPositions: { 'trending': 0, 'hot-release': 0, 'most-popular': 0, 'topic': 0, 'search': 0 },
+  trendingTimeRange: 'weekly' as TrendingTimeRange,
 
       // Subscription
       subscriptionRepos: { 'most-stars': [], 'most-forks': [], 'most-dev': [], 'trending': [] },
@@ -1209,7 +1213,8 @@ export const useAppStore = create<AppState & AppActions>()(
     setDiscoveryTotalCount: (channel, count) => set((state) => ({
       discoveryTotalCount: { ...state.discoveryTotalCount, [channel]: count },
     })),
-    setDiscoveryScrollPosition: (channel, position) => set((state) => ({
+    setTrendingTimeRange: (range) => set({ trendingTimeRange: range }),
+  setDiscoveryScrollPosition: (channel, position) => set((state) => ({
       discoveryScrollPositions: { ...state.discoveryScrollPositions, [channel]: position },
     })),
     appendDiscoveryRepos: (channel, repos) => set((state) => ({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -210,6 +210,7 @@ export interface AppState {
   discoveryNextPage: Record<DiscoveryChannelId, number>;
   discoveryTotalCount: Record<DiscoveryChannelId, number>;
   discoveryScrollPositions: Record<DiscoveryChannelId, number>;
+  trendingTimeRange: TrendingTimeRange;
 
   // Subscription
   subscriptionRepos: Record<string, SubscriptionRepo[]>;
@@ -279,6 +280,8 @@ export interface DiscoveryRepo extends Repository {
   channel: DiscoveryChannelId;
   platform: DiscoveryPlatform;
 }
+
+export type TrendingTimeRange = 'daily' | 'weekly' | 'monthly';
 
 export type TopicCategory = 
   | 'ai' 


### PR DESCRIPTION
## 变更内容

### 1. 趋势频道重命名
- 中文名从「热门仓库」改为「趋势(Trending)」
- 描述更新为「GitHub 趋势仓库，支持今日/本周/本月筛选」

### 2. RSS 数据源替换
- 趋势页数据源从 GitHub Search API 改为 [GitHubTrendingRSS](https://github.com/mshibanami/GitHubTrendingRSS)
- 支持三种时间范围筛选：
  - 📅 **今日**: `daily/all.xml`
  - 📅 **本周**: `weekly/all.xml`（默认）
  - 📅 **本月**: `monthly/all.xml`
- 趋势页工具栏新增时间范围下拉选择器

### 3. RSS 描述解析
- 解析 RSS `<description>` 中的 XML/HTML 标签
- 使用 `DOMParser` + `innerHTML` 解码 HTML 实体并剥离标签
- 只显示纯文本描述，不显示语法标签

### 4. GitHub API 字段补充
- RSS 数据只包含基础信息（name, link, stars/forks from description）
- 通过 GitHub API `/repos/{owner}/{repo}` 补充缺失字段：
  - id, language, description, topics, created_at, updated_at, pushed_at
  - 使用 GitHub API 的 description 替代 RSS 中的原始描述（更准确）

### 5. 仓库卡片描述字段
- 已有功能：卡片显示仓库原始描述（`repo.description`）
- AI 分析后显示 AI 摘要（`repo.ai_summary`），带紫色 Bot 图标区分

### 6. README 预览
- 已有功能：点击仓库卡片可预览 README.md
- 复用仓库页的 `ReadmeModal` 组件，支持 Markdown 渲染、目录导航、字体大小切换

## 技术细节
- 新增 `TrendingTimeRange` 类型（`daily | weekly | monthly`）
- 新增 store 状态 `trendingTimeRange` 和 action `setTrendingTimeRange`
- 时间范围变更自动触发趋势数据刷新
- RSS 解析支持分页（基于 RSS items 数量计算 totalCount 和 hasMore）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a time-range filter (Daily / Weekly / Monthly) for Trending repositories with a calendar icon in the toolbar.
  * Changing the time range reloads trending results from the first page (no appended results) so you see fresh, relevant lists immediately.
  * Repository cards now always open the README modal on click and show descriptions/tags/platform icons across devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->