### PR TITLE
fix: 区分分类锁定开关的锁定/未锁定状态颜色

### DIFF
--- a/src/components/RepositoryEditModal.tsx
+++ b/src/components/RepositoryEditModal.tsx
@@ -991,7 +991,7 @@ export const RepositoryEditModal: React.FC<RepositoryEditModalProps> = ({
                       disabled={!formData.category}
                       className="sr-only peer"
                     />
-                    <div className="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-brand-violet rounded-full peer dark:bg-gray-600 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-black/[0.06] after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-white/[0.04] peer-checked:bg-status-amber peer-disabled:opacity-50 peer-disabled:cursor-not-allowed"></div>
+                    <div className="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-brand-violet rounded-full peer dark:bg-gray-600 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-black/[0.06] after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-white/[0.04] peer-checked:bg-brand-violet peer-disabled:opacity-50 peer-disabled:cursor-not-allowed"></div>
                   </label>
                 </div>
                 <p className="text-xs text-gray-700 dark:text-text-secondary">

--- a/src/components/RepositoryEditModal.tsx
+++ b/src/components/RepositoryEditModal.tsx
@@ -991,7 +991,7 @@ export const RepositoryEditModal: React.FC<RepositoryEditModalProps> = ({
                       disabled={!formData.category}
                       className="sr-only peer"
                     />
-                    <div className="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-brand-violet rounded-full peer dark:bg-white/10 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-black/[0.06] after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-white/[0.04] peer-checked:bg-status-amber peer-disabled:opacity-50 peer-disabled:cursor-not-allowed"></div>
+                    <div className="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-brand-violet rounded-full peer dark:bg-gray-600 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-black/[0.06] after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-white/[0.04] peer-checked:bg-status-amber peer-disabled:opacity-50 peer-disabled:cursor-not-allowed"></div>
                   </label>
                 </div>
                 <p className="text-xs text-gray-700 dark:text-text-secondary">


### PR DESCRIPTION
## Summary

- 修复分类锁定开关在暗色模式下未锁定状态颜色不明显的问题
- 未锁定状态：暗色模式下使用 `gray-600`（深灰色）
- 锁定状态：保持 `status-amber`（琥珀色）

## Test plan

- [ ] 在亮色模式下验证未锁定(灰色)和锁定(琥珀色)状态可区分
- [ ] 在暗色模式下验证未锁定(深灰色)和锁定(琥珀色)状态可区分

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the category lock toggle appearance in dark mode for better contrast and readability.
  * Updated the toggle’s checked color to the primary brand violet for clearer state indication.
  * Visual-only change; toggle behavior and functionality remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->