### PR TITLE
fix: 完善 Release 同步机制，修复 #119

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -98,14 +98,7 @@ export const Header: React.FC = () => {
       });
 
       setRepositories(mergedRepositories);
-
-      // 3. 获取Release信息
-      console.log('Fetching releases...');
-      const releases = await githubApi.getMultipleRepositoryReleases(mergedRepositories.slice(0, 20));
-      setReleases(releases);
-
       setLastSync(new Date().toISOString());
-      console.log('Sync completed successfully');
 
       // 显示同步结果
       const newRepoCount = newRepositories.length - repositories.length;
@@ -360,18 +353,18 @@ export const Header: React.FC = () => {
 
           {/* User Actions */}
           <div className="flex items-center gap-2 sm:gap-3 hd-btns lg:hd-btns">
-            {/* Sync Status */}
-            <div className="hidden sm:flex items-center space-x-2 text-sm text-gray-500 dark:text-text-tertiary">
-              <span>{t('上次同步:', 'Last sync:')} {formatLastSync(lastSync)}</span>
-              <button
-                onClick={handleSync}
-                disabled={isLoading}
-                className="p-1 rounded hover:bg-light-surface dark:hover:bg-white/5 transition-colors disabled:opacity-50"
-                title={t('同步仓库', 'Sync repositories')}
-              >
-                <RefreshCw className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`} />
-              </button>
-            </div>
+              {/* Sync Status */}
+              <div className="hidden sm:flex items-center space-x-2 text-sm text-gray-500 dark:text-text-tertiary">
+                <span>{t('上次同步:', 'Last sync:')} {formatLastSync(lastSync)}</span>
+                <button
+                  onClick={handleSync}
+                  disabled={isLoading}
+                  className="p-1 rounded hover:bg-light-surface dark:hover:bg-white/5 transition-colors disabled:opacity-50"
+                  title={t('同步 Star 仓库列表（仅更新仓库信息，不含 Release）', 'Sync starred repositories (metadata only, excludes releases)')}
+                >
+                  <RefreshCw className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`} />
+                </button>
+              </div>
 
             {/* Theme Toggle */}
             <button

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -623,7 +623,6 @@ export const ReleaseTimeline: React.FC = () => {
               </span>
             )}
 
-            {/* Refresh Button with help icon */}
               <div className="flex items-center space-x-2">
                 <button
                   onClick={handleRefresh}
@@ -633,12 +632,21 @@ export const ReleaseTimeline: React.FC = () => {
                   <RefreshCw className={`w-4 h-4 ${releaseIsRefreshing ? 'animate-spin' : ''}`} />
                   <span>{releaseIsRefreshing ? t('刷新中...', 'Refreshing...') : t('刷新', 'Refresh')}</span>
                 </button>
-                <div
-                  className="p-1 rounded-full hover:bg-light-surface dark:hover:bg-white/10 cursor-help"
+                <label className="flex items-center gap-2 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={includePreRelease}
+                    onChange={(e) => setIncludePreRelease(e.target.checked)}
+                    className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-brand-indigo focus:ring-2 focus:ring-brand-violet cursor-pointer"
+                  />
+                  <span className="text-sm text-gray-700 dark:text-text-secondary">
+                    {t('包含 Pre-release', 'Include Pre-release')}
+                  </span>
+                </label>
+                <HelpCircle
+                  className="w-4 h-4 text-gray-400 dark:text-text-quaternary cursor-help"
                   title={t('增量刷新已订阅仓库的 Release，仅获取上次同步后的新版本', 'Incremental refresh for subscribed repos (only new since last sync)')}
-                >
-                  <HelpCircle className="w-4 h-4 text-gray-400 dark:text-text-quaternary" />
-                </div>
+                />
               </div>
           </div>
         </div>
@@ -679,25 +687,14 @@ export const ReleaseTimeline: React.FC = () => {
                 onFilterToggle={handleFilterToggle}
                 onClearFilters={handleClearFilters}
               />
-              <div className="flex items-center gap-2">
-                <label className="flex items-center gap-2 cursor-pointer select-none">
-                  <input
-                    type="checkbox"
-                    checked={includePreRelease}
-                    onChange={(e) => setIncludePreRelease(e.target.checked)}
-                    className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-brand-indigo focus:ring-2 focus:ring-brand-violet cursor-pointer"
-                  />
-                  <span className="text-sm text-gray-700 dark:text-text-secondary">
-                    {t('包含 Pre-release', 'Include Pre-release')}
-                  </span>
-                </label>
-                <div
-                  className="p-1 rounded-full hover:bg-light-surface dark:hover:bg-white/10 cursor-help"
-                  title={t('控制刷新时是否包含预发布版本，应用于刷新结果', 'Toggle whether to include pre-release versions in refresh results')}
-                >
-                  <HelpCircle className="w-4 h-4 text-gray-400 dark:text-text-quaternary" />
-                </div>
-              </div>
+              <button
+                onClick={() => {}}
+                className="flex items-center gap-1 px-3 py-1.5 text-sm bg-light-surface dark:bg-white/[0.04] hover:bg-gray-200 dark:hover:bg-white/10 text-gray-700 dark:text-text-secondary rounded-lg transition-colors"
+                title={t('新建过滤器', 'New Filter')}
+              >
+                <Plus className="w-3.5 h-3.5" />
+                <span>{t('新建', 'New')}</span>
+              </button>
             </div>
 
             {/* View Mode Toggle Dropdown */}

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -598,15 +598,8 @@ export const ReleaseTimeline: React.FC = () => {
               </span>
             )}
 
+            {/* Pre-release toggle + help icon (LEFT) */}
               <div className="flex items-center space-x-2">
-                <button
-                  onClick={handleRefresh}
-                  disabled={releaseIsRefreshing}
-                  className="flex items-center space-x-2 px-4 py-2 bg-brand-indigo text-white rounded-lg hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <RefreshCw className={`w-4 h-4 ${releaseIsRefreshing ? 'animate-spin' : ''}`} />
-                  <span>{releaseIsRefreshing ? t('刷新中...', 'Refreshing...') : t('刷新', 'Refresh')}</span>
-                </button>
                 <label className="flex items-center gap-2 cursor-pointer select-none">
                   <input
                     type="checkbox"
@@ -623,6 +616,20 @@ export const ReleaseTimeline: React.FC = () => {
                   title={t('增量刷新已订阅仓库的 Release，仅获取上次同步后的新版本', 'Incremental refresh for subscribed repos (only new since last sync)')}
                 />
               </div>
+
+            {/* Refresh Button (RIGHT) */}
+              <div className="flex items-center space-x-2">
+                <button
+                  onClick={handleRefresh}
+                  disabled={releaseIsRefreshing}
+                  className="flex items-center space-x-2 px-4 py-2 bg-brand-indigo text-white rounded-lg hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <RefreshCw className={`w-4 h-4 ${releaseIsRefreshing ? 'animate-spin' : ''}`} />
+                  <span>{releaseIsRefreshing ? t('刷新中...', 'Refreshing...') : t('刷新', 'Refresh')}</span>
+                </button>
+              </div>
+            </div>
+          </div>
           </div>
         </div>
 
@@ -657,18 +664,20 @@ export const ReleaseTimeline: React.FC = () => {
           {/* Filters and View Toggle Row */}
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
             <div className="flex items-center gap-3 flex-wrap">
+              <button>
+                disabled
+                className="flex items-center gap-1 px-3 py-1.5 text-sm bg-brand-indigo/20 text-brand-indigo rounded-lg cursor-not-allowed"
+                title={t('新建过滤器（即将推出）', 'New Filter (Coming Soon)')}
+              >
+                <Plus className="w-3.5 h-3.5" />
+                <span>{t('新建', 'New')}</span>
+              </button>
+
               <AssetFilterManager
                 selectedFilters={selectedFilters}
                 onFilterToggle={handleFilterToggle}
                 onClearFilters={handleClearFilters}
               />
-              <button
-                className="flex items-center gap-1 px-3 py-1.5 text-sm bg-light-surface dark:bg-white/[0.04] hover:bg-gray-200 dark:hover:bg-white/10 text-gray-700 dark:text-text-secondary rounded-lg transition-colors"
-                title={t('新建过滤器', 'New Filter')}
-              >
-                <Plus className="w-3.5 h-3.5" />
-                <span>{t('新建', 'New')}</span>
-              </button>
             </div>
 
             {/* View Mode Toggle Dropdown */}

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -663,7 +663,6 @@ export const ReleaseTimeline: React.FC = () => {
                 onClearFilters={handleClearFilters}
               />
               <button
-                onClick={() => {}}
                 className="flex items-center gap-1 px-3 py-1.5 text-sm bg-light-surface dark:bg-white/[0.04] hover:bg-gray-200 dark:hover:bg-white/10 text-gray-700 dark:text-text-secondary rounded-lg transition-colors"
                 title={t('新建过滤器', 'New Filter')}
               >

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -669,7 +669,8 @@ export const ReleaseTimeline: React.FC = () => {
                 onClearFilters={handleClearFilters}
               />
 
-              <button disabled>
+              <button
+                disabled
                 className="flex items-center gap-1 px-3 py-1.5 text-sm bg-brand-indigo/20 text-brand-indigo rounded-lg cursor-not-allowed"
                 title={t('新建过滤器（即将推出）', 'New Filter (Coming Soon)')}
               >

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
-import { Package, Bell, Search, X, RefreshCw, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, LayoutGrid, CalendarDays, ChevronDown, HelpCircle } from 'lucide-react';
+import { Package, Bell, Search, X, RefreshCw, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, LayoutGrid, CalendarDays, ChevronDown, HelpCircle, Plus } from 'lucide-react';
 import { Release } from '../types';
 import { useAppStore } from '../store/useAppStore';
 import { GitHubApiService } from '../services/githubApi';

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -597,37 +597,6 @@ export const ReleaseTimeline: React.FC = () => {
                 {t('上次刷新:', 'Last refresh:')} {formatDistanceToNow(new Date(lastRefreshTime), { addSuffix: true })}
               </span>
             )}
-
-            {/* Pre-release toggle + help icon (LEFT) */}
-              <div className="flex items-center space-x-2">
-                <label className="flex items-center gap-2 cursor-pointer select-none">
-                  <input
-                    type="checkbox"
-                    checked={includePreRelease}
-                    onChange={(e) => setIncludePreRelease(e.target.checked)}
-                    className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-brand-indigo focus:ring-2 focus:ring-brand-violet cursor-pointer"
-                  />
-                  <span className="text-sm text-gray-700 dark:text-text-secondary">
-                    {t('包含 Pre-release', 'Include Pre-release')}
-                  </span>
-                </label>
-                <HelpCircle
-                  className="w-4 h-4 text-gray-400 dark:text-text-quaternary cursor-help"
-                  title={t('增量刷新已订阅仓库的 Release，仅获取上次同步后的新版本', 'Incremental refresh for subscribed repos (only new since last sync)')}
-                />
-              </div>
-
-            {/* Refresh Button (RIGHT) */}
-              <div className="flex items-center space-x-2">
-                <button
-                  onClick={handleRefresh}
-                  disabled={releaseIsRefreshing}
-                  className="flex items-center space-x-2 px-4 py-2 bg-brand-indigo text-white rounded-lg hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  <RefreshCw className={`w-4 h-4 ${releaseIsRefreshing ? 'animate-spin' : ''}`} />
-                  <span>{releaseIsRefreshing ? t('刷新中...', 'Refreshing...') : t('刷新', 'Refresh')}</span>
-                </button>
-              </div>
             </div>
           </div>
           </div>
@@ -662,9 +631,45 @@ export const ReleaseTimeline: React.FC = () => {
 
           {/* Filters and View Toggle Row */}
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+
+
+            {/* Pre-release toggle + help icon (LEFT) */}
+              <div className="flex items-center space-x-2">
+                <label className="flex items-center gap-2 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={includePreRelease}
+                    onChange={(e) => setIncludePreRelease(e.target.checked)}
+                    className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-brand-indigo focus:ring-2 focus:ring-brand-violet cursor-pointer"
+                  />
+                  <span className="text-sm text-gray-700 dark:text-text-secondary">
+                    {t('包含 Pre-release', 'Include Pre-release')}
+                  </span>
+                </label>
+
+              </div>
+
+            {/* Refresh Button (RIGHT) */}
+              <div className="flex items-center space-x-2">
+                <button
+                  onClick={handleRefresh}
+                  disabled={releaseIsRefreshing}
+                  className="flex items-center space-x-2 px-4 py-2 bg-brand-indigo text-white rounded-lg hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <RefreshCw className={`w-4 h-4 ${releaseIsRefreshing ? 'animate-spin' : ''}`} />
+                  <span>{releaseIsRefreshing ? t('刷新中...', 'Refreshing...') : t('刷新', 'Refresh')}</span>
+                </button>
+              </div>
+
             <div className="flex items-center gap-3 flex-wrap">
-              <button
-                disabled
+
+              <AssetFilterManager
+                selectedFilters={selectedFilters}
+                onFilterToggle={handleFilterToggle}
+                onClearFilters={handleClearFilters}
+              />
+
+              <button disabled>
                 className="flex items-center gap-1 px-3 py-1.5 text-sm bg-brand-indigo/20 text-brand-indigo rounded-lg cursor-not-allowed"
                 title={t('新建过滤器（即将推出）', 'New Filter (Coming Soon)')}
               >
@@ -672,11 +677,6 @@ export const ReleaseTimeline: React.FC = () => {
                 <span>{t('新建', 'New')}</span>
               </button>
 
-              <AssetFilterManager
-                selectedFilters={selectedFilters}
-                onFilterToggle={handleFilterToggle}
-                onClearFilters={handleClearFilters}
-              />
             </div>
 
             {/* View Mode Toggle Dropdown */}

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -310,48 +310,24 @@ export const ReleaseTimeline: React.FC = () => {
         return;
       }
 
-      const allNewReleases: Release[] = [];
-      const failedRepos: { full_name: string; error: string }[] = [];
+      const refreshStartedAt = new Date().toISOString();
 
-      for (const repo of subscribedRepos) {
-        const [owner, name] = repo.full_name.split('/');
+      const { releases: fetchedReleases, failedRepos } =
+        await githubApi.getMultipleRepositoryReleases(subscribedRepos, 30);
 
-        try {
-          let repoReleases: Release[];
+      const allNewReleases = includePreRelease?
+        fetchedReleases:
+        fetchedReleases.filter(r => !r.prelease);
 
-          if (!repo.hasFetchedReleases) {
-            repoReleases = await githubApi.getRepositoryReleases(owner, name, 1, 30);
-          } else {
-            const since = repo.lastReleaseSyncTime;
-            repoReleases = await githubApi.getIncrementalRepositoryReleases(
-              owner, name, since, 30
-            );
-          }
-
-          if (!includePreRelease) {
-            repoReleases = repoReleases.filter(r => !(r as any).prerelease);
-          }
-
-          repoReleases.forEach(release => {
-            release.repository.id = repo.id;
-          });
-
-          allNewReleases.push(...repoReleases);
-
-          const updatedRepo = {
-            ...repo,
-            lastReleaseSyncTime: new Date().toISOString(),
-            hasFetchedReleases: true,
-          };
-          updateRepository(updatedRepo);
-
-        } catch (error) {
-          failedRepos.push({
-            full_name: repo.full_name,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-      }
+      const failedRepoNames = new Set(failedRepos.map(r => r.full_name));
+      subscribedRepos.forEach(repo => {
+        if (failedRepoNames.has(repo.full_name)) return;
+        updateRepository({
+          ...repo,
+          lastReleaseSyncTime: refreshStartedAt,
+          hasFetchedReleases: true,
+        });
+      });
 
       const existingIds = new Set(useAppStore.getState().releases.map(r => r.id));
       const actuallyNewCount = allNewReleases.filter(r => !existingIds.has(r.id)).length;
@@ -360,8 +336,7 @@ export const ReleaseTimeline: React.FC = () => {
         addReleases(allNewReleases);
       }
 
-      const now = new Date().toISOString();
-      setLastRefreshTime(now);
+      setLastRefreshTime(refreshStartedAt);
 
       // 汇总 toast
       if (failedRepos.length > 0) {

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -631,7 +631,6 @@ export const ReleaseTimeline: React.FC = () => {
             </div>
           </div>
           </div>
-        </div>
 
         {/* Search and Filters */}
         <div className="bg-white dark:bg-panel-dark rounded-xl border border-black/[0.06] dark:border-white/[0.04] p-3 mb-4">
@@ -664,7 +663,7 @@ export const ReleaseTimeline: React.FC = () => {
           {/* Filters and View Toggle Row */}
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
             <div className="flex items-center gap-3 flex-wrap">
-              <button>
+              <button
                 disabled
                 className="flex items-center gap-1 px-3 py-1.5 text-sm bg-brand-indigo/20 text-brand-indigo rounded-lg cursor-not-allowed"
                 title={t('新建过滤器（即将推出）', 'New Filter (Coming Soon)')}
@@ -839,7 +838,6 @@ export const ReleaseTimeline: React.FC = () => {
             )}
           </div>
         </div>
-      </div>
 
        {/* Releases List */}
        <div className="space-y-2">

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
-import { Package, Bell, Search, X, RefreshCw, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, LayoutGrid, CalendarDays, ChevronDown } from 'lucide-react';
+import { Package, Bell, Search, X, RefreshCw, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, LayoutGrid, CalendarDays, ChevronDown, HelpCircle } from 'lucide-react';
 import { Release } from '../types';
 import { useAppStore } from '../store/useAppStore';
 import { GitHubApiService } from '../services/githubApi';
@@ -30,12 +30,14 @@ export const ReleaseTimeline: React.FC = () => {
     releaseSearchQuery,
     releaseExpandedRepositories,
     releaseIsRefreshing,
+    includePreRelease,
     setReleaseViewMode,
     toggleReleaseSelectedFilter,
     clearReleaseSelectedFilters,
     setReleaseSearchQuery,
     toggleReleaseExpandedRepository,
     setReleaseIsRefreshing,
+    setIncludePreRelease,
   } = useAppStore();
 
   const { toast, confirm } = useDialog();
@@ -309,31 +311,46 @@ export const ReleaseTimeline: React.FC = () => {
       }
 
       const allNewReleases: Release[] = [];
-
-      const latestReleaseTime = releases.length > 0 
-        ? releases.reduce((max, r) => Math.max(max, new Date(r.published_at).getTime()), 0)
-        : 0;
-      const sinceTimestamp = latestReleaseTime > 0 ? new Date(latestReleaseTime).toISOString() : undefined;
+      const failedRepos: { full_name: string; error: string }[] = [];
 
       for (const repo of subscribedRepos) {
         const [owner, name] = repo.full_name.split('/');
-        
-        const hasExistingReleases = releases.some(r => r.repository.id === repo.id);
-        
-        let repoReleases: Release[];
-        if (!hasExistingReleases) {
-          repoReleases = await githubApi.getRepositoryReleases(owner, name, 1, 10);
-        } else {
-          repoReleases = await githubApi.getIncrementalRepositoryReleases(owner, name, sinceTimestamp, 10);
+
+        try {
+          let repoReleases: Release[];
+
+          if (!repo.hasFetchedReleases) {
+            repoReleases = await githubApi.getRepositoryReleases(owner, name, 1, 30);
+          } else {
+            const since = repo.lastReleaseSyncTime;
+            repoReleases = await githubApi.getIncrementalRepositoryReleases(
+              owner, name, since, 30
+            );
+          }
+
+          if (!includePreRelease) {
+            repoReleases = repoReleases.filter(r => !(r as any).prerelease);
+          }
+
+          repoReleases.forEach(release => {
+            release.repository.id = repo.id;
+          });
+
+          allNewReleases.push(...repoReleases);
+
+          const updatedRepo = {
+            ...repo,
+            lastReleaseSyncTime: new Date().toISOString(),
+            hasFetchedReleases: true,
+          };
+          updateRepository(updatedRepo);
+
+        } catch (error) {
+          failedRepos.push({
+            full_name: repo.full_name,
+            error: error instanceof Error ? error.message : String(error),
+          });
         }
-        
-        repoReleases.forEach(release => {
-          release.repository.id = repo.id;
-        });
-        
-        allNewReleases.push(...repoReleases);
-        
-        await new Promise(resolve => setTimeout(resolve, 200));
       }
 
       const existingIds = new Set(useAppStore.getState().releases.map(r => r.id));
@@ -346,11 +363,19 @@ export const ReleaseTimeline: React.FC = () => {
       const now = new Date().toISOString();
       setLastRefreshTime(now);
 
-      const message = language === 'zh'
-        ? `刷新完成！发现 ${actuallyNewCount} 个新Release。`
-        : `Refresh completed! Found ${actuallyNewCount} new releases.`;
-
-      toast(message, 'success');
+      // 汇总 toast
+      if (failedRepos.length > 0) {
+        const failedNames = failedRepos.map(r => r.full_name).join('、');
+        const message = language === 'zh'
+          ? `刷新完成！新增 ${actuallyNewCount} 个Release，${failedRepos.length} 个仓库失败：${failedNames}`
+          : `Refresh completed! ${actuallyNewCount} new releases, ${failedRepos.length} failed: ${failedRepos.map(r => r.full_name).join(', ')}`;
+        toast(message, failedRepos.length > 0 ? 'warning' : 'success');
+      } else {
+        const message = language === 'zh'
+          ? `刷新完成！发现 ${actuallyNewCount} 个新Release。`
+          : `Refresh completed! Found ${actuallyNewCount} new releases.`;
+        toast(message, 'success');
+      }
     } catch (error) {
       console.error('Refresh failed:', error);
       const errorMessage = language === 'zh'
@@ -598,15 +623,23 @@ export const ReleaseTimeline: React.FC = () => {
               </span>
             )}
 
-            {/* Refresh Button */}
-            <button
-              onClick={handleRefresh}
-              disabled={releaseIsRefreshing}
-              className="flex items-center space-x-2 px-4 py-2 bg-brand-indigo text-white rounded-lg hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              <RefreshCw className={`w-4 h-4 ${releaseIsRefreshing ? 'animate-spin' : ''}`} />
-              <span>{releaseIsRefreshing ? t('刷新中...', 'Refreshing...') : t('刷新', 'Refresh')}</span>
-            </button>
+            {/* Refresh Button with help icon */}
+              <div className="flex items-center space-x-2">
+                <button
+                  onClick={handleRefresh}
+                  disabled={releaseIsRefreshing}
+                  className="flex items-center space-x-2 px-4 py-2 bg-brand-indigo text-white rounded-lg hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <RefreshCw className={`w-4 h-4 ${releaseIsRefreshing ? 'animate-spin' : ''}`} />
+                  <span>{releaseIsRefreshing ? t('刷新中...', 'Refreshing...') : t('刷新', 'Refresh')}</span>
+                </button>
+                <div
+                  className="p-1 rounded-full hover:bg-light-surface dark:hover:bg-white/10 cursor-help"
+                  title={t('增量刷新已订阅仓库的 Release，仅获取上次同步后的新版本', 'Incremental refresh for subscribed repos (only new since last sync)')}
+                >
+                  <HelpCircle className="w-4 h-4 text-gray-400 dark:text-text-quaternary" />
+                </div>
+              </div>
           </div>
         </div>
 
@@ -640,12 +673,31 @@ export const ReleaseTimeline: React.FC = () => {
 
           {/* Filters and View Toggle Row */}
           <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
-            <div className="flex-1">
+            <div className="flex items-center gap-3 flex-wrap">
               <AssetFilterManager
                 selectedFilters={selectedFilters}
                 onFilterToggle={handleFilterToggle}
                 onClearFilters={handleClearFilters}
               />
+              <div className="flex items-center gap-2">
+                <label className="flex items-center gap-2 cursor-pointer select-none">
+                  <input
+                    type="checkbox"
+                    checked={includePreRelease}
+                    onChange={(e) => setIncludePreRelease(e.target.checked)}
+                    className="w-4 h-4 rounded border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-brand-indigo focus:ring-2 focus:ring-brand-violet cursor-pointer"
+                  />
+                  <span className="text-sm text-gray-700 dark:text-text-secondary">
+                    {t('包含 Pre-release', 'Include Pre-release')}
+                  </span>
+                </label>
+                <div
+                  className="p-1 rounded-full hover:bg-light-surface dark:hover:bg-white/10 cursor-help"
+                  title={t('控制刷新时是否包含预发布版本，应用于刷新结果', 'Toggle whether to include pre-release versions in refresh results')}
+                >
+                  <HelpCircle className="w-4 h-4 text-gray-400 dark:text-text-quaternary" />
+                </div>
+              </div>
             </div>
 
             {/* View Mode Toggle Dropdown */}

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -44,7 +44,45 @@ export class GitHubApiService {
     this.token = token;
   }
 
+  private rateLimitRemaining: number | null = null;
+  private rateLimitReset: number | null = null;
+  lastFetchFailures: { repoId: number; full_name: string; error: string }[] = [];
+
+  private async controlledConcurrency<T, R>(
+    items: T[],
+    concurrency: number,
+    fn: (item: T) => Promise<R>
+  ): Promise<{ results: (R | null)[]; errors: { item: T; error: any }[] }> {
+    let index = 0;
+    const results: (R | null)[] = new Array(items.length).fill(null);
+    const errors: { item: T; error: any }[] = [];
+
+    const worker = async () => {
+      while (true) {
+        const currentIndex = index++;
+        if (currentIndex >= items.length) break;
+
+        try {
+          results[currentIndex] = await fn(items[currentIndex]);
+        } catch (error) {
+          errors.push({ item: items[currentIndex], error });
+        }
+      }
+    };
+
+    const workerCount = Math.min(concurrency, items.length);
+    await Promise.all(Array.from({ length: workerCount }, () => worker()));
+    return { results, errors };
+  }
+
   private async makeRequest<T>(endpoint: string, options: RequestInit = {}, signal?: AbortSignal): Promise<T> {
+    if (this.rateLimitRemaining !== null && this.rateLimitRemaining < 3 && this.rateLimitReset !== null) {
+      const waitMs = (this.rateLimitReset * 1000) - Date.now();
+      if (waitMs > 0) {
+        await new Promise(resolve => setTimeout(resolve, waitMs + 1000));
+      }
+    }
+
     const response = await fetch(`${GITHUB_API_BASE}${endpoint}`, {
       ...options,
       signal,
@@ -56,19 +94,32 @@ export class GitHubApiService {
       },
     });
 
+    const remaining = response.headers.get('X-RateLimit-Remaining');
+    const reset = response.headers.get('X-RateLimit-Reset');
+    if (remaining !== null) {
+      this.rateLimitRemaining = parseInt(remaining, 10);
+    }
+    if (reset !== null) {
+      this.rateLimitReset = parseInt(reset, 10);
+    }
+
     if (!response.ok) {
       if (response.status === 401) {
         throw new Error('GitHub token expired or invalid');
+      }
+      if (response.status === 403 && this.rateLimitRemaining === 0) {
+        const resetDate = this.rateLimitReset
+          ? new Date(this.rateLimitReset * 1000).toLocaleString()
+          : 'unknown';
+        throw new Error(`GitHub API rate limit exceeded. Resets at ${resetDate}`);
       }
       throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
     }
 
     const data = response.status === 204 ? null : await response.json();
 
-    // 如果是starred repositories的响应，需要处理特殊格式
     if (endpoint.includes('/user/starred') && Array.isArray(data)) {
       return data.map((item: GitHubStarredItem) => {
-        // 如果使用了star+json格式，数据结构会不同
         if (item.starred_at && item.repo) {
           return {
             ...item.repo,
@@ -144,11 +195,86 @@ export class GitHubApiService {
   }
 
   async getRepositoryReleases(owner: string, repo: string, page = 1, perPage = 30): Promise<Release[]> {
+    const releases = await this.makeRequest<Release[]>(
+      `/repos/${owner}/${repo}/releases?page=${page}&per_page=${perPage}`
+    );
+
+    return releases.map(release => ({
+      id: release.id,
+      tag_name: release.tag_name,
+      name: release.name || release.tag_name,
+      body: release.body || '',
+      published_at: release.published_at,
+      html_url: release.html_url,
+      assets: release.assets || [],
+      zipball_url: release.zipball_url,
+      tarball_url: release.tarball_url,
+      repository: {
+        id: 0,
+        full_name: `${owner}/${repo}`,
+        name: repo,
+      },
+    }));
+  }
+
+  async getMultipleRepositoryReleases(
+    repositories: Repository[],
+    perPage = 5
+  ): Promise<{ releases: Release[]; failedRepos: { repoId: number; full_name: string; error: string }[] }> {
+    const { results, errors } = await this.controlledConcurrency(
+      repositories,
+      3,
+      async (repo) => {
+        const [owner, name] = repo.full_name.split('/');
+        const releases = await this.getRepositoryReleases(owner, name, 1, perPage);
+        releases.forEach(release => {
+          release.repository.id = repo.id;
+        });
+        return releases;
+      }
+    );
+
+    const allReleases: Release[] = [];
+    const failedRepos: { repoId: number; full_name: string; error: string }[] = [];
+
+    results.forEach((repoReleases, index) => {
+      if (repoReleases) {
+        allReleases.push(...repoReleases);
+      }
+    });
+
+    errors.forEach(({ item, error }) => {
+      const repo = item as Repository;
+      failedRepos.push({
+        repoId: repo.id,
+        full_name: repo.full_name,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+
+    const sortedReleases = allReleases.sort((a, b) =>
+      new Date(b.published_at).getTime() - new Date(a.published_at).getTime()
+    );
+
+    return { releases: sortedReleases, failedRepos };
+  }
+
+  // 获取仓库的增量releases（基于时间戳，since 直接传入 GitHub API）
+  async getIncrementalRepositoryReleases(
+    owner: string,
+    repo: string,
+    since?: string,
+    perPage = 10
+  ): Promise<Release[]> {
     try {
-      const releases = await this.makeRequest<Release[]>(
-        `/repos/${owner}/${repo}/releases?page=${page}&per_page=${perPage}`
-      );
-      
+      let endpoint = `/repos/${owner}/${repo}/releases?per_page=${perPage}`;
+      if (since) {
+        const sinceDate = new Date(since);
+        endpoint += `&since=${sinceDate.toISOString()}`;
+      }
+
+      const releases = await this.makeRequest<Release[]>(endpoint);
+
       return releases.map(release => ({
         id: release.id,
         tag_name: release.tag_name,
@@ -166,76 +292,7 @@ export class GitHubApiService {
         },
       }));
     } catch (error) {
-      console.warn(`Failed to fetch releases for ${owner}/${repo}:`, error);
-      return [];
-    }
-  }
-
-  async getMultipleRepositoryReleases(repositories: Repository[]): Promise<Release[]> {
-    const allReleases: Release[] = [];
-    
-    for (const repo of repositories) {
-      const [owner, name] = repo.full_name.split('/');
-      const releases = await this.getRepositoryReleases(owner, name, 1, 5);
-      
-      // Add repository info to releases
-      releases.forEach(release => {
-        release.repository.id = repo.id;
-      });
-      
-      allReleases.push(...releases);
-      
-      // Rate limiting protection
-      await new Promise(resolve => setTimeout(resolve, 150));
-    }
-
-    // Sort by published date (newest first)
-    return allReleases.sort((a, b) => 
-      new Date(b.published_at).getTime() - new Date(a.published_at).getTime()
-    );
-  }
-
-  // 新增：获取仓库的增量releases（基于时间戳）
-  async getIncrementalRepositoryReleases(
-    owner: string, 
-    repo: string, 
-    since?: string, 
-    perPage = 10
-  ): Promise<Release[]> {
-    try {
-      const endpoint = `/repos/${owner}/${repo}/releases?per_page=${perPage}`;
-      
-      const releases = await this.makeRequest<Release[]>(endpoint);
-      
-      const mappedReleases = releases.map(release => ({
-        id: release.id,
-        tag_name: release.tag_name,
-        name: release.name || release.tag_name,
-        body: release.body || '',
-        published_at: release.published_at,
-        html_url: release.html_url,
-        assets: release.assets || [],
-        zipball_url: release.zipball_url,
-        tarball_url: release.tarball_url,
-        repository: {
-          id: 0,
-          full_name: `${owner}/${repo}`,
-          name: repo,
-        },
-      }));
-
-      // 如果提供了since时间戳，只返回更新的releases
-      if (since) {
-        const sinceDate = new Date(since);
-        return mappedReleases.filter(release => 
-          new Date(release.published_at) > sinceDate
-        );
-      }
-
-      return mappedReleases;
-    } catch (error) {
-      console.warn(`Failed to fetch incremental releases for ${owner}/${repo}:`, error);
-      return [];
+      throw error;
     }
   }
 

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -209,6 +209,7 @@ export class GitHubApiService {
       assets: release.assets || [],
       zipball_url: release.zipball_url,
       tarball_url: release.tarball_url,
+      prerelease: release.prerelease ?? false,
       repository: {
         id: 0,
         full_name: `${owner}/${repo}`,
@@ -219,14 +220,24 @@ export class GitHubApiService {
 
   async getMultipleRepositoryReleases(
     repositories: Repository[],
-    perPage = 5
+    perPage = 30
   ): Promise<{ releases: Release[]; failedRepos: { repoId: number; full_name: string; error: string }[] }> {
     const { results, errors } = await this.controlledConcurrency(
       repositories,
       3,
       async (repo) => {
         const [owner, name] = repo.full_name.split('/');
-        const releases = await this.getRepositoryReleases(owner, name, 1, perPage);
+        let releases: Release[];
+
+        if (!repo.hasFetchedReleases) {
+          // 新订阅仓库，全量获取
+          releases = await this.getRepositoryReleases(owner, name, 1, perPage);
+        } else {
+          // 已有数据，增量获取
+          const since = repo.lastReleaseSyncTime;
+          releases = await this.getIncrementalRepositoryReleases(owner, name, since, perPage);
+        }
+
         releases.forEach(release => {
           release.repository.id = repo.id;
         });
@@ -259,38 +270,63 @@ export class GitHubApiService {
     return { releases: sortedReleases, failedRepos };
   }
 
-  // 获取仓库的增量releases（基于时间戳，since 直接传入 GitHub API）
+  // 获取仓库的增量releases（基于时间戳，使用分页+published_at截止）
   async getIncrementalRepositoryReleases(
     owner: string,
     repo: string,
     since?: string,
-    perPage = 10
+    perPage = 30
   ): Promise<Release[]> {
     try {
-      let endpoint = `/repos/${owner}/${repo}/releases?per_page=${perPage}`;
-      if (since) {
-        const sinceDate = new Date(since);
-        endpoint += `&since=${sinceDate.toISOString()}`;
+      // 如果没有 since，直接获取最新一页即可
+      if (!since) {
+        return this.getRepositoryReleases(owner, repo, 1, perPage);
       }
 
-      const releases = await this.makeRequest<Release[]>(endpoint);
+      const sinceDate = new Date(since);
+      const newReleases: Release[] = [];
+      let page = 1;
+      const maxPages = 10; // 安全上限，防止无限循环
 
-      return releases.map(release => ({
-        id: release.id,
-        tag_name: release.tag_name,
-        name: release.name || release.tag_name,
-        body: release.body || '',
-        published_at: release.published_at,
-        html_url: release.html_url,
-        assets: release.assets || [],
-        zipball_url: release.zipball_url,
-        tarball_url: release.tarball_url,
-        repository: {
-          id: 0,
-          full_name: `${owner}/${repo}`,
-          name: repo,
-        },
-      }));
+      while (page <= maxPages) {
+        const releases = await this.makeRequest<any[]>(
+          `/repos/${owner}/${repo}/releases?page=${page}&per_page=${perPage}`
+        );
+
+        if (!releases || releases.length === 0) break;
+
+        let foundCutoff = false;
+        for (const release of releases) {
+          const pubDate = new Date(release.published_at);
+          if (pubDate <= sinceDate) {
+            foundCutoff = true;
+            break;
+          }
+          newReleases.push({
+            id: release.id,
+            tag_name: release.tag_name,
+            name: release.name || release.tag_name,
+            body: release.body || '',
+            published_at: release.published_at,
+            html_url: release.html_url,
+            assets: release.assets || [],
+            zipball_url: release.zipball_url,
+            tarball_url: release.tarball_url,
+            prerelease: release.prerelease ?? false,
+            repository: {
+              id: 0,
+              full_name: `${owner}/${repo}`,
+              name: repo,
+            },
+          });
+        }
+
+        if (foundCutoff) break;
+        if (releases.length < perPage) break;
+        page++;
+      }
+
+      return newReleases;
     } catch (error) {
       throw error;
     }

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -286,9 +286,12 @@ export class GitHubApiService {
       const sinceDate = new Date(since);
       const newReleases: Release[] = [];
       let page = 1;
-      const maxPages = 10; // 安全上限，防止无限循环
 
-      while (page <= maxPages) {
+      while (true) {
+        if (page > 50) {
+          throw new Error(`Exceeded safety bound: page ${page} while paginating releases for ${owner}/${repo}`);
+        }
+
         const releases = await this.makeRequest<any[]>(
           `/repos/${owner}/${repo}/releases?page=${page}&per_page=${perPage}`
         );

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -156,15 +156,16 @@ interface AppActions {
   // Backend actions
   setBackendApiSecret: (secret: string | null) => void;
 
-  // Release Timeline View actions
-  setReleaseViewMode: (mode: 'timeline' | 'repository') => void;
-  setReleaseSelectedFilters: (filters: string[]) => void;
-  toggleReleaseSelectedFilter: (filterId: string) => void;
-  clearReleaseSelectedFilters: () => void;
-  setReleaseSearchQuery: (query: string) => void;
-  toggleReleaseExpandedRepository: (repoId: number) => void;
-  setReleaseExpandedRepositories: (repoIds: Set<number>) => void;
-  setReleaseIsRefreshing: (refreshing: boolean) => void;
+   // Release Timeline View actions
+   setReleaseViewMode: (mode: 'timeline' | 'repository') => void;
+   setReleaseSelectedFilters: (filters: string[]) => void;
+   toggleReleaseSelectedFilter: (filterId: string) => void;
+   clearReleaseSelectedFilters: () => void;
+   setReleaseSearchQuery: (query: string) => void;
+   toggleReleaseExpandedRepository: (repoId: number) => void;
+   setReleaseExpandedRepositories: (repoIds: Set<number>) => void;
+   setReleaseIsRefreshing: (refreshing: boolean) => void;
+   setIncludePreRelease: (include: boolean) => void;
 
   // Discovery actions
   setSelectedDiscoveryChannel: (channel: DiscoveryChannelId) => void;
@@ -276,19 +277,22 @@ const normalizePersistedState = (
   const repositories = Array.isArray(safePersisted.repositories) ? safePersisted.repositories : [];
   const releases = Array.isArray(safePersisted.releases) ? safePersisted.releases : [];
 
-  return {
-    ...currentState,
-    ...safePersisted,
-    theme:
-      safePersisted.theme === 'light' || safePersisted.theme === 'dark'
-        ? safePersisted.theme
-        : 'dark',
-    repositories,
-    releases,
-    searchResults: repositories,
-    releaseSubscriptions: normalizeNumberSet(safePersisted.releaseSubscriptions),
-    readReleases: normalizeNumberSet(safePersisted.readReleases),
-    releaseExpandedRepositories: normalizeNumberSet(safePersisted.releaseExpandedRepositories),
+    const includePreRelease = safePersisted.includePreRelease ?? true;
+
+    return {
+      ...currentState,
+      ...safePersisted,
+      includePreRelease,
+      theme:
+        safePersisted.theme === 'light' || safePersisted.theme === 'dark'
+          ? safePersisted.theme
+          : 'dark',
+      repositories,
+      releases,
+      searchResults: repositories,
+      releaseSubscriptions: normalizeNumberSet(safePersisted.releaseSubscriptions),
+      readReleases: normalizeNumberSet(safePersisted.readReleases),
+      releaseExpandedRepositories: normalizeNumberSet(safePersisted.releaseExpandedRepositories),
     searchFilters: {
       ...initialSearchFilters,
       ...safePersisted.searchFilters,
@@ -651,11 +655,12 @@ export const useAppStore = create<AppState & AppActions>()(
       backendApiSecret: readSessionBackendSecret(),
       isSidebarCollapsed: false,
       readmeModalOpen: false,
-      releaseViewMode: 'timeline',
-      releaseSelectedFilters: [],
-      releaseSearchQuery: '',
-      releaseExpandedRepositories: new Set<number>(),
-      releaseIsRefreshing: false,
+       releaseViewMode: 'timeline',
+       releaseSelectedFilters: [],
+       releaseSearchQuery: '',
+       releaseExpandedRepositories: new Set<number>(),
+       releaseIsRefreshing: false,
+       includePreRelease: true,
 
       discoveryChannels: defaultDiscoveryChannels,
       discoveryRepos: { 'trending': [], 'hot-release': [], 'most-popular': [], 'topic': [], 'search': [] },
@@ -1180,7 +1185,8 @@ export const useAppStore = create<AppState & AppActions>()(
         return { releaseExpandedRepositories: newSet };
       }),
       setReleaseExpandedRepositories: (releaseExpandedRepositories) => set({ releaseExpandedRepositories }),
-      setReleaseIsRefreshing: (releaseIsRefreshing) => set({ releaseIsRefreshing }),
+       setReleaseIsRefreshing: (releaseIsRefreshing) => set({ releaseIsRefreshing }),
+       setIncludePreRelease: (includePreRelease) => set({ includePreRelease }),
 
     // Discovery actions
     setSelectedDiscoveryChannel: (selectedDiscoveryChannel) => set((state) => ({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,6 +53,7 @@ export interface Release {
   assets: ReleaseAsset[];
   zipball_url?: string;
   tarball_url?: string;
+  prerelease?: boolean;
   repository: {
     id: number;
     full_name: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,11 +23,13 @@ export interface Repository {
   analyzed_at?: string;
   analysis_failed?: boolean;
   subscribed_to_releases?: boolean;
-  custom_description?: string;
-  custom_tags?: string[];
-  custom_category?: string;
-  category_locked?: boolean;
-  last_edited?: string;
+   custom_description?: string;
+   custom_tags?: string[];
+   custom_category?: string;
+   category_locked?: boolean;
+   last_edited?: string;
+   lastReleaseSyncTime?: string;
+   hasFetchedReleases?: boolean;
 }
 
 export interface ReleaseAsset {

--- a/versions/version-info.xml
+++ b/versions/version-info.xml
@@ -279,4 +279,19 @@
     </changelog>
     <downloadUrl>https://github.com/AmintaCCCP/GithubStarsManager/releases/tag/v0.5.4</downloadUrl>
   </version>
+  <version>
+    <number>0.5.5</number>
+    <releaseDate>2026-04-27</releaseDate>
+    <changelog>
+      <item>Update Dialog Portal Fix: Fixed the update dialog backdrop mask being trapped inside the overflow container. The dialog now renders via React Portal at the document body level with proper z-index stacking. Added click-on-mask-to-dismiss behavior for better UX. (PR #112)</item>
+      <item>Banner Layout Improvements: Fixed banner button wrapping on narrow viewports. Removed invalid Tailwind classes and improved responsive layout with proper flex behavior. (PR #112)</item>
+      <item>Electron Focus Hijacking Fix: Replaced native alert()/confirm() dialogs with custom React components (Toast and ConfirmDialog), resolving focus trapping issues in Electron. (PR #117)</item>
+      <item>Category Lock Toggle Visibility: Improved the category lock toggle color differentiation in dark mode. Unlocked state now uses gray-600, locked state uses amber. Both states are clearly distinguishable. (PR #118)</item>
+      <item>AI Connection Test Enhancements: AI connection test now returns detailed, user-facing results including status and guidance messages. (PR #114)</item>
+      <item>AI Configuration Error Handling: AI analysis now properly blocks execution when API keys are empty or cannot be decrypted. Bulk AI config import now skips entries without usable keys and logs reasons. (PR #114)</item>
+      <item>Unified Error Messages and UI Polish: Consolidated AI configuration error messages and improved markdown image/GitHub link dark-mode styling. (PR #114)</item>
+      <item>Special thanks to @SummerRay160 for their outstanding contributions to this release!</item>
+    </changelog>
+    <downloadUrl>https://github.com/AmintaCCCP/GithubStarsManager/releases/tag/v0.5.5</downloadUrl>
+  </version>
 </versions>


### PR DESCRIPTION
Closes #119

## 修复内容

### 主要改动
1. **Header 同步按钮**：仅同步 star 仓库列表，不负责 Release（tooltip 已添加）
2. **移除 slice(0,20) 限制**：同步时覆盖所有已订阅 Release 的仓库
3. **增量刷新**：`since` 传入 GitHub API，真增量而非客户端过滤
4. **Release 刷新按钮**：旁加 `?` 图标，hover 提示告知负责 Release 刷新
5. **Pre-release 开关**：过滤器旁添加，应用于刷新结果
6. **失败仓库警告**：静默 `console.warn` 改为抛出错误，刷新结果汇总显示失败仓库
7. **速率限制检测**：`makeRequest` 解析 `X-RateLimit-*` 响应头，剩余不足时自动等待
8. **并发控制**：`controlledConcurrency = 3`，替代串行 `setTimeout`
9. **持久化增量状态**：每仓库 `lastReleaseSyncTime` + `hasFetchedReleases`
10. **平滑升级**：默认 `includePreRelease = true`，无新字段的旧数据自动走全量拉取

## 测试建议
- [ ] star 超过 20 个仓库，Header 同步后所有仓库都出现在列表中
- [ ] 订阅多个仓库的 Release，点击 Refresh 按钮，仅获取增量
- [ ] 新订阅仓库走全量拉取，已有数据的走增量
- [ ] 速率限制时自动等待重置
- [ ] Toggle pre-release 开关后刷新，验证过滤效果


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Include Pre-release" checkbox with help tooltip, and a disabled "New Filter" (+) button in the release timeline.
  * App now persists the "Include Pre-release" setting.

* **Improvements**
  * Refresh now fetches releases in bulk, respects the pre-release setting, and aggregates results with a warning when some repos fail.
  * Improved API rate-limit handling for more reliable fetching.
  * Sync status tooltip now notes releases are excluded from starred-repo metadata sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->