### PR TITLE
fix: 输入框焦点样式 & Tailwind 类名拼写错误

### DIFF
--- a/src/components/AssetFilterManager.tsx
+++ b/src/components/AssetFilterManager.tsx
@@ -275,7 +275,7 @@ export const AssetFilterManager: React.FC<AssetFilterManagerProps> = ({
                     className={`group flex items-center space-x-2 px-3 py-2 rounded-lg border transition-colors ${
                       selectedFilters.includes(filter.id)
                         ? 'bg-gray-900 border-transparent text-white dark:bg-white/[0.12] dark:border-white/[0.2] dark:text-white font-medium'
-                        : 'bg-light-surfaceborder-black/[0.06] text-gray-900 dark:bg-white/[0.04] dark:border-white/[0.04] dark:text-text-secondary hover:bg-gray-200 dark:hover:bg-gray-600'
+                        : 'bg-light-surface border-black/[0.06] text-gray-900 dark:bg-white/[0.04] dark:border-white/[0.04] dark:text-text-secondary hover:bg-gray-200 dark:hover:bg-gray-600'
                     }`}
                   >
                     <button

--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -1103,7 +1103,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
                     checked={showAISummary}
                     onChange={() => hasAnalyzedRepos && setShowAISummary(true)}
                     disabled={!hasAnalyzedRepos}
-                    className="w-3.5 h-3.5 sm:w-4 sm:h-4 text-brand-violet bg-light-surfaceborder-black/[0.06] focus:ring-brand-violet dark:focus:ring-brand-violet dark:ring-offset-marketing-black focus:ring-2 dark:bg-white/5 dark:border-white/20 disabled:opacity-50"
+                    className="w-3.5 h-3.5 sm:w-4 sm:h-4 text-brand-violet bg-light-surface border-black/[0.06] focus:ring-brand-violet dark:focus:ring-brand-violet dark:ring-offset-marketing-black focus:ring-2 dark:bg-white/5 dark:border-white/20 disabled:opacity-50"
                   />
                   <span className="text-xs sm:text-sm font-medium text-gray-900 dark:text-text-secondary">
                     {t('AI分析内容', 'AI Analysis')}
@@ -1118,7 +1118,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
                     name="displayContent"
                     checked={!showAISummary}
                     onChange={() => setShowAISummary(false)}
-                    className="w-3.5 h-3.5 sm:w-4 sm:h-4 text-brand-violet bg-light-surfaceborder-black/[0.06] focus:ring-brand-violet dark:focus:ring-brand-violet dark:ring-offset-marketing-black focus:ring-2 dark:bg-white/5 dark:border-white/20"
+                    className="w-3.5 h-3.5 sm:w-4 sm:h-4 text-brand-violet bg-light-surface border-black/[0.06] focus:ring-brand-violet dark:focus:ring-brand-violet dark:ring-offset-marketing-black focus:ring-2 dark:bg-white/5 dark:border-white/20"
                   />
                   <span className="text-xs sm:text-sm font-medium text-gray-900 dark:text-text-secondary">
                     {t('原始描述', 'Original')}

--- a/src/components/settings/AIConfigPanel.tsx
+++ b/src/components/settings/AIConfigPanel.tsx
@@ -341,7 +341,7 @@ Focus on practicality and accurate categorization to help users quickly understa
                 type="text"
                 value={form.name}
                 onChange={(e) => setForm(prev => ({ ...prev, name: e.target.value }))}
-                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary"
+                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary focus:ring-2 focus:ring-brand-violet focus:border-transparent focus:outline-none"
                 placeholder={t('例如: OpenAI GPT-4', 'e.g., OpenAI GPT-4')}
               />
             </div>
@@ -353,7 +353,7 @@ Focus on practicality and accurate categorization to help users quickly understa
               <select
                 value={form.apiType}
                 onChange={(e) => setForm(prev => ({ ...prev, apiType: e.target.value as AIApiType }))}
-                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary"
+                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary focus:ring-2 focus:ring-brand-violet focus:border-transparent focus:outline-none"
               >
                 <option value="openai">OpenAI (Chat Completions)</option>
                 <option value="openai-responses">OpenAI (Responses)</option>
@@ -371,7 +371,7 @@ Focus on practicality and accurate categorization to help users quickly understa
                 type="url"
                 value={form.baseUrl}
                 onChange={(e) => setForm(prev => ({ ...prev, baseUrl: e.target.value }))}
-                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary"
+                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary focus:ring-2 focus:ring-brand-violet focus:border-transparent focus:outline-none"
                 placeholder={
                   form.apiType === 'openai' || form.apiType === 'openai-responses'
                     ? 'https://api.openai.com/v1'
@@ -411,7 +411,7 @@ Focus on practicality and accurate categorization to help users quickly understa
                 type="password"
                 value={form.apiKey}
                 onChange={(e) => setForm(prev => ({ ...prev, apiKey: e.target.value }))}
-                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary"
+                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary focus:ring-2 focus:ring-brand-violet focus:border-transparent focus:outline-none"
                 placeholder={t('输入API密钥', 'Enter API key')}
               />
             </div>
@@ -424,7 +424,7 @@ Focus on practicality and accurate categorization to help users quickly understa
                 type="text"
                 value={form.model}
                 onChange={(e) => setForm(prev => ({ ...prev, model: e.target.value }))}
-                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary"
+                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary focus:ring-2 focus:ring-brand-violet focus:border-transparent focus:outline-none"
                 placeholder="gpt-4"
               />
             </div>
@@ -452,7 +452,7 @@ Focus on practicality and accurate categorization to help users quickly understa
               <select
                 value={form.reasoningEffort}
                 onChange={(e) => setForm(prev => ({ ...prev, reasoningEffort: e.target.value as '' | AIReasoningEffort }))}
-                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary"
+                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary focus:ring-2 focus:ring-brand-violet focus:border-transparent focus:outline-none"
               >
                 <option value="">{t('默认 / 不传', 'Default / Do not send')}</option>
                 <option value="none">{t('none — 不推理', 'none — No reasoning')}</option>
@@ -493,7 +493,7 @@ Focus on practicality and accurate categorization to help users quickly understa
                     type="checkbox"
                     checked={form.useCustomPrompt}
                     onChange={(e) => handleUseCustomPromptChange(e.target.checked)}
-                    className="w-4 h-4 text-brand-violet bg-light-surfaceborder-black/[0.06] rounded focus:ring-brand-violet dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-white/[0.04] dark:border-white/[0.04]"
+                    className="w-4 h-4 text-brand-violet bg-light-surface border-black/[0.06] rounded focus:ring-brand-violet dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-white/[0.04] dark:border-white/[0.04]"
                   />
                   <span className="text-sm font-medium text-gray-900 dark:text-text-secondary">
                     {t('使用自定义提示词', 'Use Custom Prompt')}
@@ -614,7 +614,7 @@ Focus on practicality and accurate categorization to help users quickly understa
                   name="activeAI"
                   checked={config.id === activeAIConfig}
                   onChange={() => setActiveAIConfig(config.id)}
-                  className="w-4 h-4 text-gray-700 dark:text-text-secondary bg-light-surfaceborder-black/[0.06] focus:ring-purple-500 dark:focus:ring-purple-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-white/[0.04] dark:border-white/[0.04]"
+                  className="w-4 h-4 text-gray-700 dark:text-text-secondary bg-light-surface border-black/[0.06] focus:ring-purple-500 dark:focus:ring-purple-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-white/[0.04] dark:border-white/[0.04]"
                 />
                 <div>
                   <h4 className="font-medium text-gray-900 dark:text-text-primary flex items-center">

--- a/src/components/settings/BackendPanel.tsx
+++ b/src/components/settings/BackendPanel.tsx
@@ -229,7 +229,7 @@ export const BackendPanel: React.FC<BackendPanelProps> = ({ t }) => {
             type="password"
             value={secretInput}
             onChange={(e) => setSecretInput(e.target.value)}
-            className="flex-1 px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary"
+            className="flex-1 px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary focus:ring-2 focus:ring-brand-violet focus:border-transparent focus:outline-none"
             placeholder={t('输入后端 API_SECRET（可选）', 'Enter backend API_SECRET (optional)')}
           />
           <button

--- a/src/components/settings/CategoryPanel.tsx
+++ b/src/components/settings/CategoryPanel.tsx
@@ -304,7 +304,7 @@ export const CategoryPanel: React.FC<CategoryPanelProps> = ({ t }) => {
                 type="text"
                 value={newCategoryName}
                 onChange={(e) => setNewCategoryName(e.target.value)}
-                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary"
+                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary focus:ring-2 focus:ring-brand-violet focus:border-transparent focus:outline-none"
                 placeholder={t('例如: 我的项目', 'e.g., My Projects')}
               />
             </div>
@@ -322,7 +322,7 @@ export const CategoryPanel: React.FC<CategoryPanelProps> = ({ t }) => {
                     setNewCategoryIcon(value);
                   }
                 }}
-                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary"
+                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary focus:ring-2 focus:ring-brand-violet focus:border-transparent focus:outline-none"
                 placeholder="📁"
               />
             </div>
@@ -335,7 +335,7 @@ export const CategoryPanel: React.FC<CategoryPanelProps> = ({ t }) => {
               type="text"
               value={newCategoryKeywords}
               onChange={(e) => setNewCategoryKeywords(e.target.value)}
-              className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary"
+              className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary focus:ring-2 focus:ring-brand-violet focus:border-transparent focus:outline-none"
               placeholder={t('用逗号分隔关键词', 'Comma-separated keywords')}
             />
             <p className="text-xs text-gray-500 dark:text-text-tertiary mt-1">
@@ -483,14 +483,14 @@ export const CategoryPanel: React.FC<CategoryPanelProps> = ({ t }) => {
                                 setEditIcon(value);
                               }
                             }}
-                            className="w-14 px-2 py-1.5 border border-black/[0.06] dark:border-white/[0.04] rounded bg-white dark:bg-white/[0.04] text-center text-lg text-gray-900 dark:text-text-primary"
+                            className="w-14 px-2 py-1.5 border border-black/[0.06] dark:border-white/[0.04] rounded bg-white dark:bg-white/[0.04] text-center text-lg text-gray-900 dark:text-text-primary focus:ring-2 focus:ring-brand-violet focus:border-transparent focus:outline-none"
                             placeholder="📁"
                           />
                           <input
                             type="text"
                             value={editName}
                             onChange={(e) => setEditName(e.target.value)}
-                            className="flex-1 px-2 py-1.5 border border-black/[0.06] dark:border-white/[0.04] rounded bg-white dark:bg-white/[0.04] text-sm text-gray-900 dark:text-text-primary"
+                            className="flex-1 px-2 py-1.5 border border-black/[0.06] dark:border-white/[0.04] rounded bg-white dark:bg-white/[0.04] text-sm text-gray-900 dark:text-text-primary focus:ring-2 focus:ring-brand-violet focus:border-transparent focus:outline-none"
                             placeholder={t('分类名称', 'Category name')}
                           />
                         </div>
@@ -499,7 +499,7 @@ export const CategoryPanel: React.FC<CategoryPanelProps> = ({ t }) => {
                             type="text"
                             value={editKeywords}
                             onChange={(e) => setEditKeywords(e.target.value)}
-                            className="flex-1 px-2 py-1.5 border border-black/[0.06] dark:border-white/[0.04] rounded bg-white dark:bg-white/[0.04] text-sm text-gray-900 dark:text-text-primary"
+                            className="flex-1 px-2 py-1.5 border border-black/[0.06] dark:border-white/[0.04] rounded bg-white dark:bg-white/[0.04] text-sm text-gray-900 dark:text-text-primary focus:ring-2 focus:ring-brand-violet focus:border-transparent focus:outline-none"
                             placeholder={t('关键词（逗号分隔）', 'Keywords (comma separated)')}
                           />
                           <button

--- a/src/components/settings/GeneralPanel.tsx
+++ b/src/components/settings/GeneralPanel.tsx
@@ -37,7 +37,7 @@ export const GeneralPanel: React.FC<GeneralPanelProps> = ({ t }) => {
               value="zh"
               checked={language === 'zh'}
               onChange={(e) => setLanguage(e.target.value as 'zh' | 'en')}
-              className="w-4 h-4 text-brand-violet bg-light-surfaceborder-black/[0.06] focus:ring-brand-violet dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-white/[0.04] dark:border-white/[0.04]"
+              className="w-4 h-4 text-brand-violet bg-light-surface border-black/[0.06] focus:ring-brand-violet dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-white/[0.04] dark:border-white/[0.04]"
             />
             <div>
               <span className="text-base font-medium text-gray-900 dark:text-text-primary">
@@ -55,7 +55,7 @@ export const GeneralPanel: React.FC<GeneralPanelProps> = ({ t }) => {
               value="en"
               checked={language === 'en'}
               onChange={(e) => setLanguage(e.target.value as 'zh' | 'en')}
-              className="w-4 h-4 text-brand-violet bg-light-surfaceborder-black/[0.06] focus:ring-brand-violet dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-white/[0.04] dark:border-white/[0.04]"
+              className="w-4 h-4 text-brand-violet bg-light-surface border-black/[0.06] focus:ring-brand-violet dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-white/[0.04] dark:border-white/[0.04]"
             />
             <div>
               <span className="text-base font-medium text-gray-900 dark:text-text-primary">

--- a/src/components/settings/WebDAVPanel.tsx
+++ b/src/components/settings/WebDAVPanel.tsx
@@ -143,7 +143,7 @@ export const WebDAVPanel: React.FC<WebDAVPanelProps> = ({ t }) => {
                 type="text"
                 value={form.name}
                 onChange={(e) => setForm(prev => ({ ...prev, name: e.target.value }))}
-                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary"
+                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary focus:ring-2 focus:ring-brand-violet focus:border-transparent focus:outline-none"
                 placeholder={t('例如: 坚果云', 'e.g., Nutstore')}
               />
             </div>
@@ -156,7 +156,7 @@ export const WebDAVPanel: React.FC<WebDAVPanelProps> = ({ t }) => {
                 type="url"
                 value={form.url}
                 onChange={(e) => setForm(prev => ({ ...prev, url: e.target.value }))}
-                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary"
+                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary focus:ring-2 focus:ring-brand-violet focus:border-transparent focus:outline-none"
                 placeholder="https://dav.jianguoyun.com/dav/"
               />
             </div>
@@ -169,7 +169,7 @@ export const WebDAVPanel: React.FC<WebDAVPanelProps> = ({ t }) => {
                 type="text"
                 value={form.username}
                 onChange={(e) => setForm(prev => ({ ...prev, username: e.target.value }))}
-                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary"
+                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary focus:ring-2 focus:ring-brand-violet focus:border-transparent focus:outline-none"
                 placeholder={t('WebDAV用户名', 'WebDAV username')}
               />
             </div>
@@ -182,7 +182,7 @@ export const WebDAVPanel: React.FC<WebDAVPanelProps> = ({ t }) => {
                 type="password"
                 value={form.password}
                 onChange={(e) => setForm(prev => ({ ...prev, password: e.target.value }))}
-                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary"
+                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary focus:ring-2 focus:ring-brand-violet focus:border-transparent focus:outline-none"
                 placeholder={t('WebDAV密码', 'WebDAV password')}
               />
             </div>
@@ -195,7 +195,7 @@ export const WebDAVPanel: React.FC<WebDAVPanelProps> = ({ t }) => {
                 type="text"
                 value={form.path}
                 onChange={(e) => setForm(prev => ({ ...prev, path: e.target.value }))}
-                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary"
+                className="w-full px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-panel-dark text-gray-900 dark:text-text-primary focus:ring-2 focus:ring-brand-violet focus:border-transparent focus:outline-none"
                 placeholder="/github-stars-manager/"
               />
             </div>
@@ -237,7 +237,7 @@ export const WebDAVPanel: React.FC<WebDAVPanelProps> = ({ t }) => {
                   name="activeWebDAV"
                   checked={config.id === activeWebDAVConfig}
                   onChange={() => setActiveWebDAVConfig(config.id)}
-                  className="w-4 h-4 text-brand-violet bg-light-surfaceborder-black/[0.06] focus:ring-brand-violet dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-white/[0.04] dark:border-white/[0.04]"
+                  className="w-4 h-4 text-brand-violet bg-light-surface border-black/[0.06] focus:ring-brand-violet dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-white/[0.04] dark:border-white/[0.04]"
                 />
                 <div>
                   <h4 className="font-medium text-gray-900 dark:text-text-primary">{config.name}</h4>


### PR DESCRIPTION
## Summary

修复 Issue #103 和 #109 的根因：

- **Issue #103**（输入框无法点击）：AIConfigPanel 和 WebDAVPanel 中的 text/url/password/select 输入框**完全没有 focus 可见样式**，`alert()` 对话框消失后用户无法从视觉上确认焦点在哪
- **Issue #109**（焦点无高亮+光标不闪）：同样是输入框缺少 focus ring 样式
- **两处共有的 Tailwind 类名拼写错误**：`bg-light-surfaceborder-black/[0.06]` 缺少空格，导致 Tailwind 将整个字符串当作无效类名处理，背景和边框样式失效

## Changes

1. **AIConfigPanel.tsx**
   - 5个 text/url/password/select 输入框添加 `focus:ring-2 focus:ring-brand-violet focus:border-transparent focus:outline-none`
   - 修复 checkbox 和 radio 背景色的 Tailwind 类名拼写错误

2. **WebDAVPanel.tsx**
   - 5个 text/url/password 输入框添加相同的 focus ring 样式
   - 修复 radio 背景色的 Tailwind 类名拼写错误

3. **GeneralPanel.tsx / RepositoryList.tsx / AssetFilterManager.tsx**
   - 修复 Tailwind 类名拼写错误（`bg-light-surfaceborder-black/[0.06]` → `bg-light-surface border-black/[0.06]`）

## Test plan

- [ ] 进入 AI 配置页面，点击"添加 AI 配置"，点击测试连接（失败弹 alert），alert 关闭后点击任意输入框 — 应有紫色 focus ring 高亮
- [ ] 同上操作后 WebDAV 页面的输入框 — 应有紫色 focus ring 高亮
- [ ] 验证 GeneralPanel 语言切换、RepositoryList 复选框等元素的背景色正常显示

## Related Issues

Fixes #103, Fixes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed styling inconsistencies for unselected filter items, radio controls, and selection inputs across the app to ensure backgrounds and borders render correctly.

* **Style**
  * Added consistent focus rings and suppressed default outlines on various form inputs and selects, providing clearer, brand-themed visual feedback when interacting with settings and forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->