### PR TITLE
fix: 修复Gemini渠道API端点URL显示问题

### DIFF
--- a/src/components/settings/AIConfigPanel.tsx
+++ b/src/components/settings/AIConfigPanel.tsx
@@ -162,6 +162,8 @@ export const AIConfigPanel: React.FC<AIConfigPanelProps> = ({ t }) => {
   };
 
   const handleEdit = (config: AIConfig) => {
+    // Sync ref to prevent auto-fill effect from overwriting loaded config
+    prevApiTypeRef.current = config.apiType || 'openai';
     setForm({
       name: config.name,
       apiType: config.apiType || 'openai',

--- a/src/components/settings/AIConfigPanel.tsx
+++ b/src/components/settings/AIConfigPanel.tsx
@@ -64,7 +64,7 @@ export const AIConfigPanel: React.FC<AIConfigPanelProps> = ({ t }) => {
   const [form, setForm] = useState<AIFormState>({
     name: '',
     apiType: 'openai',
-    baseUrl: '',
+    baseUrl: 'https://api.openai.com/v1',
     apiKey: '',
     model: '',
     customPrompt: '',
@@ -73,11 +73,20 @@ export const AIConfigPanel: React.FC<AIConfigPanelProps> = ({ t }) => {
     reasoningEffort: '',
   });
 
+  const defaultApiEndpoints: Record<AIApiType, string> = {
+    openai: 'https://api.openai.com/v1',
+    'openai-responses': 'https://api.openai.com/v1',
+    claude: 'https://api.anthropic.com/v1',
+    gemini: 'https://generativelanguage.googleapis.com/v1beta',
+    'openai-compatible': '',
+  };
+
   const resetForm = () => {
+    const defaultUrl = defaultApiEndpoints[form.apiType] || '';
     setForm({
       name: '',
       apiType: 'openai',
-      baseUrl: '',
+      baseUrl: defaultUrl,
       apiKey: '',
       model: '',
       customPrompt: '',
@@ -390,10 +399,15 @@ Focus on practicality and accurate categorization to help users quickly understa
                       '填写完整的API调用地址，包含完整路径',
                       'Enter the full API endpoint URL including the complete path'
                     )
-                  : t(
-                      '只填到版本号即可（如 .../v1 或 .../v1beta），不要包含 /chat/completions、/responses、/messages 或 :generateContent',
-                      'Only include the version prefix (e.g. .../v1 or .../v1beta). Do not include /chat/completions, /responses, /messages, or :generateContent.'
-                    )}
+                  : form.apiType === 'gemini'
+                    ? t(
+                        '只填到 v1beta 即可，路径会自动生成',
+                        'Only include the version prefix v1beta, the path will be generated automatically'
+                      )
+                    : t(
+                        '只填到版本号即可（如 .../v1 或 .../v1beta），不要包含 /chat/completions、/responses、/messages',
+                        'Only include the version prefix (e.g. .../v1 or .../v1beta). Do not include /chat/completions, /responses, or /messages.'
+                      )}
               </p>
               {form.baseUrl && (
                 <p className="text-xs text-gray-500 dark:text-text-tertiary mt-1">

--- a/src/components/settings/AIConfigPanel.tsx
+++ b/src/components/settings/AIConfigPanel.tsx
@@ -87,8 +87,13 @@ export const AIConfigPanel: React.FC<AIConfigPanelProps> = ({ t }) => {
     if (form.apiType !== prevApiTypeRef.current) {
       const nextDefault = defaultApiEndpoints[form.apiType];
       const prevDefault = defaultApiEndpoints[prevApiTypeRef.current];
-      if (nextDefault && (form.baseUrl === '' || form.baseUrl === prevDefault)) {
-        setForm(prev => ({ ...prev, baseUrl: nextDefault }));
+      if (nextDefault) {
+        if (form.baseUrl === '' || form.baseUrl === prevDefault) {
+          setForm(prev => ({ ...prev, baseUrl: nextDefault }));
+        }
+      } else if (form.baseUrl === prevDefault) {
+        // Clear baseUrl when switching to a type with no default (e.g., openai-compatible)
+        setForm(prev => ({ ...prev, baseUrl: '' }));
       }
       prevApiTypeRef.current = form.apiType;
     }

--- a/src/components/settings/AIConfigPanel.tsx
+++ b/src/components/settings/AIConfigPanel.tsx
@@ -23,6 +23,14 @@ type AIFormState = {
   reasoningEffort: '' | AIReasoningEffort;
 };
 
+const DEFAULT_API_ENDPOINTS: Record<AIApiType, string> = {
+  openai: 'https://api.openai.com/v1',
+  'openai-responses': 'https://api.openai.com/v1',
+  claude: 'https://api.anthropic.com/v1',
+  gemini: 'https://generativelanguage.googleapis.com/v1beta',
+  'openai-compatible': '',
+};
+
 export const AIConfigPanel: React.FC<AIConfigPanelProps> = ({ t }) => {
   const {
     aiConfigs,
@@ -73,20 +81,12 @@ export const AIConfigPanel: React.FC<AIConfigPanelProps> = ({ t }) => {
     reasoningEffort: '',
   });
 
-  const defaultApiEndpoints: Record<AIApiType, string> = {
-    openai: 'https://api.openai.com/v1',
-    'openai-responses': 'https://api.openai.com/v1',
-    claude: 'https://api.anthropic.com/v1',
-    gemini: 'https://generativelanguage.googleapis.com/v1beta',
-    'openai-compatible': '',
-  };
-
   // Auto-fill baseUrl when API type changes
   const prevApiTypeRef = useRef<AIApiType>('openai');
   useEffect(() => {
     if (form.apiType !== prevApiTypeRef.current) {
-      const nextDefault = defaultApiEndpoints[form.apiType];
-      const prevDefault = defaultApiEndpoints[prevApiTypeRef.current];
+      const nextDefault = DEFAULT_API_ENDPOINTS[form.apiType];
+      const prevDefault = DEFAULT_API_ENDPOINTS[prevApiTypeRef.current];
       if (nextDefault) {
         if (form.baseUrl === '' || form.baseUrl === prevDefault) {
           setForm(prev => ({ ...prev, baseUrl: nextDefault }));
@@ -103,7 +103,7 @@ export const AIConfigPanel: React.FC<AIConfigPanelProps> = ({ t }) => {
     setForm({
       name: '',
       apiType: 'openai',
-      baseUrl: defaultApiEndpoints.openai,
+      baseUrl: DEFAULT_API_ENDPOINTS.openai,
       apiKey: '',
       model: '',
       customPrompt: '',

--- a/src/components/settings/AIConfigPanel.tsx
+++ b/src/components/settings/AIConfigPanel.tsx
@@ -81,12 +81,24 @@ export const AIConfigPanel: React.FC<AIConfigPanelProps> = ({ t }) => {
     'openai-compatible': '',
   };
 
+  // Auto-fill baseUrl when API type changes
+  const prevApiTypeRef = useRef<AIApiType>('openai');
+  useEffect(() => {
+    if (form.apiType !== prevApiTypeRef.current) {
+      const nextDefault = defaultApiEndpoints[form.apiType];
+      const prevDefault = defaultApiEndpoints[prevApiTypeRef.current];
+      if (nextDefault && (form.baseUrl === '' || form.baseUrl === prevDefault)) {
+        setForm(prev => ({ ...prev, baseUrl: nextDefault }));
+      }
+      prevApiTypeRef.current = form.apiType;
+    }
+  }, [form.apiType, form.baseUrl]);
+
   const resetForm = () => {
-    const defaultUrl = defaultApiEndpoints[form.apiType] || '';
     setForm({
       name: '',
       apiType: 'openai',
-      baseUrl: defaultUrl,
+      baseUrl: defaultApiEndpoints.openai,
       apiKey: '',
       model: '',
       customPrompt: '',
@@ -98,6 +110,7 @@ export const AIConfigPanel: React.FC<AIConfigPanelProps> = ({ t }) => {
     setEditingId(null);
     setShowCustomPrompt(false);
     setShowDefaultPrompt(false);
+    prevApiTypeRef.current = 'openai';
   };
 
   const handleSave = () => {

--- a/src/utils/apiUrlBuilder.ts
+++ b/src/utils/apiUrlBuilder.ts
@@ -40,6 +40,10 @@ export function buildFinalApiUrl(baseUrl: string, apiType: AIApiType): string {
     return baseUrl.replace(/\/$/, '');
   }
 
+  if (apiType === 'gemini') {
+    return buildApiUrl(baseUrl, 'v1beta/models/{model}:generateContent');
+  }
+
   const pathWithVersion = apiType === 'openai-responses' ? 'v1/responses' : 'v1/chat/completions';
   return buildApiUrl(baseUrl, pathWithVersion);
 }

--- a/versions/version-info.xml
+++ b/versions/version-info.xml
@@ -279,4 +279,19 @@
     </changelog>
     <downloadUrl>https://github.com/AmintaCCCP/GithubStarsManager/releases/tag/v0.5.4</downloadUrl>
   </version>
+  <version>
+    <number>0.5.5</number>
+    <releaseDate>2026-04-27</releaseDate>
+    <changelog>
+      <item>Update Dialog Portal Fix: Fixed the update dialog backdrop mask being trapped inside the overflow container. The dialog now renders via React Portal at the document body level with proper z-index stacking. Added click-on-mask-to-dismiss behavior for better UX. (PR #112)</item>
+      <item>Banner Layout Improvements: Fixed banner button wrapping on narrow viewports. Removed invalid Tailwind classes and improved responsive layout with proper flex behavior. (PR #112)</item>
+      <item>Electron Focus Hijacking Fix: Replaced native alert()/confirm() dialogs with custom React components (Toast and ConfirmDialog), resolving focus trapping issues in Electron. (PR #117)</item>
+      <item>Category Lock Toggle Visibility: Improved the category lock toggle color differentiation in dark mode. Unlocked state now uses gray-600, locked state uses amber. Both states are clearly distinguishable. (PR #118)</item>
+      <item>AI Connection Test Enhancements: AI connection test now returns detailed, user-facing results including status and guidance messages. (PR #114)</item>
+      <item>AI Configuration Error Handling: AI analysis now properly blocks execution when API keys are empty or cannot be decrypted. Bulk AI config import now skips entries without usable keys and logs reasons. (PR #114)</item>
+      <item>Unified Error Messages and UI Polish: Consolidated AI configuration error messages and improved markdown image/GitHub link dark-mode styling. (PR #114)</item>
+      <item>Special thanks to @SummerRay160 for their outstanding contributions to this release!</item>
+    </changelog>
+    <downloadUrl>https://github.com/AmintaCCCP/GithubStarsManager/releases/tag/v0.5.5</downloadUrl>
+  </version>
 </versions>


### PR DESCRIPTION
## Summary
- 选择Gemini类型时自动填充官方默认端点 `https://generativelanguage.googleapis.com/v1beta`
- 修正 `buildFinalApiUrl` 对 gemini 类型的处理，返回正确的 `v1beta/models/{model}:generateContent` 路径
- 更新UI提示文案，Gemini用户看到"只填到v1beta即可，路径会自动生成"

## Test plan
- [ ] 选择Gemini渠道时，API端点输入框应自动填充官方默认值
- [ ] 选择Gemini渠道时，提示文案应正确引导用户
- [ ] 最终请求URL预览应显示 `.../v1beta/models/{model}:generateContent` 格式

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic base URL defaults per AI provider and auto-update when switching API type.
  * Gemini endpoint input simplified—enter the v1beta model prefix; endpoint is constructed automatically.
  * API Endpoint helper text clarified with specific Gemini guidance and narrowed prohibited paths.

* **Bug Fixes**
  * Reset restores provider-specific default endpoints and preserves loaded endpoint values when editing existing configs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->