### PR TITLE
fix: 替换原生 alert/confirm 解决 Electron 焦点劫持 bug

### DIFF
--- a/.claude/settings.local 2.json
+++ b/.claude/settings.local 2.json
@@ -1,0 +1,6 @@
+{
+  "enabledMcpjsonServers": [
+    "playwright"
+  ],
+  "enableAllProjectMcpServers": true
+}

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ server/dist/
 
  # Orchestrator internal files
 .sisyphus/
+
+# Claude Code local (per-developer) settings
+.claude/settings.local.json
+
+# Landing page (separate static site)
+LandingPage/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "github-stars-manager",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "github-stars-manager",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "dependencies": {
         "date-fns": "^3.3.1",
         "highlight.js": "^11.11.1",

--- a/src/components/AssetFilterManager.tsx
+++ b/src/components/AssetFilterManager.tsx
@@ -4,6 +4,7 @@ import { useAppStore } from '../store/useAppStore';
 import { FilterModal } from './FilterModal';
 import { AssetFilter } from '../types';
 import { PRESET_FILTERS } from '../constants/presetFilters';
+import { useDialog } from '../hooks/useDialog';
 
 // 图标映射
 const ICON_MAP: Record<string, React.ElementType> = {
@@ -42,6 +43,9 @@ export const AssetFilterManager: React.FC<AssetFilterManagerProps> = ({
   onClearFilters
 }) => {
   const { assetFilters, addAssetFilter, updateAssetFilter, deleteAssetFilter, language } = useAppStore();
+
+  const { toast, confirm } = useDialog();
+
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingFilter, setEditingFilter] = useState<AssetFilter | undefined>();
   const [isExpanded, setIsExpanded] = useState(false);
@@ -69,13 +73,18 @@ export const AssetFilterManager: React.FC<AssetFilterManagerProps> = ({
     setIsModalOpen(true);
   };
 
-  const handleDeleteFilter = (filterId: string) => {
-    if (confirm(language === 'zh' ? '确定要删除这个过滤器吗？' : 'Are you sure you want to delete this filter?')) {
-      deleteAssetFilter(filterId);
-      // Remove from selected filters if it was selected
-      if (selectedFilters.includes(filterId)) {
-        onFilterToggle(filterId);
-      }
+  const handleDeleteFilter = async (filterId: string) => {
+    const confirmed = await confirm(
+      t('删除过滤器', 'Delete Filter'),
+      language === 'zh' ? '确定要删除这个过滤器吗？' : 'Are you sure you want to delete this filter?',
+      { type: 'danger', confirmText: t('删除', 'Delete') }
+    );
+
+    if (!confirmed) return;
+
+    deleteAssetFilter(filterId);
+    if (selectedFilters.includes(filterId)) {
+      onFilterToggle(filterId);
     }
   };
 
@@ -91,49 +100,55 @@ export const AssetFilterManager: React.FC<AssetFilterManagerProps> = ({
     onFilterToggle(presetId);
   };
 
-  const handleResetPresets = () => {
-    if (confirm(language === 'zh' ? '确定要重置所有预设筛选器吗？这将恢复默认设置。' : 'Are you sure you want to reset all preset filters? This will restore default settings.')) {
-      const previousFilters = assetFilters.map(f => ({ ...f }));
-      const previousSelected = [...selectedFilters];
-      const addedFilterIds: string[] = [];
-      
-      try {
-        presetFilters.forEach(filter => {
-          if (assetFilters.find(f => f.id === filter.id)) {
-            deleteAssetFilter(filter.id);
-          }
-          if (selectedFilters.includes(filter.id)) {
-            onFilterToggle(filter.id);
-          }
-        });
-        DEFAULT_PRESET_FILTERS.forEach(filter => {
-          if (!assetFilters.find(f => f.id === filter.id)) {
-            addAssetFilter(filter);
-            addedFilterIds.push(filter.id);
-          }
-        });
-      } catch (error) {
-        console.error('Failed to reset presets:', error);
-        
-        addedFilterIds.forEach(id => {
-          if (assetFilters.find(f => f.id === id)) {
-            deleteAssetFilter(id);
-          }
-        });
-        
-        previousFilters.forEach(filter => {
-          if (!assetFilters.find(f => f.id === filter.id)) {
-            addAssetFilter(filter);
-          }
-        });
-        
-        // 清除当前所有选择
-        selectedFilters.forEach(id => onFilterToggle(id));
-        // 恢复之前的选择
-        previousSelected.forEach(id => onFilterToggle(id));
-        
-        alert(language === 'zh' ? '重置预设筛选器失败，已恢复之前的状态。' : 'Failed to reset preset filters. Previous state has been restored.');
-      }
+  const handleResetPresets = async () => {
+    const confirmed = await confirm(
+      t('重置预设', 'Reset Presets'),
+      language === 'zh' ? '确定要重置所有预设筛选器吗？这将恢复默认设置。' : 'Are you sure you want to reset all preset filters? This will restore default settings.',
+      { type: 'warning' }
+    );
+
+    if (!confirmed) return;
+
+    const previousFilters = assetFilters.map(f => ({ ...f }));
+    const previousSelected = [...selectedFilters];
+    const addedFilterIds: string[] = [];
+
+    try {
+      presetFilters.forEach(filter => {
+        if (assetFilters.find(f => f.id === filter.id)) {
+          deleteAssetFilter(filter.id);
+        }
+        if (selectedFilters.includes(filter.id)) {
+          onFilterToggle(filter.id);
+        }
+      });
+      DEFAULT_PRESET_FILTERS.forEach(filter => {
+        if (!assetFilters.find(f => f.id === filter.id)) {
+          addAssetFilter(filter);
+          addedFilterIds.push(filter.id);
+        }
+      });
+    } catch (error) {
+      console.error('Failed to reset presets:', error);
+
+      addedFilterIds.forEach(id => {
+        if (assetFilters.find(f => f.id === id)) {
+          deleteAssetFilter(id);
+        }
+      });
+
+      previousFilters.forEach(filter => {
+        if (!assetFilters.find(f => f.id === filter.id)) {
+          addAssetFilter(filter);
+        }
+      });
+
+      // 清除当前所有选择
+      selectedFilters.forEach(id => onFilterToggle(id));
+      // 恢复之前的选择
+      previousSelected.forEach(id => onFilterToggle(id));
+
+      toast(language === 'zh' ? '重置预设筛选器失败，已恢复之前的状态。' : 'Failed to reset preset filters. Previous state has been restored.', 'error');
     }
   };
 

--- a/src/components/AssetFilterManager.tsx
+++ b/src/components/AssetFilterManager.tsx
@@ -114,8 +114,9 @@ export const AssetFilterManager: React.FC<AssetFilterManagerProps> = ({
     const addedFilterIds: string[] = [];
 
     try {
+      const store = useAppStore.getState();
       presetFilters.forEach(filter => {
-        if (assetFilters.find(f => f.id === filter.id)) {
+        if (store.assetFilters.find(f => f.id === filter.id)) {
           deleteAssetFilter(filter.id);
         }
         if (selectedFilters.includes(filter.id)) {
@@ -123,22 +124,29 @@ export const AssetFilterManager: React.FC<AssetFilterManagerProps> = ({
         }
       });
       DEFAULT_PRESET_FILTERS.forEach(filter => {
-        if (!assetFilters.find(f => f.id === filter.id)) {
+        if (!store.assetFilters.find(f => f.id === filter.id)) {
           addAssetFilter(filter);
           addedFilterIds.push(filter.id);
         }
       });
+      // Restore previously active preset selections that still map to a known preset id.
+      previousSelected.forEach(id => {
+        if (DEFAULT_PRESET_FILTERS.some(f => f.id === id) && !selectedFilters.includes(id)) {
+          onFilterToggle(id);
+        }
+      });
     } catch (error) {
       console.error('Failed to reset presets:', error);
+      const store = useAppStore.getState();
 
       addedFilterIds.forEach(id => {
-        if (assetFilters.find(f => f.id === id)) {
+        if (store.assetFilters.find(f => f.id === id)) {
           deleteAssetFilter(id);
         }
       });
 
       previousFilters.forEach(filter => {
-        if (!assetFilters.find(f => f.id === filter.id)) {
+        if (!store.assetFilters.find(f => f.id === filter.id)) {
           addAssetFilter(filter);
         }
       });

--- a/src/components/CategoryEditModal.tsx
+++ b/src/components/CategoryEditModal.tsx
@@ -3,6 +3,7 @@ import { Save, X, Plus } from 'lucide-react';
 import { Modal } from './Modal';
 import { Category } from '../types';
 import { useAppStore, getAllCategories } from '../store/useAppStore';
+import { useDialog } from '../hooks/useDialog';
 
 // Complete emoji collection for categories
 const availableIcons = [
@@ -794,6 +795,8 @@ export const CategoryEditModal: React.FC<CategoryEditModalProps> = ({
 }) => {
   const { addCustomCategory, updateCustomCategory, updateDefaultCategory, resetDefaultCategory, resetDefaultCategoryNameIcon, resetDefaultCategoryKeywords, defaultCategoryOverrides, language, customCategories } = useAppStore();
 
+  const { toast } = useDialog();
+
   const originalDefaultCategories = getAllCategories([], language, [], {});
   const isDefaultCategoryModified = category && !category.isCustom && category.id in defaultCategoryOverrides;
   const originalCategory = category && !category.isCustom ? originalDefaultCategories.find(c => c.id === category.id) : null;
@@ -838,7 +841,7 @@ export const CategoryEditModal: React.FC<CategoryEditModalProps> = ({
 
   const handleSave = () => {
     if (!formData.name.trim()) {
-      alert(language === 'zh' ? '请输入分类名称' : 'Please enter category name');
+      toast(language === 'zh' ? '请输入分类名称' : 'Please enter category name', 'error');
       return;
     }
 

--- a/src/components/CategorySidebar.tsx
+++ b/src/components/CategorySidebar.tsx
@@ -388,16 +388,16 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
         </div>
       ) : (
         /* 桌面端：可折叠侧栏 - sticky定位，滚动时保持可见 */
-        <div className="relative flex shrink-0 lg:sticky lg:top-24 lg:self-start">
+        <div className="relative flex shrink-0 lg:sticky lg:top-24 lg:self-start z-10">
           {/* 侧栏容器 */}
           <div
-            className={`relative bg-white dark:bg-panel-dark rounded-xl border border-black/[0.06] dark:border-white/[0.04] overflow-hidden transition-all duration-250 ease-out ${
+            className={`relative bg-white dark:bg-panel-dark rounded-xl border border-black/[0.06] dark:border-white/[0.04] overflow-visible transition-all duration-250 ease-out ${
               isSidebarCollapsed
                 ? 'w-14 p-2'
                 : 'w-64 p-4'
             }`}
             style={{
-              maxHeight: isSidebarCollapsed ? 'auto' : 'calc(100vh - 8rem)',
+              maxHeight: isSidebarCollapsed ? 'calc(100vh - 8rem)' : 'calc(100vh - 8rem)',
               transitionProperty: 'width, padding, max-height',
             }}
           >
@@ -609,7 +609,7 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
                                   e.stopPropagation();
                                   void handleHideDefaultCategory(category);
                                 }}
-                                className="p-1 rounded-md text-gray-500hover:bg-gray-200 dark:text-text-tertiary dark:hover:bg-white/10"
+                                className="p-1 rounded-md text-gray-500 hover:bg-gray-200 dark:text-text-tertiary dark:hover:bg-white/10"
                                 title={t('隐藏默认分类', 'Hide default category')}
                                 aria-label={t('隐藏默认分类', 'Hide default category')}
                               >

--- a/src/components/CategorySidebar.tsx
+++ b/src/components/CategorySidebar.tsx
@@ -12,6 +12,7 @@ import { useAppStore, getAllCategories, sortCategoriesByOrder } from '../store/u
 import { CategoryEditModal } from './CategoryEditModal';
 import { forceSyncToBackend } from '../services/autoSync';
 import { getAICategory, getDefaultCategory, computeCustomCategory, matchesCategory } from '../utils/categoryUtils';
+import { useDialog } from '../hooks/useDialog';
 
 interface CategorySidebarProps {
   repositories: Repository[];
@@ -38,6 +39,8 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
     isSidebarCollapsed,
     setSidebarCollapsed,
   } = useAppStore();
+
+  const { toast, confirm } = useDialog();
 
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [editingCategory, setEditingCategory] = useState<Category | null>(null);
@@ -195,11 +198,13 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
   };
 
   const handleDeleteCategory = async (category: Category) => {
-    const confirmed = confirm(
+    const confirmed = await confirm(
+      t('删除分类确认', 'Delete Category Confirmation'),
       t(
         `确定删除自定义分类"${category.name}"吗？\n\n仓库会保留，Star 不会取消，只会清空它们的手动分类归属。`,
         `Delete custom category "${category.name}"?\n\nRepositories will stay starred. Only their manual category assignment will be cleared.`
-      )
+      ),
+      { type: 'danger', confirmText: t('删除', 'Delete') }
     );
 
     if (!confirmed) return;
@@ -208,17 +213,18 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
     try {
       await forceSyncToBackend();
     } catch {
-      // Revert local change on failure
-      alert(t('删除分类失败，请检查后端连接。', 'Failed to delete category. Please check backend connection.'));
+      toast(t('删除分类失败，请检查后端连接。', 'Failed to delete category. Please check backend connection.'), 'error');
     }
   };
 
   const handleHideDefaultCategory = async (category: Category) => {
-    const confirmed = confirm(
+    const confirmed = await confirm(
+      t('隐藏分类确认', 'Hide Category Confirmation'),
       t(
         `隐藏默认分类"${category.name}"？\n\n这不会删除任何仓库，只是在左侧隐藏这个预设分类。`,
         `Hide default category "${category.name}"?\n\nThis will not delete any repositories. It only hides this built-in category from the sidebar.`
-      )
+      ),
+      { type: 'warning' }
     );
 
     if (!confirmed) return;
@@ -227,9 +233,8 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
     try {
       await forceSyncToBackend();
     } catch {
-      // Revert local change on failure - 回滚时调用 showDefaultCategory 恢复显示
       showDefaultCategory(category.id);
-      alert(t('隐藏分类失败，请检查后端连接。', 'Failed to hide category. Please check backend connection.'));
+      toast(t('隐藏分类失败，请检查后端连接。', 'Failed to hide category. Please check backend connection.'), 'error');
     }
   };
 
@@ -242,10 +247,11 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
   const handleSyncError = (originalRepo: Repository) => {
     updateRepository(originalRepo);
     setDragOverCategoryId(null);
-    alert(
+    toast(
       language === 'zh'
         ? `同步到后端失败，已恢复分类更改。`
-        : `Failed to sync to backend. Category change has been reverted.`
+        : `Failed to sync to backend. Category change has been reverted.`,
+      'error'
     );
   };
 

--- a/src/components/DiscoveryView.tsx
+++ b/src/components/DiscoveryView.tsx
@@ -245,8 +245,9 @@ const PlatformFilter: React.FC<PlatformFilterProps> = ({ platform, onPlatformCha
       }
     };
 
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
+    // Use mouseup instead of mousedown to avoid interfering with native select dropdowns
+    document.addEventListener('mouseup', handleClickOutside);
+    return () => document.removeEventListener('mouseup', handleClickOutside);
   }, []);
 
   const selectedPlatform = platforms.find(p => p.id === platform);

--- a/src/components/DiscoveryView.tsx
+++ b/src/components/DiscoveryView.tsx
@@ -413,7 +413,7 @@ export const DiscoveryView: React.FC = React.memo(() => {
     setTrendingTimeRange,
   } = useAppStore();
 
-  const { toast, confirm } = useDialog();
+  const { toast } = useDialog();
 
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [analysisOptimizer, setAnalysisOptimizer] = useState<AIAnalysisOptimizer | null>(null);
@@ -785,7 +785,7 @@ export const DiscoveryView: React.FC = React.memo(() => {
           `AI分析完成！成功 ${successCount} 个${failCount > 0 ? `，失败 ${failCount} 个` : ''}`,
           `AI analysis complete! ${successCount} succeeded${failCount > 0 ? `, ${failCount} failed` : ''}`
         ),
-        failCount > 0 ? 'error' : 'success'
+        successCount === 0 ? 'error' : failCount > 0 ? 'info' : 'success'
       );
     } catch (err) {
       console.error('AI analysis error:', err);

--- a/src/components/DiscoveryView.tsx
+++ b/src/components/DiscoveryView.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useCallback, useMemo, useRef, useEffect } from 'react';
-import { 
-  RefreshCw, 
-  TrendingUp, 
-  Bot, 
-  Loader2, 
-  Rocket, 
-  Tag, 
+import {
+  RefreshCw,
+  TrendingUp,
+  Bot,
+  Loader2,
+  Rocket,
+  Tag,
   Search,
   Crown,
   Filter,
@@ -28,11 +28,12 @@ import { DiscoverySidebar } from './DiscoverySidebar';
 import { SubscriptionRepoCard } from './SubscriptionRepoCard';
 import { SortAlgorithmTooltip } from './SortAlgorithmTooltip';
 import { ScrollToBottom } from './ScrollToBottom';
-import type { 
-  DiscoveryChannelId, 
+import { useDialog } from '../hooks/useDialog';
+import type {
+  DiscoveryChannelId,
   DiscoveryChannelIcon,
-  DiscoveryRepo, 
-  DiscoveryPlatform, 
+  DiscoveryRepo,
+  DiscoveryPlatform,
   ProgrammingLanguage,
   SortBy,
   SortOrder,
@@ -412,6 +413,8 @@ export const DiscoveryView: React.FC = React.memo(() => {
     setTrendingTimeRange,
   } = useAppStore();
 
+  const { toast, confirm } = useDialog();
+
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [analysisOptimizer, setAnalysisOptimizer] = useState<AIAnalysisOptimizer | null>(null);
   const [, setAnalysisState] = useState<{ paused: boolean; aborted: boolean }>({ paused: false, aborted: false });
@@ -460,7 +463,7 @@ export const DiscoveryView: React.FC = React.memo(() => {
 
   const refreshChannel = useCallback(async (channelId: DiscoveryChannelId, page: number = 1, append: boolean = false) => {
     if (!githubToken) {
-      alert(t('GitHub Token 未找到，请重新登录。', 'GitHub token not found. Please login again.'));
+      toast(t('GitHub Token 未找到，请重新登录。', 'GitHub token not found. Please login again.'), 'error');
       return;
     }
 
@@ -566,7 +569,7 @@ export const DiscoveryView: React.FC = React.memo(() => {
       if (append) {
         setDiscoveryLoadMoreError(channelId, t('加载更多失败，请重试', 'Failed to load more, please retry'));
       } else {
-        alert(t('获取数据失败，请检查网络连接或GitHub Token。', 'Failed to fetch data. Please check your network connection or GitHub Token.'));
+        toast(t('获取数据失败，请检查网络连接或GitHub Token。', 'Failed to fetch data. Please check your network connection or GitHub Token.'), 'error');
       }
     } finally {
       if (append) {
@@ -660,33 +663,33 @@ export const DiscoveryView: React.FC = React.memo(() => {
 
     const activeConfig = aiConfigs.find(c => c.id === activeAIConfig);
     if (!activeConfig) {
-      alert(t('请先在设置中配置AI服务。', 'Please configure AI service in settings first.'));
+      toast(t('请先在设置中配置AI服务。', 'Please configure AI service in settings first.'), 'error');
       return;
     }
 
     if (activeConfig.apiKeyStatus === 'decrypt_failed' || activeConfig.apiKeyStatus === 'empty') {
-      alert(t('AI服务的API密钥无法解密或为空，请在设置中重新输入并保存该配置。', 'The AI service API key could not be decrypted or is empty. Please re-enter and save the configuration in settings.'));
+      toast(t('AI服务的API密钥无法解密或为空，请在设置中重新输入并保存该配置。', 'The AI service API key could not be decrypted or is empty. Please re-enter and save the configuration in settings.'), 'error');
       return;
     }
 
     if (!activeConfig.baseUrl || !activeConfig.apiKey || !activeConfig.model) {
-      alert(t('AI服务配置不完整，请检查API端点、密钥和模型名称。', 'AI service configuration is incomplete. Please check the API endpoint, key, and model name.'));
+      toast(t('AI服务配置不完整，请检查API端点、密钥和模型名称。', 'AI service configuration is incomplete. Please check the API endpoint, key, and model name.'), 'error');
       return;
     }
 
     const pageRepos = allRepos;
-    
+
     if (pageRepos.length === 0) {
-      alert(t('当前没有项目。', 'No projects available.'));
+      toast(t('当前没有项目。', 'No projects available.'), 'error');
       return;
     }
 
     const unanalyzed = pageRepos.filter(
       (r: DiscoveryRepo) => !r.analyzed_at || r.analysis_failed
     );
-    
+
     if (unanalyzed.length === 0) {
-      alert(t('已加载的所有项目均已完成AI分析。', 'All loaded projects have been analyzed.'));
+      toast(t('已加载的所有项目均已完成AI分析。', 'All loaded projects have been analyzed.'), 'info');
       return;
     }
 
@@ -777,15 +780,16 @@ export const DiscoveryView: React.FC = React.memo(() => {
 
       const successCount = results.filter(r => r.success).length;
       const failCount = results.filter(r => !r.success).length;
-      alert(
+      toast(
         t(
           `AI分析完成！成功 ${successCount} 个${failCount > 0 ? `，失败 ${failCount} 个` : ''}`,
           `AI analysis complete! ${successCount} succeeded${failCount > 0 ? `, ${failCount} failed` : ''}`
-        )
+        ),
+        failCount > 0 ? 'error' : 'success'
       );
     } catch (err) {
       console.error('AI analysis error:', err);
-      alert(t('AI分析失败，请检查AI配置。', 'AI analysis failed. Please check your AI configuration.'));
+      toast(t('AI分析失败，请检查AI配置。', 'AI analysis failed. Please check your AI configuration.'), 'error');
     } finally {
       setIsAnalyzing(false);
       setAnalysisOptimizer(null);

--- a/src/components/DiscoveryView.tsx
+++ b/src/components/DiscoveryView.tsx
@@ -245,9 +245,8 @@ const PlatformFilter: React.FC<PlatformFilterProps> = ({ platform, onPlatformCha
       }
     };
 
-    // Use mouseup instead of mousedown to avoid interfering with native select dropdowns
-    document.addEventListener('mouseup', handleClickOutside);
-    return () => document.removeEventListener('mouseup', handleClickOutside);
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
   const selectedPlatform = platforms.find(p => p.id === platform);
@@ -280,6 +279,81 @@ const PlatformFilter: React.FC<PlatformFilterProps> = ({ platform, onPlatformCha
             >
               {p.icon}
               {language === 'zh' ? p.name : p.nameEn}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface CustomSelectOption {
+  value: string;
+  label: string;
+  icon?: React.ReactNode;
+}
+
+interface CustomSelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: CustomSelectOption[];
+  className?: string;
+  dropdownClassName?: string;
+}
+
+const CustomSelect: React.FC<CustomSelectProps> = ({
+  value,
+  onChange,
+  options,
+  className = '',
+  dropdownClassName = '',
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const selectedOption = options.find(o => o.value === value);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className={`flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium bg-white dark:bg-white/[0.04] border border-black/[0.06] dark:border-white/[0.04] text-gray-900 dark:text-text-secondary hover:bg-gray-100 dark:hover:bg-white/[0.08] transition-colors ${className}`}
+      >
+        {selectedOption?.icon && <span className="w-4 h-4">{selectedOption.icon}</span>}
+        <span>{selectedOption?.label}</span>
+        <ChevronDown className={`w-4 h-4 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+      </button>
+
+      {isOpen && (
+        <div className={`absolute left-0 sm:left-auto sm:right-0 mt-2 w-48 sm:w-48 bg-white dark:bg-panel-dark rounded-xl border border-black/[0.06] dark:border-white/[0.04] shadow-lg py-1 z-50 max-w-[calc(100vw-2rem)] ${dropdownClassName}`}>
+          {options.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => {
+                onChange(option.value);
+                setIsOpen(false);
+              }}
+              className={`flex w-full items-center gap-2 px-4 py-2 text-sm transition-colors ${
+                value === option.value
+                  ? 'bg-brand-indigo/15 text-brand-indigo dark:bg-brand-indigo/20 dark:text-white'
+                  : 'text-gray-900 dark:text-text-secondary hover:bg-light-bg dark:hover:bg-white/10'
+              }`}
+            >
+              {option.icon && <span className="w-4 h-4">{option.icon}</span>}
+              {option.label}
             </button>
           ))}
         </div>
@@ -1096,36 +1170,24 @@ export const DiscoveryView: React.FC = React.memo(() => {
                     <option value="PHP">PHP</option>
                   </select>
                   
-                  <select
+                  <CustomSelect
                     value={discoverySortBy}
-                    onChange={(e) => setDiscoverySortBy(e.target.value as SortBy)}
-                    className="px-3 py-1.5 text-sm font-medium rounded-lg border border-black/[0.06] text-gray-900 shadow-sm bg-white dark:bg-white/[0.04] dark:border-white/[0.04] dark:text-text-primary focus:ring-2 focus:ring-brand-violet focus:border-transparent transition-colors"
-                  >
-                    <option value="BestMatch">{t('最佳匹配', 'Best Match')}</option>
-                    <option value="MostStars">{t('最多Star', 'Most Stars')}</option>
-                    <option value="MostForks">{t('最多Fork', 'Most Forks')}</option>
-                  </select>
-                  
-                  <select
+                    onChange={(value) => setDiscoverySortBy(value as SortBy)}
+                    options={[
+                      { value: 'BestMatch', label: t('最佳匹配', 'Best Match') },
+                      { value: 'MostStars', label: t('最多Star', 'Most Stars') },
+                      { value: 'MostForks', label: t('最多Fork', 'Most Forks') },
+                    ]}
+                  />
+
+                  <CustomSelect
                     value={discoverySortOrder}
-                    onChange={(e) => setDiscoverySortOrder(e.target.value as SortOrder)}
-                    className="px-3 py-1.5 text-sm font-medium rounded-lg border border-black/[0.06] text-gray-900 shadow-sm bg-white dark:bg-white/[0.04] dark:border-white/[0.04] dark:text-text-primary focus:ring-2 focus:ring-brand-violet focus:border-transparent transition-colors"
-                  >
-                    <option value="Descending">{t('降序', 'Descending')}</option>
-                    <option value="Ascending">{t('升序', 'Ascending')}</option>
-                  </select>
-                  
-                  <select
-                    value={discoveryPlatform}
-                    onChange={(e) => setDiscoveryPlatform(e.target.value as DiscoveryPlatform)}
-                    className="px-3 py-1.5 text-sm font-medium rounded-lg border border-black/[0.06] text-gray-900 shadow-sm bg-white dark:bg-white/[0.04] dark:border-white/[0.04] dark:text-text-primary focus:ring-2 focus:ring-brand-violet focus:border-transparent transition-colors"
-                  >
-                    <option value="All">{t('所有平台', 'All Platforms')}</option>
-                    <option value="Android">Android</option>
-                    <option value="Macos">macOS</option>
-                    <option value="Windows">Windows</option>
-                    <option value="Linux">Linux</option>
-                  </select>
+                    onChange={(value) => setDiscoverySortOrder(value as SortOrder)}
+                    options={[
+                      { value: 'Descending', label: t('降序', 'Descending') },
+                      { value: 'Ascending', label: t('升序', 'Ascending') },
+                    ]}
+                  />
                 </div>
               </div>
             )}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { Settings, Calendar, Search, Moon, Sun, LogOut, RefreshCw, TrendingUp } from 'lucide-react';
 import { useAppStore } from '../store/useAppStore';
 import { GitHubApiService } from '../services/githubApi';
+import { useDialog } from '../hooks/useDialog';
 
 export const Header: React.FC = () => {
   const {
@@ -21,6 +22,8 @@ export const Header: React.FC = () => {
     logout,
     language,
   } = useAppStore();
+
+  const { toast, confirm } = useDialog();
 
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [isTextWrapped, setIsTextWrapped] = useState(false);
@@ -63,16 +66,16 @@ export const Header: React.FC = () => {
 
   const handleSync = async () => {
     if (!githubToken) {
-      alert('GitHub token not found. Please login again.');
+      toast('GitHub token not found. Please login again.', 'error');
       return;
     }
-    
+
     setLoading(true);
     try {
       const githubApi = new GitHubApiService(githubToken);
-       
+
       const newRepositories = await githubApi.getAllStarredRepositories();
-        
+
       const existingRepoMap = new Map(repositories.map(repo => [repo.id, repo]));
       const mergedRepositories = newRepositories.map(newRepo => {
         const existing = existingRepoMap.get(newRepo.id);
@@ -93,31 +96,31 @@ export const Header: React.FC = () => {
         }
         return newRepo;
       });
-      
+
       setRepositories(mergedRepositories);
-      
+
       // 3. 获取Release信息
       console.log('Fetching releases...');
       const releases = await githubApi.getMultipleRepositoryReleases(mergedRepositories.slice(0, 20));
       setReleases(releases);
-      
+
       setLastSync(new Date().toISOString());
       console.log('Sync completed successfully');
-      
+
       // 显示同步结果
       const newRepoCount = newRepositories.length - repositories.length;
       if (newRepoCount > 0) {
-        alert(`同步完成！发现 ${newRepoCount} 个新仓库。`);
+        toast(`同步完成！发现 ${newRepoCount} 个新仓库。`, 'success');
       } else {
-        alert('同步完成！所有仓库都是最新的。');
+        toast('同步完成！所有仓库都是最新的。', 'info');
       }
     } catch (error) {
       console.error('Sync failed:', error);
       if (error instanceof Error && error.message.includes('token')) {
-        alert('GitHub token 已过期或无效，请重新登录。');
+        toast('GitHub token 已过期或无效，请重新登录。', 'error');
         logout();
       } else {
-        alert('同步失败，请检查网络连接。');
+        toast('同步失败，请检查网络连接。', 'error');
       }
     } finally {
       setLoading(false);
@@ -397,11 +400,13 @@ export const Header: React.FC = () => {
                   </p>
                 </div>
                 <button
-                  onClick={() => {
-                    const confirmed = confirm(
+                  onClick={async () => {
+                    const confirmed = await confirm(
+                      t('确定要退出登录吗？', 'Logout Confirmation'),
                       language === 'zh'
-                        ? '确定要退出登录吗？\n\n退出后您的 AI 配置、WebDAV 设置、自定义分类等数据仍会保留。如需完全清除所有数据，请前往「设置 → 数据管理」。'
-                        : 'Are you sure you want to logout?\n\nYour AI configs, WebDAV settings, custom categories and other data will be preserved. To completely clear all data, please go to "Settings → Data Management".'
+                        ? '退出后您的 AI 配置、WebDAV 设置、自定义分类等数据仍会保留。如需完全清除所有数据，请前往「设置 → 数据管理」。'
+                        : 'Your AI configs, WebDAV settings, custom categories and other data will be preserved. To completely clear all data, please go to "Settings → Data Management".',
+                      { type: 'warning' }
                     );
                     if (confirmed) {
                       logout();

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -66,7 +66,7 @@ export const Header: React.FC = () => {
 
   const handleSync = async () => {
     if (!githubToken) {
-      toast('GitHub token not found. Please login again.', 'error');
+      toast(t('GitHub token 未找到，请重新登录。', 'GitHub token not found. Please login again.'), 'error');
       return;
     }
 
@@ -110,17 +110,17 @@ export const Header: React.FC = () => {
       // 显示同步结果
       const newRepoCount = newRepositories.length - repositories.length;
       if (newRepoCount > 0) {
-        toast(`同步完成！发现 ${newRepoCount} 个新仓库。`, 'success');
+        toast(t(`同步完成！发现 ${newRepoCount} 个新仓库。`, `Sync completed! Found ${newRepoCount} new repositories.`), 'success');
       } else {
-        toast('同步完成！所有仓库都是最新的。', 'info');
+        toast(t('同步完成！所有仓库都是最新的。', 'Sync completed! All repositories are up to date.'), 'info');
       }
     } catch (error) {
       console.error('Sync failed:', error);
       if (error instanceof Error && error.message.includes('token')) {
-        toast('GitHub token 已过期或无效，请重新登录。', 'error');
+        toast(t('GitHub token 已过期或无效，请重新登录。', 'GitHub token has expired or is invalid. Please login again.'), 'error');
         logout();
       } else {
-        toast('同步失败，请检查网络连接。', 'error');
+        toast(t('同步失败，请检查网络连接。', 'Sync failed. Please check your network connection.'), 'error');
       }
     } finally {
       setLoading(false);
@@ -402,7 +402,7 @@ export const Header: React.FC = () => {
                 <button
                   onClick={async () => {
                     const confirmed = await confirm(
-                      t('确定要退出登录吗？', 'Logout Confirmation'),
+                      t('退出登录确认', 'Logout Confirmation'),
                       language === 'zh'
                         ? '退出后您的 AI 配置、WebDAV 设置、自定义分类等数据仍会保留。如需完全清除所有数据，请前往「设置 → 数据管理」。'
                         : 'Your AI configs, WebDAV settings, custom categories and other data will be preserved. To completely clear all data, please go to "Settings → Data Management".',

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -8,6 +8,7 @@ import { formatDistanceToNow } from 'date-fns';
 import { AssetFilterManager } from './AssetFilterManager';
 import { PRESET_FILTERS } from '../constants/presetFilters';
 import ReleaseCard from './ReleaseCard';
+import { useDialog } from '../hooks/useDialog';
 
 export const ReleaseTimeline: React.FC = () => {
   const {
@@ -36,6 +37,8 @@ export const ReleaseTimeline: React.FC = () => {
     toggleReleaseExpandedRepository,
     setReleaseIsRefreshing,
   } = useAppStore();
+
+  const { toast, confirm } = useDialog();
 
   const [lastRefreshTime, setLastRefreshTime] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
@@ -291,7 +294,7 @@ export const ReleaseTimeline: React.FC = () => {
 
   const handleRefresh = async () => {
     if (!githubToken) {
-      alert(language === 'zh' ? 'GitHub token 未找到，请重新登录。' : 'GitHub token not found. Please login again.');
+      toast(language === 'zh' ? 'GitHub token 未找到，请重新登录。' : 'GitHub token not found. Please login again.', 'error');
       return;
     }
 
@@ -299,9 +302,9 @@ export const ReleaseTimeline: React.FC = () => {
     try {
       const githubApi = new GitHubApiService(githubToken);
       const subscribedRepos = repositories.filter(repo => releaseSubscriptions.has(repo.id));
-      
+
       if (subscribedRepos.length === 0) {
-        alert(language === 'zh' ? '没有订阅的仓库。' : 'No subscribed repositories.');
+        toast(language === 'zh' ? '没有订阅的仓库。' : 'No subscribed repositories.', 'error');
         return;
       }
 
@@ -346,14 +349,14 @@ export const ReleaseTimeline: React.FC = () => {
       const message = language === 'zh'
         ? `刷新完成！发现 ${actuallyNewCount} 个新Release。`
         : `Refresh completed! Found ${actuallyNewCount} new releases.`;
-      
-      alert(message);
+
+      toast(message, 'success');
     } catch (error) {
       console.error('Refresh failed:', error);
       const errorMessage = language === 'zh'
         ? 'Release刷新失败，请检查网络连接。'
         : 'Release refresh failed. Please check your network connection.';
-      alert(errorMessage);
+      toast(errorMessage, 'error');
     } finally {
       setReleaseIsRefreshing(false);
     }
@@ -465,7 +468,7 @@ export const ReleaseTimeline: React.FC = () => {
   const handleUnsubscribeRelease = async (repoId: number) => {
     const repo = repositories.find((item) => item.id === repoId);
     if (!repo) {
-      alert(t('仓库信息不完整，无法取消订阅。', 'Repository information missing. Cannot unsubscribe.'));
+      toast(t('仓库信息不完整，无法取消订阅。', 'Repository information missing. Cannot unsubscribe.'), 'error');
       return;
     }
 
@@ -473,7 +476,12 @@ export const ReleaseTimeline: React.FC = () => {
       ? `确定取消订阅 "${repo.full_name}" 的 Release 吗？`
       : `Unsubscribe from releases for "${repo.full_name}"?`;
 
-    if (!confirm(confirmMessage)) {
+    const confirmed = await confirm(
+      t('取消订阅确认', 'Unsubscribe Confirmation'),
+      confirmMessage,
+      { type: 'warning' }
+    );
+    if (!confirmed) {
       return;
     }
 
@@ -496,11 +504,11 @@ export const ReleaseTimeline: React.FC = () => {
         releases: [...state.releases, ...removedReleases],
         readReleases: new Set([...state.readReleases, ...removedReadIds]),
       });
-      alert(t('取消订阅失败，请检查后端连接。', 'Failed to unsubscribe. Please check backend connection.'));
+      toast(t('取消订阅失败，请检查后端连接。', 'Failed to unsubscribe. Please check backend connection.'), 'error');
       return;
     }
 
-    alert(t('已取消订阅该仓库的 Release。', 'Unsubscribed from repository releases.'));
+    toast(t('已取消订阅该仓库的 Release。', 'Unsubscribed from repository releases.'), 'success');
   };
 
   if (subscribedReleases.length === 0) {

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -272,7 +272,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
 
   const handleAIAnalyze = async () => {
     if (!githubToken) {
-      toast(t('GitHub token not found. Please login again.', 'GitHub token not found. Please login again.'), 'error');
+      toast(t('GitHub token 未找到，请重新登录。', 'GitHub token not found. Please login again.'), 'error');
       return;
     }
 
@@ -574,6 +574,15 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
   const handleDragStart = (event: React.DragEvent<HTMLDivElement>) => {
     event.dataTransfer.setData('application/x-gsm-repository-id', String(repository.id));
     event.dataTransfer.effectAllowed = 'move';
+
+    // 设置拖拽图片为整个卡片
+    const cardElement = event.currentTarget.closest('.repository-card') as HTMLElement;
+    if (cardElement) {
+      const rect = cardElement.getBoundingClientRect();
+      // offsetX/Y 使拖拽图片中心对准鼠标位置
+      event.dataTransfer.setDragImage(cardElement, event.clientX - rect.left, event.clientY - rect.top);
+    }
+
     event.stopPropagation();
     isDraggingRef.current = true;
     // 标记正在拖拽，防止触发卡片点击
@@ -880,7 +889,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
 
           {/* Tooltip - Only show when text is actually truncated */}
           {isTextTruncated && showTooltip && (
-            <div className="absolute z-50 bottom-full left-0 right-0 mb-2 p-3 bg-gray-900 dark:bg-surface-3 text-white dark:text-text-primary text-sm rounded-lg shadow-dialog border border-black/[0.06] dark:border-white/[0.04] max-h-48 overflow-y-auto">
+            <div className="absolute z-50 bottom-full left-0 right-0 mb-2 p-3 bg-gray-900 dark:bg-surface-3 text-white dark:text-text-primary text-sm rounded-lg shadow-dialog border border-black/[0.06] dark:border-white/[0.04]">
               <div className="whitespace-pre-wrap break-words">
                 {highlightSearchTerm(displayContent.content, searchQuery)}
               </div>

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -11,6 +11,7 @@ import { formatDistanceToNow } from 'date-fns';
 import { RepositoryEditModal } from './RepositoryEditModal';
 import { ReadmeModal } from './ReadmeModal';
 import { shallow } from 'zustand/shallow';
+import { useDialog } from '../hooks/useDialog';
 
 // Selection-aware button component to centralize selectionMode disable logic
 interface SelectionAwareButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
@@ -128,6 +129,8 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
   }, [repoId, setAnalyzingRepository]);
 
   const aiConfigs = useAppStore(state => state.aiConfigs);
+
+  const { toast, confirm } = useDialog();
 
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [readmeModalOpen, setReadmeModalOpen] = useState(false);
@@ -269,23 +272,23 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
 
   const handleAIAnalyze = async () => {
     if (!githubToken) {
-      alert('GitHub token not found. Please login again.');
+      toast(t('GitHub token not found. Please login again.', 'GitHub token not found. Please login again.'), 'error');
       return;
     }
 
     const activeConfig = aiConfigs.find(config => config.id === activeAIConfig);
     if (!activeConfig) {
-      alert(language === 'zh' ? '请先在设置中配置AI服务。' : 'Please configure AI service in settings first.');
+      toast(t('请先在设置中配置AI服务。', 'Please configure AI service in settings first.'), 'error');
       return;
     }
 
     if (activeConfig.apiKeyStatus === 'decrypt_failed' || activeConfig.apiKeyStatus === 'empty') {
-      alert(language === 'zh' ? 'AI服务的API密钥无法解密或为空，请在设置中重新输入并保存该配置。' : 'The AI service API key could not be decrypted or is empty. Please re-enter and save the configuration in settings.');
+      toast(t('AI服务的API密钥无法解密或为空，请在设置中重新输入并保存该配置。', 'The AI service API key could not be decrypted or is empty. Please re-enter and save the configuration in settings.'), 'error');
       return;
     }
 
     if (!activeConfig.baseUrl || !activeConfig.apiKey || !activeConfig.model) {
-      alert(language === 'zh' ? 'AI服务配置不完整，请检查API端点、密钥和模型名称。' : 'AI service configuration is incomplete. Please check the API endpoint, key, and model name.');
+      toast(t('AI服务配置不完整，请检查API端点、密钥和模型名称。', 'AI service configuration is incomplete. Please check the API endpoint, key, and model name.'), 'error');
       return;
     }
 
@@ -294,7 +297,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
         ? `此仓库已于 ${new Date(repository.analyzed_at).toLocaleString()} 进行过AI分析。\n\n是否要重新分析？这将覆盖现有的分析结果。`
         : `This repository was analyzed on ${new Date(repository.analyzed_at).toLocaleString()}.\n\nDo you want to re-analyze? This will overwrite the existing analysis results.`;
 
-      if (!confirm(confirmMessage)) {
+      if (!await confirm(t('重新分析确认', 'Re-analyze Confirmation'), confirmMessage, { type: 'warning' })) {
         return;
       }
     }
@@ -333,7 +336,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
         ? (language === 'zh' ? 'AI重新分析完成！' : 'AI re-analysis completed!')
         : (language === 'zh' ? 'AI分析完成！' : 'AI analysis completed!');
 
-      alert(successMessage);
+      toast(successMessage, 'success');
     } catch (error) {
       if (!controller.signal.aborted) {
         console.error('AI analysis failed:', error);
@@ -347,7 +350,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
 
         updateRepository(failedRepo);
 
-        alert(language === 'zh' ? 'AI分析失败，请检查AI配置和网络连接。' : 'AI analysis failed. Please check AI configuration and network connection.');
+        toast(language === 'zh' ? 'AI分析失败，请检查AI配置和网络连接。' : 'AI analysis failed. Please check AI configuration and network connection.', 'error');
       }
     } finally {
       if (!controller.signal.aborted) {
@@ -528,7 +531,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
 
   const handleUnstar = async () => {
     if (!githubToken) {
-      alert(t('未找到 GitHub Token，请重新登录。', 'GitHub token not found. Please login again.'));
+      toast(t('未找到 GitHub Token，请重新登录。', 'GitHub token not found. Please login again.'), 'error');
       return;
     }
 
@@ -536,7 +539,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
       ? `确定要取消 Star "${repository.full_name}" 吗？\n\n这将会从您的 GitHub 收藏中移除该仓库。`
       : `Are you sure you want to unstar "${repository.full_name}"?\n\nThis will remove the repository from your GitHub stars.`;
 
-    if (!confirm(confirmMessage)) {
+    if (!await confirm(t('取消Star确认', 'Unstar Confirmation'), confirmMessage, { type: 'danger', confirmText: t('取消Star', 'Unstar') })) {
       return;
     }
 
@@ -550,13 +553,13 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
       const successMessage = language === 'zh'
         ? '已成功取消 Star'
         : 'Successfully unstarred';
-      alert(successMessage);
+      toast(successMessage, 'success');
     } catch (error) {
       console.error('Failed to unstar repository:', error);
       const errorMessage = language === 'zh'
         ? '取消 Star 失败，请检查网络连接或重新登录。'
         : 'Failed to unstar repository. Please check your network connection or login again.';
-      alert(errorMessage);
+      toast(errorMessage, 'error');
     } finally {
       setUnstarring(false);
     }

--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -298,11 +298,11 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
 
     if (targetRepos.length === 0) {
       const message = analyzeFailedOnly
-        ? (language === 'zh' ? '没有分析失败的仓库！' : 'No failed repositories to re-analyze!')
+        ? t('没有分析失败的仓库！', 'No failed repositories to re-analyze!')
         : analyzeUnanalyzedOnly
-          ? (language === 'zh' ? '所有仓库都已经分析过了！' : 'All repositories have been analyzed!')
-          : (language === 'zh' ? '没有可分析的仓库！' : 'No repositories to analyze!');
-      toast(message, 'error');
+          ? t('所有仓库都已经分析过了！', 'All repositories have been analyzed!')
+          : t('没有可分析的仓库！', 'No repositories to analyze!');
+      toast(message, 'info');
       return;
     }
 
@@ -797,11 +797,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
           const subscribedRepos = repos.filter(repo => releaseSubscriptions.has(repo.id));
 
           if (subscribedRepos.length === 0) {
-            toast(language === 'zh'
-              ? '选中的仓库中没有被订阅的'
-              : 'None of the selected repositories are subscribed',
-              'error'
-            );
+            toast(t('选中的仓库中没有被订阅的', 'None of the selected repositories are subscribed'), 'info');
             return;
           }
 

--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -12,15 +12,16 @@ import { AIService } from '../services/aiService';
 import { AIAnalysisOptimizer, AnalysisResult } from '../services/aiAnalysisOptimizer';
 import { resolveCategoryAssignment, getAICategory, getDefaultCategory, computeCustomCategory } from '../utils/categoryUtils';
 import { forceSyncToBackend } from '../services/autoSync';
+import { useDialog } from '../hooks/useDialog';
 
 interface RepositoryListProps {
   repositories: Repository[];
   selectedCategory: string;
 }
 
-export const RepositoryList: React.FC<RepositoryListProps> = ({ 
-  repositories, 
-  selectedCategory 
+export const RepositoryList: React.FC<RepositoryListProps> = ({
+  repositories,
+  selectedCategory
 }) => {
   const {
     githubToken,
@@ -41,6 +42,8 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
     batchUnsubscribeReleases,
     releaseSubscriptions
   } = useAppStore();
+
+  const { toast, confirm } = useDialog();
 
   const [showAISummary, setShowAISummary] = useState(true);
   const [showDropdown, setShowDropdown] = useState(false);
@@ -267,23 +270,23 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
 
   const handleAIAnalyze = async (analyzeUnanalyzedOnly: boolean = false, analyzeFailedOnly: boolean = false) => {
     if (!githubToken) {
-      alert(language === 'zh' ? 'GitHub token 未找到，请重新登录。' : 'GitHub token not found. Please login again.');
+      toast(language === 'zh' ? 'GitHub token 未找到，请重新登录。' : 'GitHub token not found. Please login again.', 'error');
       return;
     }
 
     const activeConfig = aiConfigs.find(config => config.id === activeAIConfig);
     if (!activeConfig) {
-      alert(language === 'zh' ? '请先在设置中配置AI服务。' : 'Please configure AI service in settings first.');
+      toast(language === 'zh' ? '请先在设置中配置AI服务。' : 'Please configure AI service in settings first.', 'error');
       return;
     }
 
     if (activeConfig.apiKeyStatus === 'decrypt_failed' || activeConfig.apiKeyStatus === 'empty') {
-      alert(language === 'zh' ? 'AI服务的API密钥无法解密或为空，请在设置中重新输入并保存该配置。' : 'The AI service API key could not be decrypted or is empty. Please re-enter and save the configuration in settings.');
+      toast(language === 'zh' ? 'AI服务的API密钥无法解密或为空，请在设置中重新输入并保存该配置。' : 'The AI service API key could not be decrypted or is empty. Please re-enter and save the configuration in settings.', 'error');
       return;
     }
 
     if (!activeConfig.baseUrl || !activeConfig.apiKey || !activeConfig.model) {
-      alert(language === 'zh' ? 'AI服务配置不完整，请检查API端点、密钥和模型名称。' : 'AI service configuration is incomplete. Please check the API endpoint, key, and model name.');
+      toast(language === 'zh' ? 'AI服务配置不完整，请检查API端点、密钥和模型名称。' : 'AI service configuration is incomplete. Please check the API endpoint, key, and model name.', 'error');
       return;
     }
 
@@ -299,21 +302,25 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
         : analyzeUnanalyzedOnly
           ? (language === 'zh' ? '所有仓库都已经分析过了！' : 'All repositories have been analyzed!')
           : (language === 'zh' ? '没有可分析的仓库！' : 'No repositories to analyze!');
-      alert(message);
+      toast(message, 'error');
       return;
     }
 
     const actionText = analyzeFailedOnly
       ? (language === 'zh' ? '失败' : 'failed')
-      : analyzeUnanalyzedOnly 
+      : analyzeUnanalyzedOnly
         ? (language === 'zh' ? '未分析' : 'unanalyzed')
         : (language === 'zh' ? '全部' : 'all');
-    
+
     const confirmMessage = language === 'zh'
       ? `将对 ${targetRepos.length} 个${actionText}仓库进行AI分析，这可能需要几分钟时间。是否继续？`
       : `Will analyze ${targetRepos.length} ${actionText} repositories with AI. This may take several minutes. Continue?`;
-    
-    const confirmed = confirm(confirmMessage);
+
+    const confirmed = await confirm(
+      t('AI分析确认', 'AI Analysis Confirmation'),
+      confirmMessage,
+      { type: 'warning' }
+    );
     if (!confirmed) return;
 
     // 重置状态
@@ -400,13 +407,13 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
             ? `AI分析完成！成功: ${successCount}, 失败: ${failedCount} (平均响应: ${stats.averageResponseTime}ms)`
             : `AI analysis completed! Success: ${successCount}, Failed: ${failedCount} (avg: ${stats.averageResponseTime}ms)`);
 
-      alert(completionMessage);
+      toast(completionMessage, 'success');
     } catch (error) {
       console.error('AI analysis failed:', error);
       const errorMessage = language === 'zh'
         ? 'AI分析失败，请检查AI配置和网络连接。'
         : 'AI analysis failed. Please check AI configuration and network connection.';
-      alert(errorMessage);
+      toast(errorMessage, 'error');
     } finally {
       // 清理状态
       optimizerRef.current = null;
@@ -435,14 +442,19 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
     }
   };
 
-  const handleStop = () => {
+  const handleStop = async () => {
     if (!isAnalyzingRef.current) return;
 
     const confirmMessage = language === 'zh'
       ? '确定要停止 AI 分析吗？已分析的结果将会保存。'
       : 'Are you sure you want to stop AI analysis? Analyzed results will be saved.';
 
-    if (confirm(confirmMessage)) {
+    const confirmed = await confirm(
+      t('停止AI分析', 'Stop AI Analysis'),
+      confirmMessage,
+      { type: 'warning' }
+    );
+    if (confirmed) {
       shouldStopRef.current = true;
       // 中止优化器
       if (optimizerRef.current) {
@@ -561,11 +573,12 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
         : `\n\nFailed (${failedRepos.length}):\n${failedRepos.join('\n')}`)
       : '';
 
-    alert(language === 'zh'
+    toast(language === 'zh'
       ? `成功还原 ${successCount} 个仓库${skipMsg}`
-      : `Successfully restored ${successCount} repositories${skipMsg}`
+      : `Successfully restored ${successCount} repositories${skipMsg}`,
+      failedRepos.length > 0 ? 'error' : 'success'
     );
-  }, [repositories, selectedRepoIds, updateRepository, language]);
+  }, [repositories, selectedRepoIds, updateRepository, language, toast]);
 
   // 处理单击空白处 - 触发回到顶部按钮跳跃动画
   const handleClick = useCallback((e: React.MouseEvent) => {
@@ -589,7 +602,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
       switch (action) {
         case 'unstar': {
           if (!githubToken) {
-            alert(language === 'zh' ? 'GitHub token 未找到，请重新登录。' : 'GitHub token not found. Please login again.');
+            toast(language === 'zh' ? 'GitHub token 未找到，请重新登录。' : 'GitHub token not found. Please login again.', 'error');
             return;
           }
 
@@ -597,7 +610,12 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
             ? `确定要取消 ${repos.length} 个仓库的 Star 吗？此操作不可撤销！`
             : `Are you sure you want to unstar ${repos.length} repositories? This action cannot be undone!`;
 
-          if (!confirm(confirmMessage)) return;
+          const confirmed = await confirm(
+            t('取消Star确认', 'Unstar Confirmation'),
+            confirmMessage,
+            { type: 'danger', confirmText: t('取消Star', 'Unstar') }
+          );
+          if (!confirmed) return;
 
           const githubApi = new GitHubApiService(githubToken);
           const successIds: number[] = [];
@@ -618,9 +636,10 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
           }
 
           await forceSyncToBackend();
-          alert(language === 'zh'
+          toast(language === 'zh'
             ? `成功取消 ${successIds.length} 个仓库的 Star`
-            : `Successfully unstarred ${successIds.length} repositories`
+            : `Successfully unstarred ${successIds.length} repositories`,
+            'success'
           );
           break;
         }
@@ -637,7 +656,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
 
         case 'ai-summary': {
           if (!githubToken) {
-            alert(language === 'zh' ? 'GitHub token 未找到，请重新登录。' : 'GitHub token not found. Please login again.');
+            toast(language === 'zh' ? 'GitHub token 未找到，请重新登录。' : 'GitHub token not found. Please login again.', 'error');
             return;
           }
 
@@ -645,11 +664,11 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
             ? `将对 ${repos.length} 个仓库进行 AI 分析，这可能需要几分钟时间。是否继续？`
             : `Will analyze ${repos.length} repositories with AI. This may take several minutes. Continue?`;
 
-          if (!confirm(confirmMessage)) return;
+          if (!await confirm(t('AI分析确认', 'AI Analysis Confirmation'), confirmMessage, { type: 'warning' })) return;
 
           const activeConfig = aiConfigs.find(config => config.id === activeAIConfig);
           if (!activeConfig) {
-            alert(language === 'zh' ? '请先在设置中配置 AI 服务。' : 'Please configure AI service in settings first.');
+            toast(language === 'zh' ? '请先在设置中配置 AI 服务。' : 'Please configure AI service in settings first.', 'error');
             return;
           }
 
@@ -728,13 +747,14 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
             console.log('Bulk AI Analysis Stats:', stats);
 
             await forceSyncToBackend();
-            alert(language === 'zh'
+            toast(language === 'zh'
               ? `成功分析 ${successCount} 个仓库，失败 ${failedCount} 个 (平均响应: ${stats.averageResponseTime}ms)`
-              : `Successfully analyzed ${successCount} repositories, ${failedCount} failed (avg: ${stats.averageResponseTime}ms)`
+              : `Successfully analyzed ${successCount} repositories, ${failedCount} failed (avg: ${stats.averageResponseTime}ms)`,
+              failedCount > 0 ? 'error' : 'success'
             );
           } catch (error) {
             console.error('Bulk AI analysis failed:', error);
-            alert(language === 'zh' ? '批量AI分析失败' : 'Bulk AI analysis failed');
+            toast(language === 'zh' ? '批量AI分析失败' : 'Bulk AI analysis failed', 'error');
           } finally {
             // 确保状态重置
             optimizerRef.current = null;
@@ -765,20 +785,22 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
           }
 
           await forceSyncToBackend();
-          alert(language === 'zh'
+          toast(language === 'zh'
             ? `成功订阅 ${successCount} 个仓库的版本发布`
-            : `Successfully subscribed to ${successCount} repositories releases`
+            : `Successfully subscribed to ${successCount} repositories releases`,
+            'success'
           );
           break;
         }
 
         case 'unsubscribe': {
           const subscribedRepos = repos.filter(repo => releaseSubscriptions.has(repo.id));
-          
+
           if (subscribedRepos.length === 0) {
-            alert(language === 'zh'
+            toast(language === 'zh'
               ? '选中的仓库中没有被订阅的'
-              : 'None of the selected repositories are subscribed'
+              : 'None of the selected repositories are subscribed',
+              'error'
             );
             return;
           }
@@ -804,14 +826,16 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
           // 汇总结果显示
           const successCount = subscribedRepos.length - failedRepos.length;
           if (failedRepos.length > 0) {
-            alert(language === 'zh'
+            toast(language === 'zh'
               ? `成功取消 ${successCount} 个仓库的版本发布订阅\n\n失败 (${failedRepos.length} 个):\n${failedRepos.join('\n')}`
-              : `Successfully unsubscribed ${successCount} repositories from releases\n\nFailed (${failedRepos.length}):\n${failedRepos.join('\n')}`
+              : `Successfully unsubscribed ${successCount} repositories from releases\n\nFailed (${failedRepos.length}):\n${failedRepos.join('\n')}`,
+              'error'
             );
           } else {
-            alert(language === 'zh'
+            toast(language === 'zh'
               ? `成功取消 ${successCount} 个仓库的版本发布订阅`
-              : `Successfully unsubscribed ${successCount} repositories from releases`
+              : `Successfully unsubscribed ${successCount} repositories from releases`,
+              'success'
             );
           }
           break;
@@ -846,14 +870,16 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
             ? (language === 'zh' ? `\n\n跳过 ${skippedCount} 个没有自定义分类的仓库` : `\n\nSkipped ${skippedCount} repositories without custom category`)
             : '';
           if (failedRepos.length > 0) {
-            alert(language === 'zh'
+            toast(language === 'zh'
               ? `成功锁定 ${successCount} 个仓库的分类\n\n失败 (${failedRepos.length} 个):\n${failedRepos.join('\n')}${skipMsg}`
-              : `Successfully locked categories for ${successCount} repositories\n\nFailed (${failedRepos.length}):\n${failedRepos.join('\n')}${skipMsg}`
+              : `Successfully locked categories for ${successCount} repositories\n\nFailed (${failedRepos.length}):\n${failedRepos.join('\n')}${skipMsg}`,
+              'error'
             );
           } else {
-            alert(language === 'zh'
+            toast(language === 'zh'
               ? `成功锁定 ${successCount} 个仓库的分类${skipMsg}`
-              : `Successfully locked categories for ${successCount} repositories${skipMsg}`
+              : `Successfully locked categories for ${successCount} repositories${skipMsg}`,
+              'success'
             );
           }
           break;
@@ -879,28 +905,30 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
 
           await forceSyncToBackend();
           if (failedRepos.length > 0) {
-            alert(language === 'zh'
+            toast(language === 'zh'
               ? `成功解锁 ${successCount} 个仓库的分类\n\n失败 (${failedRepos.length} 个):\n${failedRepos.join('\n')}`
-              : `Successfully unlocked categories for ${successCount} repositories\n\nFailed (${failedRepos.length}):\n${failedRepos.join('\n')}`
+              : `Successfully unlocked categories for ${successCount} repositories\n\nFailed (${failedRepos.length}):\n${failedRepos.join('\n')}`,
+              'error'
             );
           } else {
-            alert(language === 'zh'
+            toast(language === 'zh'
               ? `成功解锁 ${successCount} 个仓库的分类`
-              : `Successfully unlocked categories for ${successCount} repositories`
+              : `Successfully unlocked categories for ${successCount} repositories`,
+              'success'
             );
           }
           break;
         }
 
         default:
-          alert(language === 'zh' ? '未知操作' : 'Unknown action');
+          toast(language === 'zh' ? '未知操作' : 'Unknown action', 'error');
       }
 
       // 清除选择
       handleDeselectAll();
     } catch (error) {
       console.error('Bulk action failed:', error);
-      alert(language === 'zh' ? '批量操作失败' : 'Bulk action failed');
+      toast(language === 'zh' ? '批量操作失败' : 'Bulk action failed', 'error');
     }
   };
 
@@ -939,14 +967,16 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
     // 汇总结果显示
     const successCount = selectedRepos.length - failedRepos.length;
     if (failedRepos.length > 0) {
-      alert(language === 'zh'
+      toast(language === 'zh'
         ? `成功为 ${successCount} 个仓库设置分类：${categoryName}\n\n失败 (${failedRepos.length} 个):\n${failedRepos.join('\n')}`
-        : `Successfully categorized ${successCount} repositories as: ${categoryName}\n\nFailed (${failedRepos.length}):\n${failedRepos.join('\n')}`
+        : `Successfully categorized ${successCount} repositories as: ${categoryName}\n\nFailed (${failedRepos.length}):\n${failedRepos.join('\n')}`,
+        'error'
       );
     } else {
-      alert(language === 'zh'
+      toast(language === 'zh'
         ? `成功为 ${successCount} 个仓库设置分类：${categoryName}`
-        : `Successfully categorized ${successCount} repositories as: ${categoryName}`
+        : `Successfully categorized ${successCount} repositories as: ${categoryName}`,
+        'success'
       );
     }
 

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
-import { Search, X, SlidersHorizontal, Monitor, Smartphone, Globe, Terminal, Package, CheckCircle, Bell, BellOff, Apple, Bot, Edit3, Lock, Unlock, AlertCircle } from 'lucide-react';
+import { Search, X, SlidersHorizontal, Monitor, Smartphone, Globe, Terminal, Package, CheckCircle, Bell, BellOff, Apple, Bot, Edit3, Lock, Unlock, AlertCircle, ChevronDown } from 'lucide-react';
 import { useAppStore, getAllCategories } from '../store/useAppStore';
 import { AIService } from '../services/aiService';
 import { Repository } from '../types';
@@ -7,6 +7,72 @@ import { useSearchShortcuts } from '../hooks/useSearchShortcuts';
 import { getAICategory, getDefaultCategory } from '../utils/categoryUtils';
 import { NumberInput } from './ui/NumberInput';
 
+type SortBy = 'stars' | 'updated' | 'name' | 'starred';
+
+const sortOptions: { value: SortBy; labelZh: string; labelEn: string }[] = [
+  { value: 'stars', labelZh: '按星标排序', labelEn: 'Sort by Stars' },
+  { value: 'updated', labelZh: '按更新排序', labelEn: 'Sort by Updated' },
+  { value: 'name', labelZh: '按名称排序', labelEn: 'Sort by Name' },
+  { value: 'starred', labelZh: '按加星时间排序', labelEn: 'Sort by Starred Time' },
+];
+
+interface SortByDropdownProps {
+  value: SortBy;
+  onChange: (value: SortBy) => void;
+  t: (zh: string, en: string) => string;
+}
+
+const SortByDropdown: React.FC<SortByDropdownProps> = ({ value, onChange, t }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const selected = sortOptions.find(o => o.value === value);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-2 px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-white/[0.04] text-gray-900 dark:text-text-primary text-sm hover:bg-light-bg dark:hover:bg-gray-600 transition-colors"
+      >
+        <span>{t(selected?.labelZh ?? '', selected?.labelEn ?? '')}</span>
+        <ChevronDown className={`w-4 h-4 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+      </button>
+
+      {isOpen && (
+        <div className="absolute left-0 top-full mt-1 w-48 bg-white dark:bg-panel-dark rounded-xl border border-black/[0.06] dark:border-white/[0.04] shadow-lg py-1 z-50">
+          {sortOptions.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => {
+                onChange(option.value);
+                setIsOpen(false);
+              }}
+              className={`flex w-full items-center px-4 py-2 text-sm transition-colors ${
+                value === option.value
+                  ? 'bg-brand-indigo/15 text-brand-indigo dark:bg-brand-indigo/20 dark:text-white'
+                  : 'text-gray-900 dark:text-text-secondary hover:bg-light-bg dark:hover:bg-white/10'
+              }`}
+            >
+              {t(option.labelZh, option.labelEn)}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
 
 export const SearchBar: React.FC = () => {
   const {
@@ -910,21 +976,14 @@ export const SearchBar: React.FC = () => {
 
         {/* Sort Controls */}
         <div className="flex items-center gap-2 overflow-x-auto">
-          <select
+          <SortByDropdown
             value={searchFilters.sortBy}
-            onChange={(e) => setSearchFilters({ 
-              sortBy: e.target.value as 'stars' | 'updated' | 'name' | 'starred'
-            })}
-            className="px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-white/[0.04] text-gray-900 dark:text-text-primary text-sm"
-          >
-            <option value="stars">{t('按星标排序', 'Sort by Stars')}</option>
-            <option value="updated">{t('按更新排序', 'Sort by Updated')}</option>
-            <option value="name">{t('按名称排序', 'Sort by Name')}</option>
-            <option value="starred">{t('按加星时间排序', 'Sort by Starred Time')}</option>
-          </select>
+            onChange={(value) => setSearchFilters({ sortBy: value as 'stars' | 'updated' | 'name' | 'starred' })}
+            t={t}
+          />
           <button
-            onClick={() => setSearchFilters({ 
-              sortOrder: searchFilters.sortOrder === 'desc' ? 'asc' : 'desc' 
+            onClick={() => setSearchFilters({
+              sortOrder: searchFilters.sortOrder === 'desc' ? 'asc' : 'desc'
             })}
             className="px-3 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg bg-white dark:bg-white/[0.04] text-gray-900 dark:text-text-primary text-sm hover:bg-light-bg dark:hover:bg-gray-600 transition-colors"
           >

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -50,7 +50,7 @@ const SortByDropdown: React.FC<SortByDropdownProps> = ({ value, onChange, t }) =
       </button>
 
       {isOpen && (
-        <div className="absolute left-0 top-full mt-1 w-48 bg-white dark:bg-panel-dark rounded-xl border border-black/[0.06] dark:border-white/[0.04] shadow-lg py-1 z-50">
+        <div className="absolute left-0 top-full mt-1 w-48 bg-white dark:bg-panel-dark rounded-xl border border-black/[0.06] dark:border-white/[0.04] shadow-lg py-1 z-50 overflow-hidden">
           {sortOptions.map((option) => (
             <button
               key={option.value}

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -975,7 +975,7 @@ export const SearchBar: React.FC = () => {
         </div>
 
         {/* Sort Controls */}
-        <div className="flex items-center gap-2 overflow-x-auto">
+        <div className="flex items-center gap-2">
           <SortByDropdown
             value={searchFilters.sortBy}
             onChange={(value) => setSearchFilters({ sortBy: value as 'stars' | 'updated' | 'name' | 'starred' })}

--- a/src/components/SubscriptionRepoCard.tsx
+++ b/src/components/SubscriptionRepoCard.tsx
@@ -7,6 +7,7 @@ import { forceSyncToBackend } from '../services/autoSync';
 import { GitHubApiService } from '../services/githubApi';
 import { ReadmeModal } from './ReadmeModal';
 import { Modal } from './Modal';
+import { useDialog } from '../hooks/useDialog';
 
 interface SubscriptionRepoCardProps {
   repo: DiscoveryRepo;
@@ -25,7 +26,9 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
   const repositories = useAppStore(state => state.repositories);
   const addRepository = useAppStore(state => state.addRepository);
   const deleteRepository = useAppStore(state => state.deleteRepository);
-  
+
+  const { toast } = useDialog();
+
   const t = (zh: string, en: string) => language === 'zh' ? zh : en;
 
   const [isStarring, setIsStarring] = useState(false);
@@ -122,7 +125,7 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
       setOptimisticStarred(null);
       console.error('Failed to unstar repository:', error);
       const errorMessage = t('取消 Star 失败，请检查网络连接或 GitHub Token 权限。', 'Failed to unstar repository. Please check your network connection or GitHub Token permissions.');
-      alert(errorMessage);
+      toast(errorMessage, 'error');
     } finally {
       setIsStarring(false);
       setPendingUnstarAction(null);
@@ -174,14 +177,14 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
       
       // 操作成功，清除乐观状态
       setOptimisticStarred(null);
-      
-      alert(t('已成功添加 Star', 'Successfully starred'));
+
+      toast(t('已成功添加 Star', 'Successfully starred'), 'success');
     } catch (error) {
       // 操作失败，回滚乐观状态
       setOptimisticStarred(null);
       console.error('Failed to star repository:', error);
       const errorMessage = t('Star 操作失败，请检查网络连接或 GitHub Token 权限。', 'Failed to star repository. Please check your network connection or GitHub Token permissions.');
-      alert(errorMessage);
+      toast(errorMessage, 'error');
     } finally {
       setIsStarring(false);
     }
@@ -197,25 +200,25 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
   // 处理单个项目AI分析
   const handleAnalyze = useCallback(async (e: React.MouseEvent) => {
     e.stopPropagation();
-    
+
     if (!githubToken) {
-      alert(t('GitHub Token 未找到，请重新登录。', 'GitHub token not found. Please login again.'));
+      toast(t('GitHub Token 未找到，请重新登录。', 'GitHub token not found. Please login again.'), 'error');
       return;
     }
 
     const activeConfig = aiConfigs.find(c => c.id === activeAIConfig);
     if (!activeConfig) {
-      alert(t('请先在设置中配置AI服务。', 'Please configure AI service in settings first.'));
+      toast(t('请先在设置中配置AI服务。', 'Please configure AI service in settings first.'), 'error');
       return;
     }
 
     if (activeConfig.apiKeyStatus === 'decrypt_failed' || activeConfig.apiKeyStatus === 'empty') {
-      alert(t('AI服务的API密钥无法解密或为空，请在设置中重新输入并保存该配置。', 'The AI service API key could not be decrypted or is empty. Please re-enter and save the configuration in settings.'));
+      toast(t('AI服务的API密钥无法解密或为空，请在设置中重新输入并保存该配置。', 'The AI service API key could not be decrypted or is empty. Please re-enter and save the configuration in settings.'), 'error');
       return;
     }
 
     if (!activeConfig.baseUrl || !activeConfig.apiKey || !activeConfig.model) {
-      alert(t('AI服务配置不完整，请检查API端点、密钥和模型名称。', 'AI service configuration is incomplete. Please check the API endpoint, key, and model name.'));
+      toast(t('AI服务配置不完整，请检查API端点、密钥和模型名称。', 'AI service configuration is incomplete. Please check the API endpoint, key, and model name.'), 'error');
       return;
     }
 
@@ -264,7 +267,7 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
           analysis_failed: failedResult.analysis_failed,
         };
         updateDiscoveryRepo(failedRepo);
-        alert(t('AI分析失败，请检查AI配置。', 'AI analysis failed. Please check your AI configuration.'));
+        toast(t('AI分析失败，请检查AI配置。', 'AI analysis failed. Please check your AI configuration.'), 'error');
       }
     } finally {
       if (!controller.signal.aborted) {

--- a/src/components/UpdateChecker.tsx
+++ b/src/components/UpdateChecker.tsx
@@ -45,7 +45,6 @@ export const UpdateChecker: React.FC<UpdateCheckerProps> = ({ onUpdateAvailable 
       }
     } catch (error) {
       const errorMessage = t('检查更新失败，请检查网络连接', 'Failed to check for updates. Please check your network connection.');
-      setError(errorMessage);
       if (!silent) {
         toast(errorMessage, 'error');
       }

--- a/src/components/UpdateChecker.tsx
+++ b/src/components/UpdateChecker.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import { Download, RefreshCw, ExternalLink, Calendar, Package } from 'lucide-react';
 import { UpdateService, VersionInfo } from '../services/updateService';
 import { useAppStore } from '../store/useAppStore';
+import { useDialog } from '../hooks/useDialog';
 
 interface UpdateCheckerProps {
   onUpdateAvailable?: (version: VersionInfo) => void;
@@ -10,6 +11,7 @@ interface UpdateCheckerProps {
 
 export const UpdateChecker: React.FC<UpdateCheckerProps> = ({ onUpdateAvailable }) => {
   const { language, setUpdateNotification } = useAppStore();
+  const { toast } = useDialog();
   const [isChecking, setIsChecking] = useState(false);
   const [updateInfo, setUpdateInfo] = useState<VersionInfo | null>(null);
   const [showUpdateDialog, setShowUpdateDialog] = useState(false);
@@ -39,13 +41,13 @@ export const UpdateChecker: React.FC<UpdateCheckerProps> = ({ onUpdateAvailable 
         });
       } else if (!silent) {
         // 只在手动检查时显示"已是最新版本"的消息
-        alert(t('当前已是最新版本！', 'You are already using the latest version!'));
+        toast(t('当前已是最新版本！', 'You are already using the latest version!'), 'info');
       }
     } catch (error) {
       const errorMessage = t('检查更新失败，请检查网络连接', 'Failed to check for updates. Please check your network connection.');
       setError(errorMessage);
       if (!silent) {
-        alert(errorMessage);
+        toast(errorMessage, 'error');
       }
       console.error('Update check failed:', error);
     } finally {

--- a/src/components/settings/AIConfigPanel.tsx
+++ b/src/components/settings/AIConfigPanel.tsx
@@ -5,6 +5,7 @@ import { useAppStore } from '../../store/useAppStore';
 import { AIService } from '../../services/aiService';
 import { buildFinalApiUrl } from '../../utils/apiUrlBuilder';
 import { SliderInput } from '../ui/SliderInput';
+import { useDialog } from '../../hooks/useDialog';
 
 interface AIConfigPanelProps {
   t: (zh: string, en: string) => string;
@@ -32,6 +33,8 @@ export const AIConfigPanel: React.FC<AIConfigPanelProps> = ({ t }) => {
     deleteAIConfig,
     setActiveAIConfig,
   } = useAppStore();
+
+  const { toast, confirm } = useDialog();
 
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -90,7 +93,7 @@ export const AIConfigPanel: React.FC<AIConfigPanelProps> = ({ t }) => {
 
   const handleSave = () => {
     if (!form.name || !form.baseUrl || !form.apiKey || !form.model) {
-      alert(t('请填写所有必填字段', 'Please fill in all required fields'));
+      toast(t('请填写所有必填字段', 'Please fill in all required fields'), 'error');
       return;
     }
 
@@ -155,13 +158,13 @@ export const AIConfigPanel: React.FC<AIConfigPanelProps> = ({ t }) => {
       const result = await aiService.testConnection();
 
       if (result.success) {
-        alert(t('AI服务连接成功！', 'AI service connection successful!'));
+        toast(t('AI服务连接成功！', 'AI service connection successful!'), 'success');
       } else {
-        alert(result.message);
+        toast(result.message, 'error');
       }
     } catch (error) {
       console.error('AI test failed:', error);
-      alert(t('AI服务测试失败，请检查网络连接和配置。', 'AI service test failed. Please check network connection and configuration.'));
+      toast(t('AI服务测试失败，请检查网络连接和配置。', 'AI service test failed. Please check network connection and configuration.'), 'error');
     } finally {
       setTestingId(null);
     }
@@ -169,7 +172,7 @@ export const AIConfigPanel: React.FC<AIConfigPanelProps> = ({ t }) => {
 
   const handleTestForm = async () => {
     if (!form.baseUrl || !form.apiKey || !form.model) {
-      alert(t('请先填写API端点、API密钥和模型名称', 'Please fill in API Endpoint, API Key and Model Name first'));
+      toast(t('请先填写API端点、API密钥和模型名称', 'Please fill in API Endpoint, API Key and Model Name first'), 'error');
       return;
     }
 
@@ -193,13 +196,13 @@ export const AIConfigPanel: React.FC<AIConfigPanelProps> = ({ t }) => {
       const result = await aiService.testConnection();
 
       if (result.success) {
-        alert(t('✅ AI服务连接成功！', '✅ AI service connection successful!'));
+        toast(t('✅ AI服务连接成功！', '✅ AI service connection successful!'), 'success');
       } else {
-        alert(result.message);
+        toast(result.message, 'error');
       }
     } catch (error) {
       console.error('AI test failed:', error);
-      alert(t('AI服务测试失败，请检查网络连接和配置。', 'AI service test failed. Please check network connection and configuration.'));
+      toast(t('AI服务测试失败，请检查网络连接和配置。', 'AI service test failed. Please check network connection and configuration.'), 'error');
     } finally {
       setTestingForm(false);
     }
@@ -288,25 +291,24 @@ Focus on practicality and accurate categorization to help users quickly understa
     setShowDefaultPrompt(prev => !prev);
   }, [showCustomPrompt, showNotification, t]);
 
-  const handleRestoreDefaultPrompt = useCallback(() => {
+  const handleRestoreDefaultPrompt = useCallback(async () => {
     if (isCustomPromptSameAsDefault) {
       showNotification('info', t('当前提示词已是默认值', 'Current prompt is already the default'));
       return;
     }
-    
+
     if (isCustomPromptModified) {
-      const confirmed = window.confirm(
-        t(
-          '确定要恢复默认提示词吗？这将覆盖您当前的修改。',
-          'Are you sure you want to restore the default prompt? This will overwrite your current changes.'
-        )
+      const confirmed = await confirm(
+        t('确定要恢复默认提示词吗？', 'Restore Default Prompt?'),
+        t('这将覆盖您当前的修改。', 'This will overwrite your current changes.'),
+        { type: 'warning' }
       );
       if (!confirmed) return;
     }
-    
+
     setForm(prev => ({ ...prev, customPrompt: defaultPrompt }));
     showNotification('success', t('已恢复默认提示词', 'Default prompt restored'));
-  }, [defaultPrompt, isCustomPromptModified, isCustomPromptSameAsDefault, showNotification, t]);
+  }, [defaultPrompt, isCustomPromptModified, isCustomPromptSameAsDefault, showNotification, t, confirm]);
 
   return (
     <div className="space-y-6">
@@ -662,12 +664,17 @@ Focus on practicality and accurate categorization to help users quickly understa
                   <Edit3 className="w-4 h-4" />
                 </button>
                 <button
-                  onClick={() => {
-                    if (confirm(t('确定要删除这个AI配置吗？', 'Are you sure you want to delete this AI configuration?'))) {
+                  onClick={async () => {
+                    const confirmed = await confirm(
+                      t('确定要删除这个AI配置吗？', 'Delete AI Configuration?'),
+                      t('此操作无法撤销。', 'This action cannot be undone.'),
+                      { type: 'danger', confirmText: t('删除', 'Delete') }
+                    );
+                    if (confirmed) {
                       if (config.id) {
                         deleteAIConfig(config.id);
                       } else {
-                        alert(t('删除失败：配置ID无效', 'Delete failed: Invalid config ID'));
+                        toast(t('删除失败：配置ID无效', 'Delete failed: Invalid config ID'), 'error');
                       }
                     }
                   }}

--- a/src/components/settings/BackendPanel.tsx
+++ b/src/components/settings/BackendPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Server, TestTube, RefreshCw, Upload, Download, CheckCircle, AlertCircle } from 'lucide-react';
 import { useAppStore } from '../../store/useAppStore';
 import { backend } from '../../services/backendAdapter';
+import { useDialog } from '../../hooks/useDialog';
 
 interface BackendPanelProps {
   t: (zh: string, en: string) => string;
@@ -23,6 +24,8 @@ export const BackendPanel: React.FC<BackendPanelProps> = ({ t }) => {
     showDefaultCategory,
     hideDefaultCategory,
   } = useAppStore();
+
+  const { toast, confirm } = useDialog();
 
   const [status, setStatus] = useState<'connected' | 'disconnected' | 'checking'>('disconnected');
   const [health, setHealth] = useState<{ version: string; timestamp: string } | null>(null);
@@ -61,28 +64,28 @@ export const BackendPanel: React.FC<BackendPanelProps> = ({ t }) => {
       if (healthData && authOk) {
         setStatus('connected');
         setHealth({ version: healthData.version, timestamp: healthData.timestamp });
-        alert(t('后端连接成功！', 'Backend connection successful!'));
+        toast(t('后端连接成功！', 'Backend connection successful!'), 'success');
       } else {
         setStatus('disconnected');
         setHealth(null);
-        alert(t(
+        toast(t(
           '后端连接失败，请检查服务器状态或 API Secret 是否正确。',
           'Backend connection failed. Please check the server status or whether the API Secret is correct.'
-        ));
+        ), 'error');
       }
     } catch {
       setStatus('disconnected');
       setHealth(null);
-      alert(t(
+      toast(t(
         '后端连接失败，请检查服务器状态或 API Secret 是否正确。',
         'Backend connection failed. Please check the server status or whether the API Secret is correct.'
-      ));
+      ), 'error');
     }
   };
 
   const handleSyncToBackend = async () => {
     if (!backend.isAvailable) {
-      alert(t('后端不可用', 'Backend not available'));
+      toast(t('后端不可用', 'Backend not available'), 'error');
       return;
     }
     setIsSyncingToBackend(true);
@@ -92,13 +95,13 @@ export const BackendPanel: React.FC<BackendPanelProps> = ({ t }) => {
       await backend.syncAIConfigs(aiConfigs);
       await backend.syncWebDAVConfigs(webdavConfigs);
       await backend.syncSettings({ hiddenDefaultCategoryIds });
-      alert(t(
+      toast(t(
         `已同步到后端：仓库 ${repositories.length}，发布 ${releases.length}，AI配置 ${aiConfigs.length}，WebDAV配置 ${webdavConfigs.length}`,
         `Synced to backend: repos ${repositories.length}, releases ${releases.length}, AI configs ${aiConfigs.length}, WebDAV configs ${webdavConfigs.length}`
-      ));
+      ), 'success');
     } catch (error) {
       console.error('Sync to backend failed:', error);
-      alert(`${t('同步失败', 'Sync failed')}: ${(error as Error).message}`);
+      toast(`${t('同步失败', 'Sync failed')}: ${(error as Error).message}`, 'error');
     } finally {
       setIsSyncingToBackend(false);
     }
@@ -106,14 +109,16 @@ export const BackendPanel: React.FC<BackendPanelProps> = ({ t }) => {
 
   const handleSyncFromBackend = async () => {
     if (!backend.isAvailable) {
-      alert(t('后端不可用', 'Backend not available'));
+      toast(t('后端不可用', 'Backend not available'), 'error');
       return;
     }
-    
-    if (!confirm(t(
-      '从后端同步将覆盖本地数据，是否继续？',
-      'Syncing from backend will overwrite local data. Continue?'
-    ))) return;
+
+    const confirmed = await confirm(
+      t('从后端同步', 'Sync from Backend'),
+      t('从后端同步将覆盖本地数据，是否继续？', 'Syncing from backend will overwrite local data. Continue?'),
+      { type: 'warning' }
+    );
+    if (!confirmed) return;
 
     setIsSyncingFromBackend(true);
     try {
@@ -122,7 +127,7 @@ export const BackendPanel: React.FC<BackendPanelProps> = ({ t }) => {
       const aiConfigData = await backend.fetchAIConfigs();
       const webdavConfigData = await backend.fetchWebDAVConfigs();
       const settingsData = await backend.fetchSettings();
-      
+
       // Always apply backend snapshot to state (empty array allowed)
       setRepositories(repoData.repositories);
       setReleases(releaseData.releases);
@@ -136,8 +141,8 @@ export const BackendPanel: React.FC<BackendPanelProps> = ({ t }) => {
       }
       // 显示本地隐藏列表中但服务端没有隐藏的分类（即本地手动显示的）
       if (Array.isArray(hiddenDefaultCategoryIds)) {
-        const hiddenIdsFromServer = Array.isArray(settingsData.hiddenDefaultCategoryIds) 
-          ? settingsData.hiddenDefaultCategoryIds 
+        const hiddenIdsFromServer = Array.isArray(settingsData.hiddenDefaultCategoryIds)
+          ? settingsData.hiddenDefaultCategoryIds
           : [];
         for (const categoryId of hiddenDefaultCategoryIds) {
           if (typeof categoryId === 'string' && !hiddenIdsFromServer.includes(categoryId)) {
@@ -145,14 +150,14 @@ export const BackendPanel: React.FC<BackendPanelProps> = ({ t }) => {
           }
         }
       }
-      
-      alert(t(
+
+      toast(t(
         `已从后端同步：仓库 ${repoData.repositories.length}，发布 ${releaseData.releases.length}，AI配置 ${aiConfigData.length}，WebDAV配置 ${webdavConfigData.length}`,
         `Synced from backend: repos ${repoData.repositories.length}, releases ${releaseData.releases.length}, AI configs ${aiConfigData.length}, WebDAV configs ${webdavConfigData.length}`
-      ));
+      ), 'success');
     } catch (error) {
       console.error('Sync from backend failed:', error);
-      alert(`${t('同步失败', 'Sync failed')}: ${(error as Error).message}`);
+      toast(`${t('同步失败', 'Sync failed')}: ${(error as Error).message}`, 'error');
     } finally {
       setIsSyncingFromBackend(false);
     }

--- a/src/components/settings/BackupPanel.tsx
+++ b/src/components/settings/BackupPanel.tsx
@@ -3,6 +3,7 @@ import { Download, Upload, RefreshCw, Cloud, AlertCircle } from 'lucide-react';
 import { AIConfig, WebDAVConfig } from '../../types';
 import { useAppStore } from '../../store/useAppStore';
 import { WebDAVService } from '../../services/webdavService';
+import { useDialog } from '../../hooks/useDialog';
 
 interface BackupPanelProps {
   t: (zh: string, en: string) => string;
@@ -33,6 +34,8 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
     deleteWebDAVConfig,
   } = useAppStore();
 
+  const { toast, confirm } = useDialog();
+
   const [isBackingUp, setIsBackingUp] = useState(false);
   const [isRestoring, setIsRestoring] = useState(false);
 
@@ -40,14 +43,14 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
 
   const handleBackup = async () => {
     if (!activeConfig) {
-      alert(t('请先配置并激活WebDAV服务。', 'Please configure and activate WebDAV service first.'));
+      toast(t('请先配置并激活WebDAV服务。', 'Please configure and activate WebDAV service first.'), 'error');
       return;
     }
 
     setIsBackingUp(true);
     try {
       const webdavService = new WebDAVService(activeConfig);
-      
+
       const backupData = {
         repositories,
         releases,
@@ -70,14 +73,14 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
 
       if (success) {
         setLastBackup(new Date().toISOString());
-        alert(t('数据备份成功！', 'Data backup successful!'));
+        toast(t('数据备份成功！', 'Data backup successful!'), 'success');
       } else {
         console.error('Backup failed: uploadFile returned falsy');
-        alert(t('数据备份失败！', 'Data backup failed!'));
+        toast(t('数据备份失败！', 'Data backup failed!'), 'error');
       }
     } catch (error) {
       console.error('Backup failed:', error);
-      alert(`${t('备份失败', 'Backup failed')}: ${(error as Error).message}`);
+      toast(`${t('备份失败', 'Backup failed')}: ${(error as Error).message}`, 'error');
     } finally {
       setIsBackingUp(false);
     }
@@ -85,37 +88,37 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
 
   const handleRestore = async () => {
     if (!activeConfig) {
-      alert(t('请先配置并激活WebDAV服务。', 'Please configure and activate WebDAV service first.'));
+      toast(t('请先配置并激活WebDAV服务。', 'Please configure and activate WebDAV service first.'), 'error');
       return;
     }
 
-    const confirmMessage = t(
-      '恢复数据将覆盖当前所有数据，是否继续？',
-      'Restoring data will overwrite all current data. Continue?'
+    const confirmed = await confirm(
+      t('恢复数据', 'Restore Data'),
+      t('恢复数据将覆盖当前所有数据，是否继续？', 'Restoring data will overwrite all current data. Continue?'),
+      { type: 'warning' }
     );
-    
-    if (!confirm(confirmMessage)) return;
+    if (!confirmed) return;
 
     setIsRestoring(true);
     try {
       const webdavService = new WebDAVService(activeConfig);
       const files = await webdavService.listFiles();
-      
+
       const backupFiles = files.filter(file => file.startsWith('github-stars-backup-'));
       if (backupFiles.length === 0) {
-        alert(t('未找到备份文件。', 'No backup files found.'));
+        toast(t('未找到备份文件。', 'No backup files found.'), 'error');
         return;
       }
 
       const latestBackup = backupFiles.sort().reverse()[0];
       const backupContent = await webdavService.downloadFile(latestBackup);
-      
+
       if (!backupContent) {
         setIsRestoring(false);
-        alert(t('备份文件内容为空，无法恢复。', 'Backup file is empty, cannot restore.'));
+        toast(t('备份文件内容为空，无法恢复。', 'Backup file is empty, cannot restore.'), 'error');
         return;
       }
-      
+
       try {
         const backupData = JSON.parse(backupContent);
 
@@ -240,13 +243,13 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
           console.warn('恢复 WebDAV 配置时发生问题：', e);
         }
 
-        alert(t(
+        toast(t(
           `已从备份恢复数据：仓库 ${backupData.repositories?.length ?? 0}，发布 ${backupData.releases?.length ?? 0}，自定义分类 ${backupData.customCategories?.length ?? 0}。`,
           `Data restored from backup: repositories ${backupData.repositories?.length ?? 0}, releases ${backupData.releases?.length ?? 0}, custom categories ${backupData.customCategories?.length ?? 0}.`
-        ));
+        ), 'success');
       } catch (error) {
         console.error('Restore failed:', error);
-        alert(`${t('恢复失败', 'Restore failed')}: ${(error as Error).message}`);
+        toast(`${t('恢复失败', 'Restore failed')}: ${(error as Error).message}`, 'error');
       }
     } finally {
       setIsRestoring(false);

--- a/src/components/settings/BackupPanel.tsx
+++ b/src/components/settings/BackupPanel.tsx
@@ -114,7 +114,6 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
       const backupContent = await webdavService.downloadFile(latestBackup);
 
       if (!backupContent) {
-        setIsRestoring(false);
         toast(t('备份文件内容为空，无法恢复。', 'Backup file is empty, cannot restore.'), 'error');
         return;
       }
@@ -251,6 +250,9 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
         console.error('Restore failed:', error);
         toast(`${t('恢复失败', 'Restore failed')}: ${(error as Error).message}`, 'error');
       }
+    } catch (error) {
+      console.error('Restore failed:', error);
+      toast(`${t('恢复失败', 'Restore failed')}: ${(error as Error).message}`, 'error');
     } finally {
       setIsRestoring(false);
     }

--- a/src/components/settings/CategoryPanel.tsx
+++ b/src/components/settings/CategoryPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useRef, useCallback } from 'react';
 import { Package, Plus, Trash2, Edit3, Save, X, Eye, EyeOff, GripVertical, ArrowUp, ArrowDown, ArrowUpToLine, ArrowDownToLine, LayoutGrid } from 'lucide-react';
 import { useAppStore, getAllCategories, sortCategoriesByOrder } from '../../store/useAppStore';
 import { StepperInput } from '../ui/StepperInput';
+import { useDialog } from '../../hooks/useDialog';
 
 interface CategoryPanelProps {
   t: (zh: string, en: string) => string;
@@ -25,6 +26,8 @@ export const CategoryPanel: React.FC<CategoryPanelProps> = ({ t }) => {
   const showDefaultCategory = useAppStore(state => state.showDefaultCategory);
   const setCategoryOrder = useAppStore(state => state.setCategoryOrder);
   const setCollapsedSidebarCategoryCount = useAppStore(state => state.setCollapsedSidebarCategoryCount);
+
+  const { toast, confirm } = useDialog();
 
   const [showAddForm, setShowAddForm] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -68,7 +71,7 @@ export const CategoryPanel: React.FC<CategoryPanelProps> = ({ t }) => {
 
   const handleAddCategory = () => {
     if (!newCategoryName.trim()) {
-      alert(t('请输入分类名称', 'Please enter category name'));
+      toast(t('请输入分类名称', 'Please enter category name'), 'error');
       return;
     }
 
@@ -96,7 +99,7 @@ export const CategoryPanel: React.FC<CategoryPanelProps> = ({ t }) => {
 
   const handleSaveEdit = () => {
     if (!editName.trim()) {
-      alert(t('分类名称不能为空', 'Category name cannot be empty'));
+      toast(t('分类名称不能为空', 'Category name cannot be empty'), 'error');
       return;
     }
 
@@ -142,8 +145,13 @@ export const CategoryPanel: React.FC<CategoryPanelProps> = ({ t }) => {
     setEditKeywords('');
   };
 
-  const handleDeleteCategory = (categoryId: string) => {
-    if (confirm(t('确定要删除这个自定义分类吗？', 'Are you sure you want to delete this custom category?'))) {
+  const handleDeleteCategory = async (categoryId: string) => {
+    const confirmed = await confirm(
+      t('确定要删除这个自定义分类吗？', 'Delete Custom Category?'),
+      t('此操作无法撤销。', 'This action cannot be undone.'),
+      { type: 'danger', confirmText: t('删除', 'Delete') }
+    );
+    if (confirmed) {
       deleteCustomCategory(categoryId);
     }
   };
@@ -182,8 +190,13 @@ export const CategoryPanel: React.FC<CategoryPanelProps> = ({ t }) => {
   };
 
   // 重置分类排序
-  const handleResetOrder = () => {
-    if (confirm(t('确定要重置分类排序吗？这将恢复默认顺序。', 'Are you sure you want to reset category order? This will restore the default order.'))) {
+  const handleResetOrder = async () => {
+    const confirmed = await confirm(
+      t('确定要重置分类排序吗？', 'Reset Category Order?'),
+      t('这将恢复默认顺序。', 'This will restore the default order.'),
+      { type: 'warning' }
+    );
+    if (confirmed) {
       setCategoryOrder([]);
     }
   };

--- a/src/components/settings/WebDAVPanel.tsx
+++ b/src/components/settings/WebDAVPanel.tsx
@@ -3,6 +3,7 @@ import { Cloud, Plus, Edit3, Trash2, Save, X, TestTube, RefreshCw } from 'lucide
 import { WebDAVConfig } from '../../types';
 import { useAppStore } from '../../store/useAppStore';
 import { WebDAVService } from '../../services/webdavService';
+import { useDialog } from '../../hooks/useDialog';
 
 interface WebDAVPanelProps {
   t: (zh: string, en: string) => string;
@@ -17,6 +18,8 @@ export const WebDAVPanel: React.FC<WebDAVPanelProps> = ({ t }) => {
     deleteWebDAVConfig,
     setActiveWebDAVConfig,
   } = useAppStore();
+
+  const { toast, confirm } = useDialog();
 
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -54,7 +57,7 @@ export const WebDAVPanel: React.FC<WebDAVPanelProps> = ({ t }) => {
         if (err === '路径必须以 / 开头') return t('路径必须以 / 开头', 'Path must start with /');
         return err;
       });
-      alert(translated.join('\n'));
+      toast(translated.join('\n'), 'error');
       return;
     }
 
@@ -96,15 +99,15 @@ export const WebDAVPanel: React.FC<WebDAVPanelProps> = ({ t }) => {
     try {
       const webdavService = new WebDAVService(config);
       const isConnected = await webdavService.testConnection();
-      
+
       if (isConnected) {
-        alert(t('WebDAV连接成功！', 'WebDAV connection successful!'));
+        toast(t('WebDAV连接成功！', 'WebDAV connection successful!'), 'success');
       } else {
-        alert(t('WebDAV连接失败，请检查配置。', 'WebDAV connection failed. Please check configuration.'));
+        toast(t('WebDAV连接失败，请检查配置。', 'WebDAV connection failed. Please check configuration.'), 'error');
       }
     } catch (error) {
       console.error('WebDAV test failed:', error);
-      alert(`${t('WebDAV测试失败', 'WebDAV test failed')}: ${(error as Error).message}`);
+      toast(`${t('WebDAV测试失败', 'WebDAV test failed')}: ${(error as Error).message}`, 'error');
     } finally {
       setTestingId(null);
     }
@@ -276,8 +279,13 @@ export const WebDAVPanel: React.FC<WebDAVPanelProps> = ({ t }) => {
                   <Edit3 className="w-4 h-4" />
                 </button>
                 <button
-                  onClick={() => {
-                    if (confirm(t('确定要删除这个WebDAV配置吗？', 'Are you sure you want to delete this WebDAV configuration?'))) {
+                  onClick={async () => {
+                    const confirmed = await confirm(
+                      t('确定要删除这个WebDAV配置吗？', 'Delete WebDAV Configuration?'),
+                      t('此操作无法撤销。', 'This action cannot be undone.'),
+                      { type: 'danger', confirmText: t('删除', 'Delete') }
+                    );
+                    if (confirmed) {
                       deleteWebDAVConfig(config.id);
                     }
                   }}

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,141 @@
+import React, { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { AlertTriangle } from 'lucide-react';
+
+interface ConfirmDialogProps {
+  isOpen: boolean;
+  title: string;
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  type?: 'danger' | 'warning' | 'info';
+}
+
+export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
+  isOpen,
+  title,
+  message,
+  confirmText = 'Confirm',
+  cancelText = 'Cancel',
+  onConfirm,
+  onCancel,
+  type = 'warning',
+}) => {
+  const previousActiveElement = useRef<HTMLElement | null>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      previousActiveElement.current = document.activeElement as HTMLElement;
+      document.body.style.overflow = 'hidden';
+
+      // Focus cancel button by default for safety
+      setTimeout(() => {
+        cancelButtonRef.current?.focus();
+      }, 0);
+    } else {
+      document.body.style.overflow = '';
+      previousActiveElement.current?.focus();
+    }
+
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && isOpen) {
+        onCancel();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape);
+    }
+
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isOpen, onCancel]);
+
+  if (!isOpen) return null;
+
+  const handleConfirm = () => {
+    onConfirm();
+  };
+
+  const handleCancel = () => {
+    onCancel();
+  };
+
+  const handleBackdropClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      onCancel();
+    }
+  };
+
+  const buttonClass = type === 'danger'
+    ? 'bg-status-red hover:bg-status-red/90 dark:bg-status-red/80 dark:hover:bg-status-red'
+    : 'bg-brand-indigo hover:bg-brand-hover dark:bg-brand-indigo dark:hover:bg-brand-hover';
+
+  const dialogContent = (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center"
+      onClick={handleBackdropClick}
+    >
+      {/* Backdrop */}
+      <div className="fixed inset-0 bg-black/50" />
+
+      {/* Dialog */}
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-dialog-title"
+        className="relative w-full max-w-md mx-4 bg-white dark:bg-panel-dark dark:border dark:border-white/[0.04] rounded-xl shadow-xl"
+      >
+        <div className="p-6">
+          <div className="flex items-start space-x-4">
+            <div className={`flex-shrink-0 p-2 rounded-full ${
+              type === 'danger' ? 'bg-status-red/10' : 'bg-brand-indigo/10'
+            }`}>
+              <AlertTriangle className={`w-6 h-6 ${
+                type === 'danger' ? 'text-status-red' : 'text-brand-indigo dark:text-brand-indigo'
+              }`} />
+            </div>
+            <div className="flex-1">
+              <h3 id="confirm-dialog-title" className="text-lg font-semibold text-gray-900 dark:text-text-primary">
+                {title}
+              </h3>
+              <p className="mt-2 text-sm text-gray-600 dark:text-text-secondary">
+                {message}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex justify-end space-x-3 px-6 py-4 bg-light-bg dark:bg-white/[0.02] border-t border-black/[0.06] dark:border-white/[0.04] rounded-b-xl">
+          <button
+            ref={cancelButtonRef}
+            onClick={handleCancel}
+            className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-text-primary bg-white dark:bg-panel-dark border border-black/[0.06] dark:border-white/[0.08] rounded-lg hover:bg-gray-50 dark:hover:bg-white/[0.08] transition-colors"
+          >
+            {cancelText}
+          </button>
+          <button
+            onClick={handleConfirm}
+            className={`px-4 py-2 text-sm font-medium text-white rounded-lg transition-colors ${buttonClass}`}
+          >
+            {confirmText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(dialogContent, document.body);
+};

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useId } from 'react';
 import { createPortal } from 'react-dom';
 import { AlertTriangle } from 'lucide-react';
 
@@ -26,13 +26,15 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
   const previousActiveElement = useRef<HTMLElement | null>(null);
   const dialogRef = useRef<HTMLDivElement>(null);
   const cancelButtonRef = useRef<HTMLButtonElement>(null);
+  const onCancelRef = useRef(onCancel);
+  onCancelRef.current = onCancel;
+  const titleId = useId();
 
   useEffect(() => {
     if (isOpen) {
       previousActiveElement.current = document.activeElement as HTMLElement;
       document.body.style.overflow = 'hidden';
 
-      // Focus cancel button by default for safety
       setTimeout(() => {
         cancelButtonRef.current?.focus();
       }, 0);
@@ -49,7 +51,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
   useEffect(() => {
     const handleEscape = (event: KeyboardEvent) => {
       if (event.key === 'Escape' && isOpen) {
-        onCancel();
+        onCancelRef.current();
       }
     };
 
@@ -60,7 +62,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
     return () => {
       document.removeEventListener('keydown', handleEscape);
     };
-  }, [isOpen, onCancel]);
+  }, [isOpen]);
 
   if (!isOpen) return null;
 
@@ -72,12 +74,6 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
     onCancel();
   };
 
-  const handleBackdropClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    if (event.target === event.currentTarget) {
-      onCancel();
-    }
-  };
-
   const buttonClass = type === 'danger'
     ? 'bg-status-red hover:bg-status-red/90 dark:bg-status-red/80 dark:hover:bg-status-red'
     : 'bg-brand-indigo hover:bg-brand-hover dark:bg-brand-indigo dark:hover:bg-brand-hover';
@@ -85,17 +81,19 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
   const dialogContent = (
     <div
       className="fixed inset-0 z-[100] flex items-center justify-center"
-      onClick={handleBackdropClick}
     >
       {/* Backdrop */}
-      <div className="fixed inset-0 bg-black/50" />
+      <div
+        className="fixed inset-0 bg-black/50"
+        onClick={onCancel}
+      />
 
       {/* Dialog */}
       <div
         ref={dialogRef}
         role="dialog"
         aria-modal="true"
-        aria-labelledby="confirm-dialog-title"
+        aria-labelledby={titleId}
         className="relative w-full max-w-md mx-4 bg-white dark:bg-panel-dark dark:border dark:border-white/[0.04] rounded-xl shadow-xl"
       >
         <div className="p-6">
@@ -108,7 +106,7 @@ export const ConfirmDialog: React.FC<ConfirmDialogProps> = ({
               }`} />
             </div>
             <div className="flex-1">
-              <h3 id="confirm-dialog-title" className="text-lg font-semibold text-gray-900 dark:text-text-primary">
+              <h3 id={titleId} className="text-lg font-semibold text-gray-900 dark:text-text-primary">
                 {title}
               </h3>
               <p className="mt-2 text-sm text-gray-600 dark:text-text-secondary">

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { CheckCircle, AlertCircle, Info, X } from 'lucide-react';
+
+export type ToastType = 'success' | 'error' | 'info';
+
+interface ToastProps {
+  message: string;
+  type: ToastType;
+  onClose: () => void;
+  duration?: number;
+}
+
+const iconMap = {
+  success: CheckCircle,
+  error: AlertCircle,
+  info: Info,
+};
+
+const bgMap = {
+  success: 'bg-gray-50 dark:bg-white/[0.04] border-status-green/30',
+  error: 'bg-gray-50 dark:bg-white/[0.04] border-status-red/30',
+  info: 'bg-gray-50 dark:bg-white/[0.04] border-gray-200 dark:border-white/[0.08]',
+};
+
+const iconColorMap = {
+  success: 'text-status-green dark:text-status-green',
+  error: 'text-status-red dark:text-status-red',
+  info: 'text-gray-500 dark:text-text-secondary',
+};
+
+export const Toast: React.FC<ToastProps> = ({ message, type, onClose, duration = 3000 }) => {
+  const previousActiveElement = useRef<HTMLElement | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    previousActiveElement.current = document.activeElement as HTMLElement;
+
+    timeoutRef.current = setTimeout(() => {
+      onClose();
+    }, duration);
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+      previousActiveElement.current?.focus();
+    };
+  }, [duration, onClose]);
+
+  const Icon = iconMap[type];
+
+  const toastContent = (
+    <div className="fixed top-4 right-4 z-[100] animate-in slide-in-from-top-2 fade-in duration-200">
+      <div className={`flex items-center space-x-3 px-4 py-3 rounded-lg border shadow-lg ${bgMap[type]}`}>
+        <Icon className={`w-5 h-5 flex-shrink-0 ${iconColorMap[type]}`} />
+        <p className="text-sm text-gray-900 dark:text-text-primary">{message}</p>
+        <button
+          onClick={onClose}
+          className="p-1 rounded hover:bg-black/5 dark:hover:bg-white/10 transition-colors"
+        >
+          <X className="w-4 h-4 text-gray-400 dark:text-text-tertiary" />
+        </button>
+      </div>
+    </div>
+  );
+
+  return createPortal(toastContent, document.body);
+};

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -32,34 +32,45 @@ const iconColorMap = {
 export const Toast: React.FC<ToastProps> = ({ message, type, onClose, duration = 3000 }) => {
   const previousActiveElement = useRef<HTMLElement | null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
 
   useEffect(() => {
     previousActiveElement.current = document.activeElement as HTMLElement;
 
     timeoutRef.current = setTimeout(() => {
-      onClose();
+      onCloseRef.current();
     }, duration);
 
     return () => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
       }
-      previousActiveElement.current?.focus();
+      // Only restore focus if user hasn't moved focus elsewhere (activeElement is body)
+      if (document.activeElement === document.body) {
+        previousActiveElement.current?.focus();
+      }
     };
-  }, [duration, onClose]);
+  }, [duration]);
 
   const Icon = iconMap[type];
 
   const toastContent = (
-    <div className="fixed top-4 right-4 z-[100] animate-in slide-in-from-top-2 fade-in duration-200">
+    <div
+      role={type === 'error' ? 'alert' : 'status'}
+      aria-live={type === 'error' ? 'assertive' : 'polite'}
+      aria-atomic="true"
+      className="fixed top-4 right-4 z-[100] animate-in slide-in-from-top-2 fade-in duration-200"
+    >
       <div className={`flex items-center space-x-3 px-4 py-3 rounded-lg border shadow-lg ${bgMap[type]}`}>
-        <Icon className={`w-5 h-5 flex-shrink-0 ${iconColorMap[type]}`} />
-        <p className="text-sm text-gray-900 dark:text-text-primary">{message}</p>
+        <Icon className={`w-5 h-5 flex-shrink-0 ${iconColorMap[type]}`} aria-hidden="true" />
+        <p className="text-sm text-gray-900 dark:text-text-primary whitespace-pre-line">{message}</p>
         <button
           onClick={onClose}
+          aria-label={`${message} - close`}
           className="p-1 rounded hover:bg-black/5 dark:hover:bg-white/10 transition-colors"
         >
-          <X className="w-4 h-4 text-gray-400 dark:text-text-tertiary" />
+          <X className="w-4 h-4 text-gray-400 dark:text-text-tertiary" aria-hidden="true" />
         </button>
       </div>
     </div>

--- a/src/hooks/useDialog.tsx
+++ b/src/hooks/useDialog.tsx
@@ -1,0 +1,121 @@
+import { useState, useCallback, createContext, useContext, ReactNode } from 'react';
+import { Toast, ToastType } from '../components/ui/Toast';
+import { ConfirmDialog } from '../components/ui/ConfirmDialog';
+
+interface ToastState {
+  message: string;
+  type: ToastType;
+  key: number;
+}
+
+interface ConfirmState {
+  isOpen: boolean;
+  title: string;
+  message: string;
+  confirmText?: string;
+  cancelText?: string;
+  type?: 'danger' | 'warning' | 'info';
+  resolve: ((value: boolean) => void) | null;
+}
+
+interface DialogContextValue {
+  toast: (message: string, type?: ToastType) => void;
+  confirm: (title: string, message: string, options?: {
+    confirmText?: string;
+    cancelText?: string;
+    type?: 'danger' | 'warning' | 'info';
+  }) => Promise<boolean>;
+}
+
+const DialogContext = createContext<DialogContextValue | null>(null);
+
+export const useDialog = (): DialogContextValue => {
+  const context = useContext(DialogContext);
+  if (!context) {
+    throw new Error('useDialog must be used within a DialogProvider');
+  }
+  return context;
+};
+
+interface DialogProviderProps {
+  children: ReactNode;
+}
+
+export const DialogProvider: React.FC<DialogProviderProps> = ({ children }) => {
+  const [toastState, setToastState] = useState<ToastState | null>(null);
+  const [confirmState, setConfirmState] = useState<ConfirmState>({
+    isOpen: false,
+    title: '',
+    message: '',
+    resolve: null,
+  });
+
+  const toast = useCallback((message: string, type: ToastType = 'info') => {
+    setToastState({ message, type, key: Date.now() });
+  }, []);
+
+  const closeToast = useCallback(() => {
+    setToastState(null);
+  }, []);
+
+  const confirm = useCallback((
+    title: string,
+    message: string,
+    options?: {
+      confirmText?: string;
+      cancelText?: string;
+      type?: 'danger' | 'warning' | 'info';
+    }
+  ): Promise<boolean> => {
+    return new Promise((resolve) => {
+      setConfirmState({
+        isOpen: true,
+        title,
+        message,
+        confirmText: options?.confirmText,
+        cancelText: options?.cancelText,
+        type: options?.type || 'warning',
+        resolve,
+      });
+    });
+  }, []);
+
+  const handleConfirm = useCallback(() => {
+    confirmState.resolve?.(true);
+    setConfirmState((prev) => ({ ...prev, isOpen: false, resolve: null }));
+  }, [confirmState.resolve]);
+
+  const handleCancel = useCallback(() => {
+    confirmState.resolve?.(false);
+    setConfirmState((prev) => ({ ...prev, isOpen: false, resolve: null }));
+  }, [confirmState.resolve]);
+
+  const value: DialogContextValue = {
+    toast,
+    confirm,
+  };
+
+  return (
+    <DialogContext.Provider value={value}>
+      {children}
+      {toastState && (
+        <Toast
+          key={toastState.key}
+          message={toastState.message}
+          type={toastState.type}
+          onClose={closeToast}
+        />
+      )}
+      <ConfirmDialog
+        isOpen={confirmState.isOpen}
+        title={confirmState.title}
+        message={confirmState.message}
+        confirmText={confirmState.confirmText}
+        cancelText={confirmState.cancelText}
+        type={confirmState.type}
+        onConfirm={handleConfirm}
+        onCancel={handleCancel}
+      />
+    </DialogContext.Provider>
+  );
+};

--- a/src/hooks/useDialog.tsx
+++ b/src/hooks/useDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, createContext, useContext, ReactNode } from 'react';
+import React, { useState, useCallback, createContext, useContext, ReactNode, useMemo, useRef } from 'react';
 import { Toast, ToastType } from '../components/ui/Toast';
 import { ConfirmDialog } from '../components/ui/ConfirmDialog';
 
@@ -15,7 +15,6 @@ interface ConfirmState {
   confirmText?: string;
   cancelText?: string;
   type?: 'danger' | 'warning' | 'info';
-  resolve: ((value: boolean) => void) | null;
 }
 
 interface DialogContextValue {
@@ -47,8 +46,12 @@ export const DialogProvider: React.FC<DialogProviderProps> = ({ children }) => {
     isOpen: false,
     title: '',
     message: '',
-    resolve: null,
+    confirmText: undefined,
+    cancelText: undefined,
+    type: 'warning',
   });
+
+  const pendingResolveRef = useRef<((value: boolean) => void) | null>(null);
 
   const toast = useCallback((message: string, type: ToastType = 'info') => {
     setToastState({ message, type, key: Date.now() });
@@ -67,7 +70,12 @@ export const DialogProvider: React.FC<DialogProviderProps> = ({ children }) => {
       type?: 'danger' | 'warning' | 'info';
     }
   ): Promise<boolean> => {
+    // Cancel any pending confirm so its awaiter does not hang.
+    pendingResolveRef.current?.(false);
+    pendingResolveRef.current = null;
+
     return new Promise((resolve) => {
+      pendingResolveRef.current = resolve;
       setConfirmState({
         isOpen: true,
         title,
@@ -75,25 +83,26 @@ export const DialogProvider: React.FC<DialogProviderProps> = ({ children }) => {
         confirmText: options?.confirmText,
         cancelText: options?.cancelText,
         type: options?.type || 'warning',
-        resolve,
       });
     });
   }, []);
 
   const handleConfirm = useCallback(() => {
-    confirmState.resolve?.(true);
-    setConfirmState((prev) => ({ ...prev, isOpen: false, resolve: null }));
-  }, [confirmState.resolve]);
+    pendingResolveRef.current?.(true);
+    pendingResolveRef.current = null;
+    setConfirmState((prev) => ({ ...prev, isOpen: false }));
+  }, []);
 
   const handleCancel = useCallback(() => {
-    confirmState.resolve?.(false);
-    setConfirmState((prev) => ({ ...prev, isOpen: false, resolve: null }));
-  }, [confirmState.resolve]);
+    pendingResolveRef.current?.(false);
+    pendingResolveRef.current = null;
+    setConfirmState((prev) => ({ ...prev, isOpen: false }));
+  }, []);
 
-  const value: DialogContextValue = {
+  const value = useMemo<DialogContextValue>(() => ({
     toast,
     confirm,
-  };
+  }), [toast, confirm]);
 
   return (
     <DialogContext.Provider value={value}>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 import { ErrorBoundary } from './components/ErrorBoundary.tsx';
+import { DialogProvider } from './hooks/useDialog';
 
 console.log('Main.tsx loading...');
 
@@ -21,7 +22,9 @@ try {
   root.render(
     <StrictMode>
       <ErrorBoundary>
-        <App />
+        <DialogProvider>
+          <App />
+        </DialogProvider>
       </ErrorBoundary>
     </StrictMode>
   );


### PR DESCRIPTION
## Summary

- 创建 `Toast` 和 `ConfirmDialog` 组件替换原生 `alert()`/`confirm()`
- 创建 `useDialog` hook 提供 `toast()` 和 `confirm()` API
- 替换所有设置面板（AIConfigPanel、BackendPanel、WebDAVPanel、BackupPanel、CategoryPanel）中的 alert/confirm 调用

## Problem

`window.alert()` / `window.confirm()` 在 Electron 中会破坏 renderer 进程的焦点状态。用户点击"确定"关闭对话框后，之前聚焦的 input 元素丢失焦点且无法重新获得，必须 Alt+Tab 切换窗口才能恢复。

## Solution

使用 React Portal + 非阻塞对话框，参考 ReadmeModal.tsx 的焦点恢复模式：
- 保存 `document.activeElement`，对话框关闭后 `.focus()` 恢复
- Toast 组件：3秒自动关闭，支持 success/error/info 类型
- ConfirmDialog 组件：返回 Promise 支持 async/await，支持 danger/warning/info 类型

## Test plan

- [ ] 打开 AI 配置面板
- [ ] 填写 AI 配置后点击"测试连接"
- [ ] 等待连接失败弹出 toast
- [ ] 点击 toast 关闭后，原 input 应保持焦点（无需 Alt+Tab 切换）
- [ ] 确认删除操作时，对话框关闭后焦点应正确恢复

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-app confirmation dialogs for important actions like deletions and overwrites.
  * New landing page showcasing application features, architecture, and download options.
  * Added toast-style notifications for user feedback instead of browser alerts.

* **Improvements**
  * Enhanced confirmation dialogs with warning and danger states for clarity.
  * Improved landing page with animations, feature cards, and platform showcase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->