### PR TITLE
fix: 从 package.json 读取版本号而非硬编码

### DIFF
--- a/src/services/updateService.ts
+++ b/src/services/updateService.ts
@@ -6,6 +6,7 @@ export interface VersionInfo {
 }
 
 import { PROJECT_REPO_URL } from '../constants/project';
+import { version } from '../../package.json';
 
 const REPO_OWNER = PROJECT_REPO_URL.split('/').slice(-2).join('/');
 const VERSION_INFO_URL = `https://raw.githubusercontent.com/${REPO_OWNER}/main/versions/version-info.xml`;
@@ -20,9 +21,7 @@ export class UpdateService {
   private static readonly REPO_URL = VERSION_INFO_URL;
 
   private static getCurrentVersion(): string {
-    // 在实际应用中，这个版本号应该在构建时注入
-    // 这里暂时硬编码，你可以通过构建脚本或环境变量来动态设置
-    return '0.5.3';
+    return version;
   }
 
   static async checkForUpdates(): Promise<UpdateCheckResult> {


### PR DESCRIPTION
## Summary

`UpdateService.getCurrentVersion()` 原为硬编码的 `'0.5.3'`，改为从 `package.json` 导入 `version`，遵循 `GeneralPanel` 中已有的相同模式。

## Changes

- `src/services/updateService.ts`
  - 添加 `import { version } from '../../package.json'`
  - `getCurrentVersion()` 返回值由硬编码改为 `version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version detection accuracy for the update checking system. The application now correctly identifies available updates using proper version information, ensuring users receive accurate and timely notifications about software updates. This enhancement increases the reliability of automatic update detection, helping users maintain their software at the latest version with confidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->