### PR TITLE
fix: 完善 Release 同步机制 (#119)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "github-stars-manager",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "github-stars-manager",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "dependencies": {
         "date-fns": "^3.3.1",
         "highlight.js": "^11.11.1",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -82,6 +82,8 @@ export const Header: React.FC = () => {
         if (existing) {
           return {
             ...newRepo,
+            has_fetched_releases: existing.has_fetched_releases,
+            last_release_fetch_time: existing.last_release_fetch_time,
             ai_summary: existing.ai_summary,
             ai_tags: existing.ai_tags,
             ai_platforms: existing.ai_platforms,

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -99,10 +99,8 @@ export const Header: React.FC = () => {
 
       setRepositories(mergedRepositories);
 
-      // 3. 获取Release信息
-      console.log('Fetching releases...');
-      const releases = await githubApi.getMultipleRepositoryReleases(mergedRepositories.slice(0, 20));
-      setReleases(releases);
+      // Note: Release fetching is now handled by the Refresh button in Release Timeline
+      // Header sync only syncs the starred repos list
 
       setLastSync(new Date().toISOString());
       console.log('Sync completed successfully');
@@ -367,7 +365,7 @@ export const Header: React.FC = () => {
                 onClick={handleSync}
                 disabled={isLoading}
                 className="p-1 rounded hover:bg-light-surface dark:hover:bg-white/5 transition-colors disabled:opacity-50"
-                title={t('同步仓库', 'Sync repositories')}
+                title={t('同步星标仓库列表（不包含Release）', 'Sync starred repos list (excludes Release)')}
               >
                 <RefreshCw className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`} />
               </button>

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -36,6 +36,8 @@ export const ReleaseTimeline: React.FC = () => {
     setReleaseSearchQuery,
     toggleReleaseExpandedRepository,
     setReleaseIsRefreshing,
+    includePreRelease,
+    setIncludePreRelease,
   } = useAppStore();
 
   const { toast, confirm } = useDialog();
@@ -301,6 +303,7 @@ export const ReleaseTimeline: React.FC = () => {
     setReleaseIsRefreshing(true);
     try {
       const githubApi = new GitHubApiService(githubToken);
+      // Only fetch releases for repos that are subscribed to releases
       const subscribedRepos = repositories.filter(repo => releaseSubscriptions.has(repo.id));
 
       if (subscribedRepos.length === 0) {
@@ -308,49 +311,46 @@ export const ReleaseTimeline: React.FC = () => {
         return;
       }
 
-      const allNewReleases: Release[] = [];
+      // Use the new getMultipleRepositoryReleases with options
+      const { releases: newReleases, failedRepos } = await githubApi.getMultipleRepositoryReleases(
+        subscribedRepos,
+        { includePreRelease }
+      );
 
-      const latestReleaseTime = releases.length > 0 
-        ? releases.reduce((max, r) => Math.max(max, new Date(r.published_at).getTime()), 0)
-        : 0;
-      const sinceTimestamp = latestReleaseTime > 0 ? new Date(latestReleaseTime).toISOString() : undefined;
-
-      for (const repo of subscribedRepos) {
-        const [owner, name] = repo.full_name.split('/');
-        
-        const hasExistingReleases = releases.some(r => r.repository.id === repo.id);
-        
-        let repoReleases: Release[];
-        if (!hasExistingReleases) {
-          repoReleases = await githubApi.getRepositoryReleases(owner, name, 1, 10);
-        } else {
-          repoReleases = await githubApi.getIncrementalRepositoryReleases(owner, name, sinceTimestamp, 10);
-        }
-        
-        repoReleases.forEach(release => {
-          release.repository.id = repo.id;
-        });
-        
-        allNewReleases.push(...repoReleases);
-        
-        await new Promise(resolve => setTimeout(resolve, 200));
-      }
-
-      const existingIds = new Set(useAppStore.getState().releases.map(r => r.id));
-      const actuallyNewCount = allNewReleases.filter(r => !existingIds.has(r.id)).length;
-
-      if (allNewReleases.length > 0) {
-        addReleases(allNewReleases);
-      }
-
+      // Update repository sync metadata
       const now = new Date().toISOString();
+      for (const repo of subscribedRepos) {
+        updateRepository({
+          ...repo,
+          has_fetched_releases: true,
+          last_release_fetch_time: now,
+        });
+      }
+
+      // Filter out existing releases and add new ones
+      const existingIds = new Set(useAppStore.getState().releases.map(r => r.id));
+      const actuallyNewReleases = newReleases.filter(r => !existingIds.has(r.id));
+      const actuallyNewCount = actuallyNewReleases.length;
+
+      if (actuallyNewReleases.length > 0) {
+        addReleases(actuallyNewReleases);
+      }
+
       setLastRefreshTime(now);
 
-      const message = language === 'zh'
-        ? `刷新完成！发现 ${actuallyNewCount} 个新Release。`
-        : `Refresh completed! Found ${actuallyNewCount} new releases.`;
+      // Build success message with failed repos info
+      let message: string;
+      if (failedRepos.length > 0) {
+        message = language === 'zh'
+          ? `刷新完成！发现 ${actuallyNewCount} 个新Release，${failedRepos.length} 个仓库刷新失败。`
+          : `Refresh completed! Found ${actuallyNewCount} new releases, ${failedRepos.length} repos failed.`;
+      } else {
+        message = language === 'zh'
+          ? `刷新完成！发现 ${actuallyNewCount} 个新Release。`
+          : `Refresh completed! Found ${actuallyNewCount} new releases.`;
+      }
 
-      toast(message, 'success');
+      toast(message, actuallyNewCount > 0 ? 'success' : 'info');
     } catch (error) {
       console.error('Refresh failed:', error);
       const errorMessage = language === 'zh'
@@ -527,19 +527,35 @@ export const ReleaseTimeline: React.FC = () => {
                }
              </p>
         
-        {/* 刷新按钮 - 在有订阅仓库时显示 */}
+        {/* Pre-release toggle + Refresh button */}
         {subscribedRepoCount > 0 && (
-           <div className="mb-6">
+           <div className="mb-6 flex flex-col items-center gap-3">
+             {/* Pre-release toggle */}
+             <label className="flex items-center gap-2 cursor-pointer select-none">
+               <div
+                 onClick={() => setIncludePreRelease(!includePreRelease)}
+                 className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${includePreRelease ? 'bg-brand-indigo' : 'bg-gray-300 dark:bg-gray-600'}`}
+               >
+                 <span
+                   className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${includePreRelease ? 'translate-x-[18px]' : 'translate-x-[2px]'}`}
+                 />
+               </div>
+               <span className="text-sm text-gray-600 dark:text-text-secondary">
+                 {t('包含 Pre-release', 'Include Pre-release')}
+               </span>
+             </label>
+
+             {/* Refresh button */}
              <button
                onClick={handleRefresh}
                disabled={releaseIsRefreshing}
-               className="flex items-center space-x-2 px-6 py-3 bg-brand-indigo text-white rounded-lg hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed mx-auto"
+               className="flex items-center space-x-2 px-6 py-3 bg-brand-indigo text-white rounded-lg hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
              >
                <RefreshCw className={`w-5 h-5 ${releaseIsRefreshing ? 'animate-spin' : ''}`} />
                <span>{releaseIsRefreshing ? t('刷新中...', 'Refreshing...') : t('刷新Release', 'Refresh Releases')}</span>
              </button>
             {lastRefreshTime && (
-              <p className="text-sm text-gray-500 dark:text-text-tertiary mt-2">
+              <p className="text-sm text-gray-500 dark:text-text-tertiary">
                 {t('上次刷新:', 'Last refresh:')} {formatDistanceToNow(new Date(lastRefreshTime), { addSuffix: true })}
               </p>
             )}
@@ -597,6 +613,21 @@ export const ReleaseTimeline: React.FC = () => {
                 {t('上次刷新:', 'Last refresh:')} {formatDistanceToNow(new Date(lastRefreshTime), { addSuffix: true })}
               </span>
             )}
+
+            {/* Pre-release toggle */}
+            <label className="flex items-center gap-1.5 cursor-pointer select-none">
+              <div
+                onClick={() => setIncludePreRelease(!includePreRelease)}
+                className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${includePreRelease ? 'bg-brand-indigo' : 'bg-gray-300 dark:bg-gray-600'}`}
+              >
+                <span
+                  className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${includePreRelease ? 'translate-x-[18px]' : 'translate-x-[2px]'}`}
+                />
+              </div>
+              <span className="text-xs text-gray-600 dark:text-text-secondary hidden sm:inline">
+                {t('Pre', 'Pre')}
+              </span>
+            </label>
 
             {/* Refresh Button */}
             <button

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -181,9 +181,12 @@ export const ReleaseTimeline: React.FC = () => {
     return links;
   }, []);
 
-  const subscribedReleases = useMemo(() => 
-    releases.filter(release => releaseSubscriptions.has(release.repository.id)),
-    [releases, releaseSubscriptions]
+  const subscribedReleases = useMemo(() =>
+    releases.filter(release =>
+      releaseSubscriptions.has(release.repository.id) &&
+      (includePreRelease || !release.prerelease)
+    ),
+    [releases, releaseSubscriptions, includePreRelease]
   );
 
   // 预计算每个 release 的下载链接和过滤后的链接
@@ -317,9 +320,13 @@ export const ReleaseTimeline: React.FC = () => {
         { includePreRelease }
       );
 
-      // Update repository sync metadata
+      // Update repository sync metadata only for repos that succeeded
       const now = new Date().toISOString();
+      const failedRepoIds = new Set(failedRepos.map(repo => repo.repoId));
       for (const repo of subscribedRepos) {
+        if (failedRepoIds.has(repo.id)) {
+          continue;
+        }
         updateRepository({
           ...repo,
           has_fetched_releases: true,
@@ -532,14 +539,17 @@ export const ReleaseTimeline: React.FC = () => {
            <div className="mb-6 flex flex-col items-center gap-3">
              {/* Pre-release toggle */}
              <label className="flex items-center gap-2 cursor-pointer select-none">
-               <div
+               <button
+                 type="button"
+                 role="switch"
+                 aria-checked={includePreRelease}
                  onClick={() => setIncludePreRelease(!includePreRelease)}
                  className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${includePreRelease ? 'bg-brand-indigo' : 'bg-gray-300 dark:bg-gray-600'}`}
                >
                  <span
                    className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${includePreRelease ? 'translate-x-[18px]' : 'translate-x-[2px]'}`}
                  />
-               </div>
+               </button>
                <span className="text-sm text-gray-600 dark:text-text-secondary">
                  {t('包含 Pre-release', 'Include Pre-release')}
                </span>
@@ -616,14 +626,17 @@ export const ReleaseTimeline: React.FC = () => {
 
             {/* Pre-release toggle */}
             <label className="flex items-center gap-1.5 cursor-pointer select-none">
-              <div
+              <button
+                type="button"
+                role="switch"
+                aria-checked={includePreRelease}
                 onClick={() => setIncludePreRelease(!includePreRelease)}
                 className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${includePreRelease ? 'bg-brand-indigo' : 'bg-gray-300 dark:bg-gray-600'}`}
               >
                 <span
                   className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${includePreRelease ? 'translate-x-[18px]' : 'translate-x-[2px]'}`}
                 />
-              </div>
+              </button>
               <span className="text-xs text-gray-600 dark:text-text-secondary hidden sm:inline">
                 {t('Pre', 'Pre')}
               </span>

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -278,19 +278,33 @@ export class GitHubApiService {
             // New subscription: full sync (fetch up to 30)
             releases = await this.fetchAllReleasesForRepo(owner, name, 30);
           } else {
-            // Already synced: incremental sync (fetch 10, filter client-side)
+            // Already synced: incremental sync with pagination until we cross the watermark
             const sinceTime = repo.last_release_fetch_time
               ? new Date(repo.last_release_fetch_time)
               : null;
 
-            releases = await this.getRepositoryReleases(owner, name, 1, 10);
+            let page = 1;
+            releases = [];
+            while (true) {
+              const batch = await this.getRepositoryReleases(owner, name, page, 10);
 
-            // Client-side filtering by time
-            if (sinceTime) {
-              releases = releases.filter(r => {
-                const publishedTime = new Date(r.published_at);
-                return publishedTime > sinceTime;
-              });
+              if (batch.length === 0) break;
+
+              const fresh = sinceTime
+                ? batch.filter(r => new Date(r.published_at) > sinceTime)
+                : batch;
+
+              releases.push(...fresh);
+
+              // Stop if we hit the watermark or ran out of data
+              if (
+                batch.length < 10 ||
+                (sinceTime && batch.some(r => new Date(r.published_at) <= sinceTime))
+              ) {
+                break;
+              }
+
+              page++;
             }
           }
 

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -60,7 +60,23 @@ export class GitHubApiService {
       const waitMs = (this.rateLimitReset * 1000) - Date.now();
       if (waitMs > 0) {
         console.log(`Rate limit low (${this.rateLimitRemaining}), waiting ${Math.ceil(waitMs / 1000)}s for reset...`);
-        await new Promise(resolve => setTimeout(resolve, waitMs + 1000));
+        // Honor abort signal during rate limit wait
+        await new Promise<void>((resolve, reject) => {
+          const timeoutId = setTimeout(() => resolve(), waitMs + 1000);
+          const signalHandler = () => {
+            clearTimeout(timeoutId);
+            reject(new Error('Aborted'));
+          };
+          signal?.addEventListener('abort', signalHandler);
+          // Also check if already aborted
+          if (signal?.aborted) {
+            clearTimeout(timeoutId);
+            signal?.removeEventListener('abort', signalHandler);
+            reject(new Error('Aborted'));
+          }
+        }).catch(err => {
+          if (err.message === 'Aborted') throw err;
+        });
       }
     }
 
@@ -208,15 +224,16 @@ export class GitHubApiService {
   }
 
   /**
-   * Fetch all releases for a repository with pagination (up to 30)
+   * Fetch all releases for a repository with pagination.
+   * New repos (never synced) use this for full sync - paginates until exhausted.
    */
-  async fetchAllReleasesForRepo(owner: string, repo: string, perPage = 30): Promise<Release[]> {
+  async fetchAllReleasesForRepo(owner: string, repo: string): Promise<Release[]> {
     const allReleases: Release[] = [];
     let page = 1;
 
-    while (allReleases.length < perPage) {
+    while (true) {
       const batch = await this.makeRequest<Release[]>(
-        `/repos/${owner}/${repo}/releases?page=${page}&per_page=${Math.min(perPage, 30)}`
+        `/repos/${owner}/${repo}/releases?page=${page}&per_page=30`
       );
 
       if (batch.length === 0) break;
@@ -241,14 +258,14 @@ export class GitHubApiService {
 
       allReleases.push(...mapped);
 
-      if (batch.length < perPage) break;
+      if (batch.length < 30) break;
       page++;
 
       // Rate limiting protection between pages
       await new Promise(resolve => setTimeout(resolve, 100));
     }
 
-    return allReleases.slice(0, perPage);
+    return allReleases;
   }
 
   async getMultipleRepositoryReleases(
@@ -276,7 +293,7 @@ export class GitHubApiService {
 
           if (!repo.has_fetched_releases) {
             // New subscription: full sync (fetch up to 30)
-            releases = await this.fetchAllReleasesForRepo(owner, name, 30);
+            releases = await this.fetchAllReleasesForRepo(owner, name);
           } else {
             // Already synced: incremental sync with pagination until we cross the watermark
             const sinceTime = repo.last_release_fetch_time

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -1,11 +1,11 @@
-import { 
-  Repository, 
-  Release, 
-  GitHubUser, 
-  DiscoveryPlatform, 
-  ProgrammingLanguage, 
-  SortBy, 
-  SortOrder, 
+import {
+  Repository,
+  Release,
+  GitHubUser,
+  DiscoveryPlatform,
+  ProgrammingLanguage,
+  SortBy,
+  SortOrder,
   PaginatedDiscoveryRepositories,
   DiscoveryChannelId,
   TopicCategory,
@@ -35,16 +35,35 @@ interface GitHubSearchRepoResponse {
   total_count: number;
 }
 
+export interface ReleaseFetchOptions {
+  includePreRelease?: boolean;
+}
+
+export interface MultipleReleasesResult {
+  releases: Release[];
+  failedRepos: { repoId: number; full_name: string; error: string }[];
+}
 
 
 export class GitHubApiService {
   private token: string;
+  private rateLimitRemaining: number | null = null;
+  private rateLimitReset: number | null = null;
 
   constructor(token: string) {
     this.token = token;
   }
 
   private async makeRequest<T>(endpoint: string, options: RequestInit = {}, signal?: AbortSignal): Promise<T> {
+    // Check rate limit before making request
+    if (this.rateLimitRemaining !== null && this.rateLimitRemaining < 100 && this.rateLimitReset !== null) {
+      const waitMs = (this.rateLimitReset * 1000) - Date.now();
+      if (waitMs > 0) {
+        console.log(`Rate limit low (${this.rateLimitRemaining}), waiting ${Math.ceil(waitMs / 1000)}s for reset...`);
+        await new Promise(resolve => setTimeout(resolve, waitMs + 1000));
+      }
+    }
+
     const response = await fetch(`${GITHUB_API_BASE}${endpoint}`, {
       ...options,
       signal,
@@ -56,9 +75,25 @@ export class GitHubApiService {
       },
     });
 
+    // Parse rate limit headers
+    const remaining = response.headers.get('X-RateLimit-Remaining');
+    const reset = response.headers.get('X-RateLimit-Reset');
+    if (remaining !== null) {
+      this.rateLimitRemaining = parseInt(remaining, 10);
+    }
+    if (reset !== null) {
+      this.rateLimitReset = parseInt(reset, 10);
+    }
+
     if (!response.ok) {
       if (response.status === 401) {
         throw new Error('GitHub token expired or invalid');
+      }
+      if (response.status === 403 && this.rateLimitRemaining === 0) {
+        const resetDate = this.rateLimitReset
+          ? new Date(this.rateLimitReset * 1000).toLocaleString()
+          : 'unknown';
+        throw new Error(`GitHub API rate limit exceeded. Resets at ${resetDate}`);
       }
       throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
     }
@@ -78,7 +113,7 @@ export class GitHubApiService {
         return item;
       }) as T;
     }
-    
+
     return data;
   }
 
@@ -106,12 +141,12 @@ export class GitHubApiService {
     while (true) {
       const repos = await this.getStarredRepositories(page, perPage);
       if (repos.length === 0) break;
-      
+
       allRepos = [...allRepos, ...repos];
-      
+
       if (repos.length < perPage) break;
       page++;
-      
+
       // Rate limiting protection
       await new Promise(resolve => setTimeout(resolve, 100));
     }
@@ -148,7 +183,7 @@ export class GitHubApiService {
       const releases = await this.makeRequest<Release[]>(
         `/repos/${owner}/${repo}/releases?page=${page}&per_page=${perPage}`
       );
-      
+
       return releases.map(release => ({
         id: release.id,
         tag_name: release.tag_name,
@@ -159,6 +194,7 @@ export class GitHubApiService {
         assets: release.assets || [],
         zipball_url: release.zipball_url,
         tarball_url: release.tarball_url,
+        prerelease: release.prerelease ?? false,
         repository: {
           id: 0,
           full_name: `${owner}/${repo}`,
@@ -167,46 +203,144 @@ export class GitHubApiService {
       }));
     } catch (error) {
       console.warn(`Failed to fetch releases for ${owner}/${repo}:`, error);
-      return [];
+      throw error; // Re-throw to let caller handle
     }
   }
 
-  async getMultipleRepositoryReleases(repositories: Repository[]): Promise<Release[]> {
+  /**
+   * Fetch all releases for a repository with pagination (up to 30)
+   */
+  async fetchAllReleasesForRepo(owner: string, repo: string, perPage = 30): Promise<Release[]> {
     const allReleases: Release[] = [];
-    
-    for (const repo of repositories) {
-      const [owner, name] = repo.full_name.split('/');
-      const releases = await this.getRepositoryReleases(owner, name, 1, 5);
-      
-      // Add repository info to releases
-      releases.forEach(release => {
-        release.repository.id = repo.id;
-      });
-      
-      allReleases.push(...releases);
-      
-      // Rate limiting protection
-      await new Promise(resolve => setTimeout(resolve, 150));
+    let page = 1;
+
+    while (allReleases.length < perPage) {
+      const batch = await this.makeRequest<Release[]>(
+        `/repos/${owner}/${repo}/releases?page=${page}&per_page=${Math.min(perPage, 30)}`
+      );
+
+      if (batch.length === 0) break;
+
+      const mapped = batch.map(release => ({
+        id: release.id,
+        tag_name: release.tag_name,
+        name: release.name || release.tag_name,
+        body: release.body || '',
+        published_at: release.published_at,
+        html_url: release.html_url,
+        assets: release.assets || [],
+        zipball_url: release.zipball_url,
+        tarball_url: release.tarball_url,
+        prerelease: release.prerelease ?? false,
+        repository: {
+          id: 0,
+          full_name: `${owner}/${repo}`,
+          name: repo,
+        },
+      }));
+
+      allReleases.push(...mapped);
+
+      if (batch.length < perPage) break;
+      page++;
+
+      // Rate limiting protection between pages
+      await new Promise(resolve => setTimeout(resolve, 100));
     }
 
+    return allReleases.slice(0, perPage);
+  }
+
+  async getMultipleRepositoryReleases(
+    repositories: Repository[],
+    options: ReleaseFetchOptions = {}
+  ): Promise<MultipleReleasesResult> {
+    const { includePreRelease = true } = options;
+    const allReleases: Release[] = [];
+    const failedRepos: { repoId: number; full_name: string; error: string }[] = [];
+
+    // Controlled concurrency: process 3 repos at a time
+    const concurrency = 3;
+    let index = 0;
+
+    const workers = Array.from({ length: Math.min(concurrency, repositories.length) }, async () => {
+      while (true) {
+        const currentIndex = index++;
+        if (currentIndex >= repositories.length) break;
+
+        const repo = repositories[currentIndex];
+        const [owner, name] = repo.full_name.split('/');
+
+        try {
+          let releases: Release[];
+
+          if (!repo.has_fetched_releases) {
+            // New subscription: full sync (fetch up to 30)
+            releases = await this.fetchAllReleasesForRepo(owner, name, 30);
+          } else {
+            // Already synced: incremental sync (fetch 10, filter client-side)
+            const sinceTime = repo.last_release_fetch_time
+              ? new Date(repo.last_release_fetch_time)
+              : null;
+
+            releases = await this.getRepositoryReleases(owner, name, 1, 10);
+
+            // Client-side filtering by time
+            if (sinceTime) {
+              releases = releases.filter(r => {
+                const publishedTime = new Date(r.published_at);
+                return publishedTime > sinceTime;
+              });
+            }
+          }
+
+          // Add repository info to releases
+          releases.forEach(release => {
+            release.repository.id = repo.id;
+          });
+
+          // Filter by pre-release setting
+          if (!includePreRelease) {
+            releases = releases.filter(r => !r.prerelease);
+          }
+
+          allReleases.push(...releases);
+
+        } catch (error) {
+          failedRepos.push({
+            repoId: repo.id,
+            full_name: repo.full_name,
+            error: error instanceof Error ? error.message : String(error)
+          });
+        }
+
+        // Rate limiting protection between repos
+        await new Promise(resolve => setTimeout(resolve, 150));
+      }
+    });
+
+    await Promise.all(workers);
+
     // Sort by published date (newest first)
-    return allReleases.sort((a, b) => 
+    const sortedReleases = allReleases.sort((a, b) =>
       new Date(b.published_at).getTime() - new Date(a.published_at).getTime()
     );
+
+    return { releases: sortedReleases, failedRepos };
   }
 
   // 新增：获取仓库的增量releases（基于时间戳）
   async getIncrementalRepositoryReleases(
-    owner: string, 
-    repo: string, 
-    since?: string, 
+    owner: string,
+    repo: string,
+    since?: string,
     perPage = 10
   ): Promise<Release[]> {
     try {
       const endpoint = `/repos/${owner}/${repo}/releases?per_page=${perPage}`;
-      
+
       const releases = await this.makeRequest<Release[]>(endpoint);
-      
+
       const mappedReleases = releases.map(release => ({
         id: release.id,
         tag_name: release.tag_name,
@@ -217,6 +351,7 @@ export class GitHubApiService {
         assets: release.assets || [],
         zipball_url: release.zipball_url,
         tarball_url: release.tarball_url,
+        prerelease: release.prerelease ?? false,
         repository: {
           id: 0,
           full_name: `${owner}/${repo}`,
@@ -227,7 +362,7 @@ export class GitHubApiService {
       // 如果提供了since时间戳，只返回更新的releases
       if (since) {
         const sinceDate = new Date(since);
-        return mappedReleases.filter(release => 
+        return mappedReleases.filter(release =>
           new Date(release.published_at) > sinceDate
         );
       }
@@ -589,7 +724,7 @@ export class GitHubApiService {
               pushed_at: string;
             }>(`/repos/${owner}/${repo}`);
             r.id = data.id;
-            r.stargazers_count = data.stargazers_count ?? r.stargazers_count;
+            r.stargazers_count = data.stargizers_count ?? r.stargazers_count;
             r.forks_count = data.forks_count ?? r.forks_count;
             r.forks = data.forks ?? r.forks;
             r.language = data.language ?? r.language;
@@ -631,7 +766,7 @@ export class GitHubApiService {
   ): Promise<PaginatedDiscoveryRepositories> {
     const fourteenDaysAgo = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
     const platformQuery = this.buildPlatformQuery(platform);
-    
+
     let query = `stars:>10 archived:false pushed:>=${fourteenDaysAgo}`;
     if (platformQuery) {
       query += ` ${platformQuery}`;
@@ -664,7 +799,7 @@ export class GitHubApiService {
     const sixMonthsAgo = new Date(Date.now() - 6 * 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
     const oneYearAgo = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
     const platformQuery = this.buildPlatformQuery(platform);
-    
+
     let query = `stars:>1000 archived:false created:<${sixMonthsAgo} pushed:>=${oneYearAgo}`;
     if (platformQuery) {
       query += ` ${platformQuery}`;
@@ -696,7 +831,7 @@ export class GitHubApiService {
     perPage: number = 20
   ): Promise<PaginatedDiscoveryRepositories> {
     const platformQuery = this.buildPlatformQuery(platform);
-    
+
     let query = `${searchKeywords} in:name,description,topics stars:>10 archived:false`;
     if (platformQuery) {
       query += ` ${platformQuery}`;
@@ -795,6 +930,6 @@ export const createGitHubOAuthUrl = (clientId: string, redirectUri: string): str
     scope: 'read:user user:email repo',
     state: Math.random().toString(36).substring(7),
   });
-  
+
   return `https://github.com/login/oauth/authorize?${params.toString()}`;
 };

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -724,7 +724,7 @@ export class GitHubApiService {
               pushed_at: string;
             }>(`/repos/${owner}/${repo}`);
             r.id = data.id;
-            r.stargazers_count = data.stargizers_count ?? r.stargazers_count;
+            r.stargazers_count = data.stargazers_count ?? r.stargazers_count;
             r.forks_count = data.forks_count ?? r.forks_count;
             r.forks = data.forks ?? r.forks;
             r.language = data.language ?? r.language;

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -168,6 +168,7 @@ interface AppActions {
   toggleReleaseExpandedRepository: (repoId: number) => void;
   setReleaseExpandedRepositories: (repoIds: Set<number>) => void;
   setReleaseIsRefreshing: (refreshing: boolean) => void;
+  setIncludePreRelease: (include: boolean) => void;
 
   // Discovery actions
   setSelectedDiscoveryChannel: (channel: DiscoveryChannelId) => void;
@@ -279,6 +280,24 @@ const normalizePersistedState = (
   const repositories = Array.isArray(safePersisted.repositories) ? safePersisted.repositories : [];
   const releases = Array.isArray(safePersisted.releases) ? safePersisted.releases : [];
 
+  // Migration for old users: mark repos with existing releases as already synced
+  const migratedRepositories = repositories.map(repo => {
+    const hasExistingRelease = releases.some(r => r.repository?.id === repo.id);
+    if (hasExistingRelease && !repo.has_fetched_releases) {
+      return {
+        ...repo,
+        has_fetched_releases: true,
+        last_release_fetch_time: repo.last_release_fetch_time || new Date().toISOString()
+      };
+    }
+    return repo;
+  });
+
+  // Default includePreRelease to true if not set (backward compatibility)
+  const includePreRelease = safePersisted.includePreRelease !== undefined
+    ? safePersisted.includePreRelease
+    : true;
+
   return {
     ...currentState,
     ...safePersisted,
@@ -286,12 +305,13 @@ const normalizePersistedState = (
       safePersisted.theme === 'light' || safePersisted.theme === 'dark'
         ? safePersisted.theme
         : 'dark',
-    repositories,
+    repositories: migratedRepositories,
     releases,
-    searchResults: repositories,
+    searchResults: migratedRepositories,
     releaseSubscriptions: normalizeNumberSet(safePersisted.releaseSubscriptions),
     readReleases: normalizeNumberSet(safePersisted.readReleases),
     releaseExpandedRepositories: normalizeNumberSet(safePersisted.releaseExpandedRepositories),
+    includePreRelease,
     searchFilters: {
       ...initialSearchFilters,
       ...safePersisted.searchFilters,
@@ -660,6 +680,7 @@ export const useAppStore = create<AppState & AppActions>()(
       releaseSearchQuery: '',
       releaseExpandedRepositories: new Set<number>(),
       releaseIsRefreshing: false,
+      includePreRelease: true,
 
       discoveryChannels: defaultDiscoveryChannels,
       discoveryRepos: { 'trending': [], 'hot-release': [], 'most-popular': [], 'topic': [], 'search': [] },
@@ -1188,6 +1209,7 @@ export const useAppStore = create<AppState & AppActions>()(
       }),
       setReleaseExpandedRepositories: (releaseExpandedRepositories) => set({ releaseExpandedRepositories }),
       setReleaseIsRefreshing: (releaseIsRefreshing) => set({ releaseIsRefreshing }),
+      setIncludePreRelease: (includePreRelease) => set({ includePreRelease }),
 
     // Discovery actions
     setSelectedDiscoveryChannel: (selectedDiscoveryChannel) => set((state) => ({

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -236,6 +236,7 @@ type PersistedAppState = Partial<
     | 'releaseViewMode'
     | 'releaseSelectedFilters'
     | 'releaseSearchQuery'
+    | 'includePreRelease'
     | 'discoveryChannels'
     | 'discoveryRepos'
     | 'discoveryLastRefresh'
@@ -284,10 +285,15 @@ const normalizePersistedState = (
   const migratedRepositories = repositories.map(repo => {
     const hasExistingRelease = releases.some(r => r.repository?.id === repo.id);
     if (hasExistingRelease && !repo.has_fetched_releases) {
+      // Backfill last_release_fetch_time from the latest persisted release timestamp
+      const repoReleases = releases.filter(r => r.repository?.id === repo.id);
+      const latestReleaseTime = repoReleases.length > 0
+        ? Math.max(...repoReleases.map(r => new Date(r.published_at).getTime()))
+        : null;
       return {
         ...repo,
         has_fetched_releases: true,
-        last_release_fetch_time: repo.last_release_fetch_time || new Date().toISOString()
+        last_release_fetch_time: repo.last_release_fetch_time || (latestReleaseTime ? new Date(latestReleaseTime).toISOString() : new Date().toISOString())
       };
     }
     return repo;
@@ -1356,6 +1362,7 @@ export const useAppStore = create<AppState & AppActions>()(
         releaseSelectedFilters: state.releaseSelectedFilters,
         releaseSearchQuery: state.releaseSearchQuery,
         releaseExpandedRepositories: Array.from(state.releaseExpandedRepositories),
+        includePreRelease: state.includePreRelease,
 
       // 持久化发现设置
       discoveryChannels: state.discoveryChannels,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -28,6 +28,8 @@ export interface Repository {
   custom_category?: string;
   category_locked?: boolean;
   last_edited?: string;
+  last_release_fetch_time?: string;  // ISO timestamp, for incremental sync
+  has_fetched_releases?: boolean;   // whether this repo has been synced for releases
 }
 
 export interface ReleaseAsset {
@@ -51,6 +53,7 @@ export interface Release {
   assets: ReleaseAsset[];
   zipball_url?: string;
   tarball_url?: string;
+  prerelease?: boolean;
   repository: {
     id: number;
     full_name: string;
@@ -194,6 +197,7 @@ export interface AppState {
   releaseSearchQuery: string;
   releaseExpandedRepositories: Set<number>;
   releaseIsRefreshing: boolean;
+  includePreRelease: boolean;  // whether to include pre-release in refresh
 
   // Discovery
   discoveryChannels: DiscoveryChannel[];

--- a/versions/version-info.xml
+++ b/versions/version-info.xml
@@ -279,4 +279,19 @@
     </changelog>
     <downloadUrl>https://github.com/AmintaCCCP/GithubStarsManager/releases/tag/v0.5.4</downloadUrl>
   </version>
+  <version>
+    <number>0.5.5</number>
+    <releaseDate>2026-04-27</releaseDate>
+    <changelog>
+      <item>Update Dialog Portal Fix: Fixed the update dialog backdrop mask being trapped inside the overflow container. The dialog now renders via React Portal at the document body level with proper z-index stacking. Added click-on-mask-to-dismiss behavior for better UX. (PR #112)</item>
+      <item>Banner Layout Improvements: Fixed banner button wrapping on narrow viewports. Removed invalid Tailwind classes and improved responsive layout with proper flex behavior. (PR #112)</item>
+      <item>Electron Focus Hijacking Fix: Replaced native alert()/confirm() dialogs with custom React components (Toast and ConfirmDialog), resolving focus trapping issues in Electron. (PR #117)</item>
+      <item>Category Lock Toggle Visibility: Improved the category lock toggle color differentiation in dark mode. Unlocked state now uses gray-600, locked state uses amber. Both states are clearly distinguishable. (PR #118)</item>
+      <item>AI Connection Test Enhancements: AI connection test now returns detailed, user-facing results including status and guidance messages. (PR #114)</item>
+      <item>AI Configuration Error Handling: AI analysis now properly blocks execution when API keys are empty or cannot be decrypted. Bulk AI config import now skips entries without usable keys and logs reasons. (PR #114)</item>
+      <item>Unified Error Messages and UI Polish: Consolidated AI configuration error messages and improved markdown image/GitHub link dark-mode styling. (PR #114)</item>
+      <item>Special thanks to @SummerRay160 for their outstanding contributions to this release!</item>
+    </changelog>
+    <downloadUrl>https://github.com/AmintaCCCP/GithubStarsManager/releases/tag/v0.5.5</downloadUrl>
+  </version>
 </versions>


### PR DESCRIPTION
## 修复内容

### 问题背景
Issue #119 描述了 Release 同步的多个问题：首次同步只覆盖前20个仓库、增量更新机制有缺陷、刷新失败静默跳过等。

### 主要改动

1. **Header 同步按钮重构** (`Header.tsx`)
   - 移除 Release 获取逻辑，仅同步星标仓库列表
   - 更新 tooltip 说明不包含 Release

2. **增量同步机制** (`githubApi.ts`)
   - 重构 `getMultipleRepositoryReleases` 支持增量同步
   - 新增 `fetchAllReleasesForRepo` 分页拉取最多30条
   - 新仓库全量拉取，已有数据的仓库拉10条后客户端过滤
   - 支持 `includePreRelease` 选项控制是否包含预发布版

3. **速率限制处理** (`githubApi.ts`)
   - `makeRequest` 检测 `X-RateLimit-*` 响应头
   - 配额低于100时自动等待至 reset 时间 + 1s
   - 触发限制时抛出明确错误信息

4. **Pre-release 开关** (`ReleaseTimeline.tsx`)
   - 刷新按钮左侧添加 toggle switch
   - 默认开启，状态持久化到 localStorage

5. **老数据迁移** (`useAppStore.ts`)
   - 已有 release 数据的仓库标记 `has_fetched_releases = true`
   - 默认 `includePreRelease = true` 保持向后兼容

6. **失败汇总提示**
   - 刷新完成后显示失败仓库数量

### 测试建议
- [ ] star 超过 20 个仓库，验证 Header 同步不再获取 Release
- [ ] 订阅多个仓库的 Release，点击刷新，验证所有订阅仓库都被刷新
- [ ] 验证 Pre-release 开关可以正常过滤结果
- [ ] 验证老用户升级后行为不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-release toggle in header and empty-state; preference persisted across sessions.
  * Option to include/exclude prereleases when refreshing subscribed releases.

* **Improvements**
  * Bulk, concurrent release refreshes with deduplication and clearer failure counts.
  * Sync button tooltip clarified to state it excludes release fetching.
  * Improved rate-limit handling to reduce transient failures.

* **Bug Fixes / Data Migration**
  * Backfilled release-sync metadata for existing repos to enable incremental refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->