### PR TITLE
feat: 添加 Fork 复刻管理页面

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "github-stars-manager",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "github-stars-manager",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "dependencies": {
         "@types/query-string": "^6.2.0",
         "date-fns": "^3.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { SearchBar } from './components/SearchBar';
 import { RepositoryList } from './components/RepositoryList';
 import { CategorySidebar } from './components/CategorySidebar';
 import { ReleaseTimeline } from './components/ReleaseTimeline';
+import { ForkTimeline } from './components/ForkTimeline';
 import { SettingsPanel } from './components/SettingsPanel';
 import { DiscoveryView } from './components/DiscoveryView';
 import { BackToTop } from './components/BackToTop';
@@ -46,6 +47,9 @@ RepositoriesView.displayName = 'RepositoriesView';
 
 const ReleasesView = React.memo(() => <ReleaseTimeline />);
 ReleasesView.displayName = 'ReleasesView';
+
+const ForksView = React.memo(() => <ForkTimeline />);
+ForksView.displayName = 'ForksView';
 
 const SettingsView = React.memo(() => <SettingsPanel />);
 SettingsView.displayName = 'SettingsView';
@@ -117,6 +121,8 @@ function App() {
         );
       case 'releases':
         return <ReleasesView />;
+      case 'forks':
+        return <ForksView />;
       case 'subscription':
         return (
           <ErrorBoundary>

--- a/src/components/ForkCard.tsx
+++ b/src/components/ForkCard.tsx
@@ -15,6 +15,7 @@ interface ForkCardProps {
   isLoadingWorkflows: boolean;
   isSyncing: boolean;
   isRunningWorkflow: boolean;
+  needsSync: boolean; // true = out-of-date, can sync; false = already up-to-date
   language: 'zh' | 'en';
 }
 
@@ -30,12 +31,12 @@ const ForkCard: React.FC<ForkCardProps> = memo(({
   isLoadingWorkflows,
   isSyncing,
   isRunningWorkflow,
+  needsSync,
   language,
 }) => {
   const t = useCallback((zh: string, en: string) => language === 'zh' ? zh : en, [language]);
 
   const sourceFullName = fork.source?.full_name || fork.parent?.full_name || '';
-  const sourceName = fork.source?.name || fork.parent?.name || '';
   // A repo is only a fork if it has a parent/source OR the fork boolean is true
   const isFork = !!fork.parent || !!fork.source || fork.fork === true;
 
@@ -66,11 +67,6 @@ const ForkCard: React.FC<ForkCardProps> = memo(({
                 {fork.language && (
                   <span className="px-1.5 py-0.5 bg-gray-100 dark:bg-white/[0.06] text-gray-700 dark:text-text-secondary text-xs font-medium rounded-md border border-black/[0.06] dark:border-white/[0.04] shrink-0">
                     {fork.language}
-                  </span>
-                )}
-                {!isFork && (
-                  <span className="px-1.5 py-0.5 bg-gray-200 dark:bg-white/[0.06] text-gray-600 dark:text-text-tertiary text-xs font-medium rounded-md border border-black/[0.06] dark:border-white/[0.04] shrink-0">
-                    {t('非Fork', 'Not Fork')}
                   </span>
                 )}
               </div>
@@ -126,6 +122,7 @@ const ForkCard: React.FC<ForkCardProps> = memo(({
                 onClick={(e) => {
                   e.stopPropagation();
                   onToggleWorkflows();
+                  onMarkAsRead();
                 }}
                 className={`flex items-center space-x-0.5 px-1.5 py-1 rounded transition-all duration-200 whitespace-nowrap ${
                   isWorkflowsExpanded
@@ -141,20 +138,23 @@ const ForkCard: React.FC<ForkCardProps> = memo(({
                 {isWorkflowsExpanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
               </button>
 
-              {/* Sync Upstream button — only enabled for actual forks */}
+              {/* Sync Upstream button — enabled only when fork needs sync (out-of-date) */}
               <button
                 onClick={(e) => {
                   e.stopPropagation();
                   onSyncUpstream();
+                  onMarkAsRead();
                 }}
-                disabled={isSyncing || !isFork}
+                disabled={isSyncing || !needsSync}
                 className={`p-1 rounded transition-colors disabled:cursor-not-allowed ${
-                  isFork
+                  needsSync
                     ? 'bg-light-surface text-gray-700 dark:bg-white/[0.04] dark:text-text-secondary hover:bg-gray-200 hover:text-gray-900 dark:hover:bg-white/[0.08] dark:hover:text-text-primary'
                     : 'bg-light-surface text-gray-300 dark:text-gray-600 cursor-not-allowed'
                 } ${isSyncing ? 'opacity-50' : ''}`}
-                title={isFork ? t('同步上游仓库', 'Sync upstream repository') : t('非Fork仓库，无法同步', 'Not a fork. Cannot sync.')}
-                aria-label={t('同步上游仓库', 'Sync upstream repository')}
+                title={needsSync
+                  ? t('Update branch', 'Update branch')
+                  : t('已是最新版本', 'Already up to date')}
+                aria-label={t('Update branch', 'Update branch')}
               >
                 {isSyncing ? (
                   <Loader2 className="w-3.5 h-3.5 animate-spin" />
@@ -239,6 +239,7 @@ const ForkCard: React.FC<ForkCardProps> = memo(({
                         onClick={(e) => {
                           e.stopPropagation();
                           onRunWorkflow(workflow.path, workflow.name);
+                          onMarkAsRead();
                         }}
                         disabled={workflow.state === 'disabled' || isRunningWorkflow}
                         className="ml-2 p-1.5 rounded bg-brand-indigo text-white hover:bg-brand-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex-shrink-0"

--- a/src/components/ForkCard.tsx
+++ b/src/components/ForkCard.tsx
@@ -79,8 +79,23 @@ const ForkCard: React.FC<ForkCardProps> = memo(({
               </p>
               {sourceFullName && (
                 <p className="text-xs text-gray-400 dark:text-text-quaternary truncate mt-0.5 flex items-center gap-1">
-                  <span>↑</span>
-                  <span>{sourceFullName}</span>
+                  <span>{t('Forked from', 'Forked from')}</span>
+                  {fork.parent?.html_url || fork.source?.html_url ? (
+                    <a
+                      href={fork.parent?.html_url || fork.source?.html_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-brand-indigo hover:underline truncate"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onMarkAsRead();
+                      }}
+                    >
+                      {sourceFullName}
+                    </a>
+                  ) : (
+                    <span className="text-brand-indigo truncate">{sourceFullName}</span>
+                  )}
                 </p>
               )}
             </div>
@@ -227,6 +242,10 @@ const ForkCard: React.FC<ForkCardProps> = memo(({
                         }}
                         disabled={workflow.state === 'disabled' || isRunningWorkflow}
                         className="ml-2 p-1.5 rounded bg-brand-indigo text-white hover:bg-brand-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex-shrink-0"
+                        aria-label={workflow.state === 'disabled'
+                          ? (language === 'zh' ? '工作流已禁用' : 'Workflow disabled')
+                          : `${language === 'zh' ? '运行工作流' : 'Run workflow'}: ${workflow.name}`
+                        }
                         title={workflow.state === 'disabled'
                           ? (language === 'zh' ? '工作流已禁用' : 'Workflow disabled')
                           : (language === 'zh' ? '运行工作流' : 'Run workflow')

--- a/src/components/ForkCard.tsx
+++ b/src/components/ForkCard.tsx
@@ -14,6 +14,7 @@ interface ForkCardProps {
   workflows: WorkflowDefinition[];
   isLoadingWorkflows: boolean;
   isSyncing: boolean;
+  isRunningWorkflow: boolean;
   language: 'zh' | 'en';
 }
 
@@ -28,14 +29,15 @@ const ForkCard: React.FC<ForkCardProps> = memo(({
   workflows,
   isLoadingWorkflows,
   isSyncing,
+  isRunningWorkflow,
   language,
 }) => {
   const t = useCallback((zh: string, en: string) => language === 'zh' ? zh : en, [language]);
 
   const sourceFullName = fork.source?.full_name || fork.parent?.full_name || '';
   const sourceName = fork.source?.name || fork.parent?.name || '';
-  // A repo is only a fork if it has a parent or source
-  const isFork = !!fork.parent || !!fork.source;
+  // A repo is only a fork if it has a parent/source OR the fork boolean is true
+  const isFork = !!fork.parent || !!fork.source || fork.fork === true;
 
   return (
     <div
@@ -223,14 +225,18 @@ const ForkCard: React.FC<ForkCardProps> = memo(({
                           e.stopPropagation();
                           onRunWorkflow(workflow.path, workflow.name);
                         }}
-                        disabled={workflow.state === 'disabled'}
+                        disabled={workflow.state === 'disabled' || isRunningWorkflow}
                         className="ml-2 p-1.5 rounded bg-brand-indigo text-white hover:bg-brand-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex-shrink-0"
                         title={workflow.state === 'disabled'
                           ? (language === 'zh' ? '工作流已禁用' : 'Workflow disabled')
                           : (language === 'zh' ? '运行工作流' : 'Run workflow')
                         }
                       >
-                        <Play className="w-3.5 h-3.5" />
+                        {isRunningWorkflow ? (
+                          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                        ) : (
+                          <Play className="w-3.5 h-3.5" />
+                        )}
                       </button>
                     </div>
                   ))}

--- a/src/components/ForkCard.tsx
+++ b/src/components/ForkCard.tsx
@@ -1,6 +1,6 @@
-import React, { memo, useState, useCallback } from 'react';
+import React, { memo, useCallback } from 'react';
 import { ExternalLink, GitFork, RefreshCw, ChevronDown, ChevronUp, FolderOpen, Folder, Play, Loader2 } from 'lucide-react';
-import { ForkRepo, WorkflowRun } from '../types';
+import { ForkRepo, WorkflowDefinition } from '../types';
 import { formatDistanceToNow } from 'date-fns';
 
 interface ForkCardProps {
@@ -10,8 +10,8 @@ interface ForkCardProps {
   onToggleWorkflows: () => void;
   onSyncUpstream: () => void;
   onMarkAsRead: () => void;
-  onRunWorkflow: (workflowPath: string, workflowName: string, branch: string) => void;
-  workflows: WorkflowRun[];
+  onRunWorkflow: (workflowPath: string, workflowName: string) => void;
+  workflows: WorkflowDefinition[];
   isLoadingWorkflows: boolean;
   isSyncing: boolean;
   language: 'zh' | 'en';
@@ -34,6 +34,8 @@ const ForkCard: React.FC<ForkCardProps> = memo(({
 
   const sourceFullName = fork.source?.full_name || fork.parent?.full_name || '';
   const sourceName = fork.source?.name || fork.parent?.name || '';
+  // A repo is only a fork if it has a parent or source
+  const isFork = !!fork.parent || !!fork.source;
 
   return (
     <div
@@ -62,6 +64,11 @@ const ForkCard: React.FC<ForkCardProps> = memo(({
                 {fork.language && (
                   <span className="px-1.5 py-0.5 bg-gray-100 dark:bg-white/[0.06] text-gray-700 dark:text-text-secondary text-xs font-medium rounded-md border border-black/[0.06] dark:border-white/[0.04] shrink-0">
                     {fork.language}
+                  </span>
+                )}
+                {!isFork && (
+                  <span className="px-1.5 py-0.5 bg-gray-200 dark:bg-white/[0.06] text-gray-600 dark:text-text-tertiary text-xs font-medium rounded-md border border-black/[0.06] dark:border-white/[0.04] shrink-0">
+                    {t('非Fork', 'Not Fork')}
                   </span>
                 )}
               </div>
@@ -117,15 +124,19 @@ const ForkCard: React.FC<ForkCardProps> = memo(({
                 {isWorkflowsExpanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
               </button>
 
-              {/* Sync Upstream button */}
+              {/* Sync Upstream button — only enabled for actual forks */}
               <button
                 onClick={(e) => {
                   e.stopPropagation();
                   onSyncUpstream();
                 }}
-                disabled={isSyncing}
-                className="p-1 rounded bg-light-surface text-gray-700 dark:bg-white/[0.04] dark:text-text-secondary hover:bg-gray-200 hover:text-gray-900 dark:hover:bg-white/[0.08] dark:hover:text-text-primary transition-colors disabled:opacity-50"
-                title={t('同步上游仓库', 'Sync upstream repository')}
+                disabled={isSyncing || !isFork}
+                className={`p-1 rounded transition-colors disabled:cursor-not-allowed ${
+                  isFork
+                    ? 'bg-light-surface text-gray-700 dark:bg-white/[0.04] dark:text-text-secondary hover:bg-gray-200 hover:text-gray-900 dark:hover:bg-white/[0.08] dark:hover:text-text-primary'
+                    : 'bg-light-surface text-gray-300 dark:text-gray-600 cursor-not-allowed'
+                } ${isSyncing ? 'opacity-50' : ''}`}
+                title={isFork ? t('同步上游仓库', 'Sync upstream repository') : t('非Fork仓库，无法同步', 'Not a fork. Cannot sync.')}
                 aria-label={t('同步上游仓库', 'Sync upstream repository')}
               >
                 {isSyncing ? (
@@ -194,34 +205,32 @@ const ForkCard: React.FC<ForkCardProps> = memo(({
                     >
                       <div className="flex items-center space-x-2 min-w-0 flex-1">
                         <span className={`w-2 h-2 rounded-full flex-shrink-0 ${
-                          workflow.conclusion === 'success' ? 'bg-green-500' :
-                          workflow.conclusion === 'failure' ? 'bg-red-500' :
-                          workflow.status === 'in_progress' ? 'bg-yellow-500 animate-pulse' :
-                          'bg-gray-400'
+                          workflow.state === 'active' ? 'bg-green-500' :
+                          workflow.state === 'disabled' ? 'bg-gray-400' :
+                          'bg-yellow-500'
                         }`} />
                         <div className="min-w-0 flex-1">
                           <p className="text-sm truncate text-gray-900 dark:text-text-secondary">
                             {workflow.name}
                           </p>
-                          <p className="text-xs text-gray-500 dark:text-text-tertiary truncate">
-                            #{workflow.run_number} • {workflow.head_branch} • {formatDistanceToNow(new Date(workflow.created_at), { addSuffix: true })}
+                          <p className="text-xs text-gray-400 dark:text-text-quaternary truncate">
+                            {workflow.path}
                           </p>
                         </div>
                       </div>
                       <button
                         onClick={(e) => {
                           e.stopPropagation();
-                          onRunWorkflow(workflow.path, workflow.name, workflow.head_branch);
+                          onRunWorkflow(workflow.path, workflow.name);
                         }}
-                        disabled={workflow.status === 'in_progress'}
-                        className="ml-2 p-1.5 rounded bg-brand-indigo text-white hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex-shrink-0"
-                        title={t('运行工作流', 'Run workflow')}
+                        disabled={workflow.state === 'disabled'}
+                        className="ml-2 p-1.5 rounded bg-brand-indigo text-white hover:bg-brand-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex-shrink-0"
+                        title={workflow.state === 'disabled'
+                          ? (language === 'zh' ? '工作流已禁用' : 'Workflow disabled')
+                          : (language === 'zh' ? '运行工作流' : 'Run workflow')
+                        }
                       >
-                        {workflow.status === 'in_progress' ? (
-                          <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                        ) : (
-                          <Play className="w-3.5 h-3.5" />
-                        )}
+                        <Play className="w-3.5 h-3.5" />
                       </button>
                     </div>
                   ))}

--- a/src/components/ForkCard.tsx
+++ b/src/components/ForkCard.tsx
@@ -10,7 +10,7 @@ interface ForkCardProps {
   onToggleWorkflows: () => void;
   onSyncUpstream: () => void;
   onMarkAsRead: () => void;
-  onRunWorkflow: (workflowId: string, workflowName: string, branch: string) => void;
+  onRunWorkflow: (workflowPath: string, workflowName: string, branch: string) => void;
   workflows: WorkflowRun[];
   isLoadingWorkflows: boolean;
   isSyncing: boolean;
@@ -211,7 +211,7 @@ const ForkCard: React.FC<ForkCardProps> = memo(({
                       <button
                         onClick={(e) => {
                           e.stopPropagation();
-                          onRunWorkflow(String(workflow.id), workflow.name, workflow.head_branch);
+                          onRunWorkflow(workflow.path, workflow.name, workflow.head_branch);
                         }}
                         disabled={workflow.status === 'in_progress'}
                         className="ml-2 p-1.5 rounded bg-brand-indigo text-white hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex-shrink-0"

--- a/src/components/ForkCard.tsx
+++ b/src/components/ForkCard.tsx
@@ -1,0 +1,240 @@
+import React, { memo, useState, useCallback } from 'react';
+import { ExternalLink, GitFork, RefreshCw, ChevronDown, ChevronUp, FolderOpen, Folder, Play, Loader2 } from 'lucide-react';
+import { ForkRepo, WorkflowRun } from '../types';
+import { formatDistanceToNow } from 'date-fns';
+
+interface ForkCardProps {
+  fork: ForkRepo;
+  isUnread: boolean;
+  isWorkflowsExpanded: boolean;
+  onToggleWorkflows: () => void;
+  onSyncUpstream: () => void;
+  onMarkAsRead: () => void;
+  onRunWorkflow: (workflowId: string, workflowName: string, branch: string) => void;
+  workflows: WorkflowRun[];
+  isLoadingWorkflows: boolean;
+  isSyncing: boolean;
+  language: 'zh' | 'en';
+}
+
+const ForkCard: React.FC<ForkCardProps> = memo(({
+  fork,
+  isUnread,
+  isWorkflowsExpanded,
+  onToggleWorkflows,
+  onSyncUpstream,
+  onMarkAsRead,
+  onRunWorkflow,
+  workflows,
+  isLoadingWorkflows,
+  isSyncing,
+  language,
+}) => {
+  const t = useCallback((zh: string, en: string) => language === 'zh' ? zh : en, [language]);
+
+  const sourceFullName = fork.source?.full_name || fork.parent?.full_name || '';
+  const sourceName = fork.source?.name || fork.parent?.name || '';
+
+  return (
+    <div
+      onClick={onMarkAsRead}
+      className={`bg-white dark:bg-[#121314] rounded-xl border transition-all duration-300 ease-in-out cursor-pointer ${
+        isWorkflowsExpanded
+          ? 'border-brand-indigo/20 shadow-lg ring-1 ring-brand-indigo/30'
+          : 'border-black/[0.06] dark:border-white/[0.04] hover:shadow-md hover:border-black/10 dark:hover:border-white/10'
+      }`}
+    >
+      {/* Header */}
+      <div className="p-3 sm:p-4">
+        <div className="flex items-stretch justify-between gap-3">
+          <div className="flex items-center min-w-0 flex-1">
+            {isUnread && (
+              <div className="w-1.5 h-1.5 bg-brand-violet rounded-full flex-shrink-0 animate-pulse mr-2"></div>
+            )}
+            <div className="flex items-center justify-center w-8 h-8 bg-gray-100 dark:bg-white/[0.04] rounded-lg flex-shrink-0 border border-transparent dark:border-white/[0.04]">
+              <GitFork className="w-4 h-4 text-gray-500 dark:text-text-tertiary" />
+            </div>
+            <div className="min-w-0 flex-1 ml-3">
+              <div className="flex items-center gap-2 min-w-0 flex-wrap">
+                <h4 className="font-semibold text-gray-900 dark:text-text-primary text-sm truncate">
+                  {fork.name}
+                </h4>
+                {fork.language && (
+                  <span className="px-1.5 py-0.5 bg-gray-100 dark:bg-white/[0.06] text-gray-700 dark:text-text-secondary text-xs font-medium rounded-md border border-black/[0.06] dark:border-white/[0.04] shrink-0">
+                    {fork.language}
+                  </span>
+                )}
+              </div>
+              <p className="text-xs text-gray-500 dark:text-text-quaternary truncate mt-1">
+                {fork.full_name}
+              </p>
+              {sourceFullName && (
+                <p className="text-xs text-gray-400 dark:text-text-quaternary truncate mt-0.5 flex items-center gap-1">
+                  <span>↑</span>
+                  <span>{sourceFullName}</span>
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div className="flex items-center gap-4 flex-shrink-0 self-stretch">
+            <div className="hidden md:flex min-w-[140px] flex-col justify-center gap-2 text-xs text-gray-500 dark:text-text-tertiary">
+              <div className="flex items-center gap-1.5">
+                <RefreshCw className="w-3.5 h-3.5" />
+                <span>
+                  {fork.updated_at
+                    ? formatDistanceToNow(new Date(fork.updated_at), { addSuffix: true })
+                    : '-'}
+                </span>
+              </div>
+              {fork.source?.updated_at && (
+                <div className="flex items-center gap-1.5">
+                  <GitFork className="w-3.5 h-3.5" />
+                  <span>
+                    {formatDistanceToNow(new Date(fork.source.updated_at), { addSuffix: true })}
+                  </span>
+                </div>
+              )}
+            </div>
+            <div className="flex items-center space-x-1 flex-shrink-0">
+              {/* Workflows dropdown */}
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onToggleWorkflows();
+                }}
+                className={`flex items-center space-x-0.5 px-1.5 py-1 rounded transition-all duration-200 whitespace-nowrap ${
+                  isWorkflowsExpanded
+                    ? 'bg-brand-indigo/15 text-brand-indigo dark:bg-brand-indigo/20 dark:text-white'
+                    : 'bg-light-surface text-gray-700 dark:bg-white/[0.04] dark:text-text-tertiary hover:bg-gray-200 dark:hover:bg-white/[0.08]'
+                }`}
+                title={isWorkflowsExpanded ? t('隐藏工作流', 'Hide Workflows') : t('显示工作流', 'Show Workflows')}
+                aria-label={isWorkflowsExpanded ? t('隐藏工作流', 'Hide Workflows') : t('显示工作流', 'Show Workflows')}
+                aria-expanded={isWorkflowsExpanded}
+              >
+                {isWorkflowsExpanded ? <FolderOpen className="w-3.5 h-3.5" /> : <Folder className="w-3.5 h-3.5" />}
+                <span className="text-xs font-medium">{isWorkflowsExpanded ? t('隐藏', 'Hide') : t('工作流', 'Workflows')}</span>
+                {isWorkflowsExpanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+              </button>
+
+              {/* Sync Upstream button */}
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onSyncUpstream();
+                }}
+                disabled={isSyncing}
+                className="p-1 rounded bg-light-surface text-gray-700 dark:bg-white/[0.04] dark:text-text-secondary hover:bg-gray-200 hover:text-gray-900 dark:hover:bg-white/[0.08] dark:hover:text-text-primary transition-colors disabled:opacity-50"
+                title={t('同步上游仓库', 'Sync upstream repository')}
+                aria-label={t('同步上游仓库', 'Sync upstream repository')}
+              >
+                {isSyncing ? (
+                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                ) : (
+                  <RefreshCw className="w-3.5 h-3.5" />
+                )}
+              </button>
+
+              {/* View on GitHub link */}
+              <a
+                href={fork.html_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="p-1 rounded bg-light-surface text-gray-700 dark:bg-white/[0.04] dark:text-text-secondary hover:bg-gray-200 hover:text-gray-900 dark:hover:bg-white/[0.08] dark:hover:text-text-primary transition-colors"
+                title={t('在GitHub上查看', 'View on GitHub')}
+                aria-label={t('在GitHub上查看', 'View on GitHub')}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onMarkAsRead();
+                }}
+              >
+                <ExternalLink className="w-3.5 h-3.5" />
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Expandable Workflows section */}
+      <div
+        className="grid transition-[grid-template-rows] duration-300 ease-in-out"
+        style={{ gridTemplateRows: isWorkflowsExpanded ? '1fr' : '0fr' }}
+      >
+        <div className="overflow-hidden min-h-0">
+          <div className="px-3 sm:px-4 pb-3 sm:pb-4 pt-3 sm:pt-4 border-t border-black/[0.06] dark:border-white/[0.04]">
+            {isLoadingWorkflows ? (
+              <div className="flex items-center justify-center py-6">
+                <Loader2 className="w-5 h-5 animate-spin text-gray-400 dark:text-text-tertiary" />
+                <span className="ml-2 text-sm text-gray-500 dark:text-text-tertiary">
+                  {t('加载工作流中...', 'Loading workflows...')}
+                </span>
+              </div>
+            ) : workflows.length === 0 ? (
+              <div className="py-4 text-center text-sm text-gray-500 dark:text-text-tertiary">
+                {t('暂无工作流', 'No workflows')}
+              </div>
+            ) : (
+              <div className="py-2">
+                <div className="flex items-center space-x-2 mb-3">
+                  <Folder className="w-3.5 h-3.5 text-gray-700 dark:text-text-secondary" />
+                  <span className="text-xs font-medium text-gray-900 dark:text-text-secondary">
+                    {t('工作流', 'Workflows')}
+                  </span>
+                  <span className="text-xs text-gray-500 dark:text-text-tertiary">
+                    ({workflows.length})
+                  </span>
+                </div>
+
+                <div className="bg-gray-50 dark:bg-[#121314] rounded border border-black/[0.06] dark:border-white/[0.04] max-h-72 overflow-y-auto">
+                  {workflows.map((workflow) => (
+                    <div
+                      key={workflow.id}
+                      className="flex items-center justify-between px-4 py-3 hover:bg-light-surface dark:hover:bg-white/[0.06] transition-colors border-b border-black/[0.04] dark:border-white/[0.04] last:border-b-0"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <div className="flex items-center space-x-2 min-w-0 flex-1">
+                        <span className={`w-2 h-2 rounded-full flex-shrink-0 ${
+                          workflow.conclusion === 'success' ? 'bg-green-500' :
+                          workflow.conclusion === 'failure' ? 'bg-red-500' :
+                          workflow.status === 'in_progress' ? 'bg-yellow-500 animate-pulse' :
+                          'bg-gray-400'
+                        }`} />
+                        <div className="min-w-0 flex-1">
+                          <p className="text-sm truncate text-gray-900 dark:text-text-secondary">
+                            {workflow.name}
+                          </p>
+                          <p className="text-xs text-gray-500 dark:text-text-tertiary truncate">
+                            #{workflow.run_number} • {workflow.head_branch} • {formatDistanceToNow(new Date(workflow.created_at), { addSuffix: true })}
+                          </p>
+                        </div>
+                      </div>
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onRunWorkflow(String(workflow.id), workflow.name, workflow.head_branch);
+                        }}
+                        disabled={workflow.status === 'in_progress'}
+                        className="ml-2 p-1.5 rounded bg-brand-indigo text-white hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex-shrink-0"
+                        title={t('运行工作流', 'Run workflow')}
+                      >
+                        {workflow.status === 'in_progress' ? (
+                          <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                        ) : (
+                          <Play className="w-3.5 h-3.5" />
+                        )}
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+ForkCard.displayName = 'ForkCard';
+
+export default ForkCard;

--- a/src/components/ForkTimeline.tsx
+++ b/src/components/ForkTimeline.tsx
@@ -236,13 +236,14 @@ export const ForkTimeline: React.FC = () => {
   };
 
   const loadWorkflows = async (forkId: number) => {
+    if (!githubToken) return;
     const fork = forks.find(f => f.id === forkId);
     if (!fork) return;
 
     setLoadingWorkflows(prev => new Set(prev).add(forkId));
     try {
       const [owner, repo] = fork.full_name.split('/');
-      const githubApi = new GitHubApiService(githubToken!);
+      const githubApi = new GitHubApiService(githubToken);
       const workflows = await githubApi.getRepositoryWorkflows(owner, repo);
       setWorkflowsMap(prev => ({ ...prev, [forkId]: workflows }));
     } catch (error) {
@@ -266,7 +267,7 @@ export const ForkTimeline: React.FC = () => {
     try {
       const [owner, repo] = fork.full_name.split('/');
       const githubApi = new GitHubApiService(githubToken);
-      const result = await githubApi.syncFork(owner, repo);
+      const result = await githubApi.syncFork(owner, repo, fork.default_branch || 'main');
 
       // Update fork's upstream_updated_at and clear unread badge (user took action)
       if (result.sourceUpdatedAt) {
@@ -313,7 +314,7 @@ export const ForkTimeline: React.FC = () => {
     }
   };
 
-  const handleRunWorkflow = async (forkId: number, workflowId: string, workflowName: string, branch: string) => {
+  const handleRunWorkflow = async (forkId: number, workflowPath: string, workflowName: string, branch: string) => {
     if (!githubToken) {
       toast(language === 'zh' ? 'GitHub token 未找到，请重新登录。' : 'GitHub token not found. Please login again.', 'error');
       return;
@@ -325,7 +326,7 @@ export const ForkTimeline: React.FC = () => {
     try {
       const [owner, repo] = fork.full_name.split('/');
       const githubApi = new GitHubApiService(githubToken);
-      await githubApi.triggerWorkflowRun(owner, repo, workflowId, branch);
+      await githubApi.triggerWorkflowRun(owner, repo, workflowPath, branch);
 
       toast(language === 'zh'
         ? `已触发工作流 "${workflowName}" 在 ${branch} 分支。`

--- a/src/components/ForkTimeline.tsx
+++ b/src/components/ForkTimeline.tsx
@@ -1,0 +1,633 @@
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import { Package, Search, X, RefreshCw, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-react';
+import { ForkRepo, WorkflowRun } from '../types';
+import { useAppStore } from '../store/useAppStore';
+import { GitHubApiService } from '../services/githubApi';
+import { formatDistanceToNow } from 'date-fns';
+import ForkCard from './ForkCard';
+import { useDialog } from '../hooks/useDialog';
+import { GitFork } from 'lucide-react';
+
+export const ForkTimeline: React.FC = () => {
+  const {
+    forks,
+    readForks,
+    githubToken,
+    language,
+    setForks,
+    addForks,
+    markForkAsRead,
+    markAllForksAsRead,
+    updateFork,
+    // Fork Timeline View State from global store
+    forkViewMode,
+    forkSelectedFilters,
+    forkSearchQuery,
+    forkExpandedRepositories,
+    forkIsRefreshing,
+    setForkViewMode,
+    toggleForkSelectedFilter,
+    clearForkSelectedFilters,
+    setForkSearchQuery,
+    toggleForkExpandedRepository,
+    setForkIsRefreshing,
+  } = useAppStore();
+
+  const { toast } = useDialog();
+
+  const [lastRefreshTime, setLastRefreshTime] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [itemsPerPage, setItemsPerPage] = useState(20);
+  // Workflow expansion state (local UI state)
+  const [expandedWorkflows, setExpandedWorkflows] = useState<Set<number>>(new Set());
+  const [workflowsMap, setWorkflowsMap] = useState<Record<number, WorkflowRun[]>>({});
+  const [loadingWorkflows, setLoadingWorkflows] = useState<Set<number>>(new Set());
+  const [syncingForks, setSyncingForks] = useState<Set<number>>(new Set());
+
+  // Alias global state for local use
+  const viewMode = forkViewMode;
+  const selectedFilters = forkSelectedFilters;
+  const searchQuery = forkSearchQuery;
+  const expandedRepositories = forkExpandedRepositories;
+
+  const t = useCallback((zh: string, en: string) => language === 'zh' ? zh : en, [language]);
+
+  const isForkUnread = useCallback((forkId: number) => {
+    return !readForks.has(forkId);
+  }, [readForks]);
+
+  // Filter and sort forks
+  const filteredForks = useMemo(() => {
+    let filtered = [...forks];
+
+    // Sort by source.updated_at desc (upstream latest update first)
+    filtered.sort((a, b) => {
+      const aTime = a.source?.updated_at ? new Date(a.source.updated_at).getTime() : 0;
+      const bTime = b.source?.updated_at ? new Date(b.source.updated_at).getTime() : 0;
+      return bTime - aTime;
+    });
+
+    // Search filter
+    if (searchQuery.trim()) {
+      const query = searchQuery.toLowerCase();
+      filtered = filtered.filter(fork =>
+        fork.name.toLowerCase().includes(query) ||
+        fork.full_name.toLowerCase().includes(query) ||
+        (fork.source?.full_name || '').toLowerCase().includes(query) ||
+        (fork.description || '').toLowerCase().includes(query) ||
+        (fork.source?.description || '').toLowerCase().includes(query)
+      );
+    }
+
+    return filtered;
+  }, [forks, searchQuery]);
+
+  // Pagination
+  const totalPages = Math.ceil(filteredForks.length / itemsPerPage);
+  const clampedPage = Math.max(1, Math.min(currentPage, totalPages || 1));
+  const startIndex = (clampedPage - 1) * itemsPerPage;
+  const paginatedForks = filteredForks.slice(startIndex, startIndex + itemsPerPage);
+
+  // Sync currentPage when data changes
+  useEffect(() => {
+    const maxPage = Math.max(totalPages, 1);
+    if (currentPage < 1 || currentPage > maxPage) {
+      setCurrentPage(Math.min(Math.max(currentPage, 1), maxPage));
+    }
+  }, [totalPages, currentPage]);
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(Math.max(1, Math.min(page, totalPages)));
+  };
+
+  const getPageNumbers = () => {
+    const delta = 2;
+    const range = [];
+    const rangeWithDots = [];
+    const activePage = clampedPage;
+
+    for (let i = Math.max(2, activePage - delta); i <= Math.min(totalPages - 1, activePage + delta); i++) {
+      range.push(i);
+    }
+
+    if (activePage - delta > 2) {
+      rangeWithDots.push(1, '...');
+    } else {
+      rangeWithDots.push(1);
+    }
+
+    rangeWithDots.push(...range);
+
+    if (activePage + delta < totalPages - 1) {
+      rangeWithDots.push('...', totalPages);
+    } else if (totalPages > 1) {
+      rangeWithDots.push(totalPages);
+    }
+
+    return rangeWithDots;
+  };
+
+  const handleRefresh = async () => {
+    if (!githubToken) {
+      toast(language === 'zh' ? 'GitHub token 未找到，请重新登录。' : 'GitHub token not found. Please login again.', 'error');
+      return;
+    }
+
+    setForkIsRefreshing(true);
+    try {
+      const githubApi = new GitHubApiService(githubToken);
+      const newForks = await githubApi.getUserForks();
+
+      // Merge with existing forks, preserving read status
+      const existingForkMap = new Map(forks.map(f => [f.id, f]));
+      const mergedForks: ForkRepo[] = newForks.map(newFork => {
+        const existing = existingForkMap.get(newFork.id);
+        if (existing) {
+          // Preserve local state
+          return {
+            ...newFork,
+            has_unread: existing.has_unread,
+            upstream_updated_at: existing.upstream_updated_at,
+          };
+        }
+        // New fork — mark as unread if upstream has updates
+        return {
+          ...newFork,
+          has_unread: false,
+          upstream_updated_at: newFork.source?.updated_at,
+        };
+      });
+
+      // Check for upstream updates on existing forks - mark as unread if source has newer commits
+      const updatedForks = mergedForks.map(fork => {
+        const existing = existingForkMap.get(fork.id);
+        if (existing) {
+          // Compare: if source updated since last check, mark as unread
+          const prevUpstreamTime = existing.upstream_updated_at;
+          const currentUpstreamTime = fork.source?.updated_at;
+          if (prevUpstreamTime && currentUpstreamTime) {
+            const hasNewUpdates = new Date(currentUpstreamTime) > new Date(prevUpstreamTime);
+            if (hasNewUpdates) {
+              // Mark as unread by removing from readForks
+              useAppStore.setState(state => {
+                const newReadForks = new Set(state.readForks);
+                newReadForks.delete(fork.id);
+                return { readForks: newReadForks };
+              });
+              return {
+                ...fork,
+                upstream_updated_at: currentUpstreamTime,
+              };
+            }
+          }
+          return {
+            ...fork,
+            upstream_updated_at: existing.upstream_updated_at || fork.source?.updated_at,
+          };
+        }
+        return fork;
+      });
+
+      setForks(updatedForks);
+      const now = new Date().toISOString();
+      setLastRefreshTime(now);
+
+      // Count new forks
+      const newCount = newForks.filter(f => !existingForkMap.has(f.id)).length;
+      if (newCount > 0) {
+        toast(language === 'zh'
+          ? `刷新完成！发现 ${newCount} 个新Fork。`
+          : `Refresh completed! Found ${newCount} new forks.`,
+          'success'
+        );
+      } else {
+        toast(language === 'zh'
+          ? `刷新完成！`
+          : `Refresh completed!`,
+          'info'
+        );
+      }
+    } catch (error) {
+      console.error('Fork refresh failed:', error);
+      toast(language === 'zh'
+        ? 'Fork刷新失败，请检查网络连接。'
+        : 'Fork refresh failed. Please check your network connection.',
+        'error'
+      );
+    } finally {
+      setForkIsRefreshing(false);
+    }
+  };
+
+  const toggleWorkflows = async (forkId: number) => {
+    setExpandedWorkflows(prev => {
+      const newSet = new Set(prev);
+      if (newSet.has(forkId)) {
+        newSet.delete(forkId);
+      } else {
+        newSet.add(forkId);
+        // Fetch workflows if not loaded yet
+        if (!workflowsMap[forkId]) {
+          loadWorkflows(forkId);
+        }
+      }
+      return newSet;
+    });
+  };
+
+  const loadWorkflows = async (forkId: number) => {
+    const fork = forks.find(f => f.id === forkId);
+    if (!fork) return;
+
+    setLoadingWorkflows(prev => new Set(prev).add(forkId));
+    try {
+      const [owner, repo] = fork.full_name.split('/');
+      const githubApi = new GitHubApiService(githubToken!);
+      const workflows = await githubApi.getRepositoryWorkflows(owner, repo);
+      setWorkflowsMap(prev => ({ ...prev, [forkId]: workflows }));
+    } catch (error) {
+      console.error('Failed to load workflows:', error);
+    } finally {
+      setLoadingWorkflows(prev => {
+        const newSet = new Set(prev);
+        newSet.delete(forkId);
+        return newSet;
+      });
+    }
+  };
+
+  const handleSyncUpstream = async (fork: ForkRepo) => {
+    if (!githubToken) {
+      toast(language === 'zh' ? 'GitHub token 未找到，请重新登录。' : 'GitHub token not found. Please login again.', 'error');
+      return;
+    }
+
+    setSyncingForks(prev => new Set(prev).add(fork.id));
+    try {
+      const [owner, repo] = fork.full_name.split('/');
+      const githubApi = new GitHubApiService(githubToken);
+      const result = await githubApi.syncFork(owner, repo);
+
+      // Update fork's upstream_updated_at and clear unread badge (user took action)
+      if (result.sourceUpdatedAt) {
+        updateFork({
+          ...fork,
+          upstream_updated_at: result.sourceUpdatedAt,
+        });
+        // Clear unread badge after sync
+        useAppStore.setState(state => {
+          const newReadForks = new Set(state.readForks);
+          newReadForks.add(fork.id);
+          return { readForks: newReadForks };
+        });
+      }
+
+      toast(language === 'zh'
+        ? `已同步 ${fork.name} 到最新版本。`
+        : `${fork.name} synced to latest.`,
+        'success'
+      );
+    } catch (error) {
+      console.error('Sync failed:', error);
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      // 409 means already up to date
+      if (errorMsg.includes('409') || errorMsg.toLowerCase().includes('already up to date')) {
+        toast(language === 'zh'
+          ? `${fork.name} 已是最新版本。`
+          : `${fork.name} is already up to date.`,
+          'info'
+        );
+      } else {
+        toast(language === 'zh'
+          ? `同步失败: ${errorMsg}`
+          : `Sync failed: ${errorMsg}`,
+          'error'
+        );
+      }
+    } finally {
+      setSyncingForks(prev => {
+        const newSet = new Set(prev);
+        newSet.delete(fork.id);
+        return newSet;
+      });
+    }
+  };
+
+  const handleRunWorkflow = async (forkId: number, workflowId: string, workflowName: string, branch: string) => {
+    if (!githubToken) {
+      toast(language === 'zh' ? 'GitHub token 未找到，请重新登录。' : 'GitHub token not found. Please login again.', 'error');
+      return;
+    }
+
+    const fork = forks.find(f => f.id === forkId);
+    if (!fork) return;
+
+    try {
+      const [owner, repo] = fork.full_name.split('/');
+      const githubApi = new GitHubApiService(githubToken);
+      await githubApi.triggerWorkflowRun(owner, repo, workflowId, branch);
+
+      toast(language === 'zh'
+        ? `已触发工作流 "${workflowName}" 在 ${branch} 分支。`
+        : `Triggered workflow "${workflowName}" on branch ${branch}.`,
+        'success'
+      );
+
+      // Reload workflows after triggering
+      await loadWorkflows(forkId);
+    } catch (error) {
+      console.error('Failed to run workflow:', error);
+      toast(language === 'zh'
+        ? `运行工作流失败。`
+        : `Failed to run workflow.`,
+        'error'
+      );
+    }
+  };
+
+  if (forks.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <GitFork className="w-16 h-16 text-gray-500 dark:text-quaternary mx-auto mb-4" />
+        <h3 className="text-lg font-medium text-gray-900 dark:text-text-primary mb-2">
+          {t('没有Fork仓库', 'No Forked Repositories')}
+        </h3>
+        <p className="text-gray-500 dark:text-text-tertiary mb-6 max-w-md mx-auto">
+          {t('您还没有Fork任何仓库。Fork一个仓库后即可在此处管理。', 'You have not forked any repositories. Fork a repository to manage it here.')}
+        </p>
+
+        {/* Refresh button */}
+        <div className="mb-6 flex flex-col items-center gap-3">
+          <button
+            onClick={handleRefresh}
+            disabled={forkIsRefreshing}
+            className="flex items-center space-x-2 px-6 py-3 bg-brand-indigo text-white rounded-lg hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <RefreshCw className={`w-5 h-5 ${forkIsRefreshing ? 'animate-spin' : ''}`} />
+            <span>{forkIsRefreshing ? t('刷新中...', 'Refreshing...') : t('刷新Fork', 'Refresh Forks')}</span>
+          </button>
+          {lastRefreshTime && (
+            <p className="text-sm text-gray-500 dark:text-text-tertiary">
+              {t('上次刷新:', 'Last refresh:')} {formatDistanceToNow(new Date(lastRefreshTime), { addSuffix: true })}
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-full mx-auto px-2 sm:px-4">
+      {/* Header */}
+      <div className="mb-6 sm:mb-8">
+        <div className="flex flex-col gap-4 mb-4 lg:flex-row lg:items-start lg:justify-between">
+          <div>
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-text-primary mb-2">
+              {t('复刻时间线', 'Fork Timeline')}
+            </h2>
+            <p className="text-gray-700 dark:text-text-tertiary">
+              {t(`管理您的 ${forks.length} 个Fork仓库`, `Manage your ${forks.length} forked repositories`)}
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+            {/* Last Refresh Time */}
+            {lastRefreshTime && (
+              <span className="w-full text-sm text-gray-500 dark:text-text-tertiary lg:w-auto">
+                {t('上次刷新:', 'Last refresh:')} {formatDistanceToNow(new Date(lastRefreshTime), { addSuffix: true })}
+              </span>
+            )}
+
+            {/* Refresh Button */}
+            <button
+              onClick={handleRefresh}
+              disabled={forkIsRefreshing}
+              className="flex items-center space-x-2 px-4 py-2 bg-brand-indigo text-white rounded-lg hover:bg-brand-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <RefreshCw className={`w-4 h-4 ${forkIsRefreshing ? 'animate-spin' : ''}`} />
+              <span>{forkIsRefreshing ? t('刷新中...', 'Refreshing...') : t('刷新', 'Refresh')}</span>
+            </button>
+          </div>
+        </div>
+
+        {/* Search Bar */}
+        <div className="bg-white dark:bg-panel-dark rounded-xl border border-black/[0.06] dark:border-white/[0.04] p-3 mb-4">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 dark:text-text-quaternary w-5 h-5" />
+            <input
+              type="text"
+              placeholder={t('搜索Fork...', 'Search forks...')}
+              value={searchQuery}
+              onChange={(e) => {
+                setForkSearchQuery(e.target.value);
+                setCurrentPage(1);
+              }}
+              className="w-full pl-10 pr-10 py-2 border border-black/[0.06] dark:border-white/[0.04] rounded-lg focus:ring-2 focus:ring-brand-violet focus:border-transparent bg-white dark:bg-white/[0.04] text-gray-900 dark:text-text-primary"
+            />
+            {searchQuery && (
+              <button
+                onClick={() => {
+                  setForkSearchQuery('');
+                  setCurrentPage(1);
+                }}
+                className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 dark:text-text-quaternary hover:text-gray-700 dark:text-text-secondary dark:hover:text-gray-300"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            )}
+          </div>
+        </div>
+
+        {/* Results Info and Pagination Controls */}
+        <div className="flex flex-col gap-2 mb-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex flex-wrap items-center gap-2 sm:gap-4">
+            <span className="text-sm text-gray-700 dark:text-text-tertiary">
+              {t(
+                `显示 ${startIndex + 1}-${Math.min(startIndex + itemsPerPage, filteredForks.length)} 共 ${filteredForks.length} 个Fork`,
+                `Showing ${startIndex + 1}-${Math.min(startIndex + itemsPerPage, filteredForks.length)} of ${filteredForks.length} forks`
+              )}
+            </span>
+            {searchQuery && (
+              <span className="text-sm text-brand-violet dark:text-brand-violet">
+                ({t('已筛选', 'filtered')})
+              </span>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+            {/* Items per page selector */}
+            <div className="flex items-center space-x-2">
+              <span className="text-sm text-gray-700 dark:text-text-tertiary">{t('每页:', 'Per page:')}</span>
+              <select
+                value={itemsPerPage}
+                onChange={(e) => {
+                  setItemsPerPage(Number(e.target.value));
+                  setCurrentPage(1);
+                }}
+                className="px-3 py-1 border border-black/[0.06] dark:border-white/[0.04] rounded bg-white dark:bg-white/[0.04] text-gray-900 dark:text-text-primary text-sm"
+              >
+                <option value={20}>20</option>
+                <option value={50}>50</option>
+                <option value={100}>100</option>
+                <option value={200}>200</option>
+              </select>
+            </div>
+
+            {/* Pagination */}
+            {totalPages > 1 && (
+              <div className="flex items-center space-x-1 overflow-x-auto pb-1">
+                <button
+                  onClick={() => handlePageChange(1)}
+                  disabled={clampedPage === 1}
+                  className="p-2 rounded-lg bg-light-surface text-gray-700 dark:bg-white/[0.04] dark:text-text-tertiary hover:bg-gray-200 dark:hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <ChevronsLeft className="w-4 h-4" />
+                </button>
+                <button
+                  onClick={() => handlePageChange(clampedPage - 1)}
+                  disabled={clampedPage === 1}
+                  className="p-2 rounded-lg bg-light-surface text-gray-700 dark:bg-white/[0.04] dark:text-text-tertiary hover:bg-gray-200 dark:hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <ChevronLeft className="w-4 h-4" />
+                </button>
+
+                {getPageNumbers().map((page, index) => (
+                  <button
+                    key={index}
+                    onClick={() => typeof page === 'number' ? handlePageChange(page) : undefined}
+                    disabled={typeof page !== 'number'}
+                    className={`px-3 py-2 rounded-lg text-sm ${
+                      page === clampedPage
+                        ? 'bg-brand-indigo text-white'
+                        : typeof page === 'number'
+                        ? 'bg-light-surface text-gray-700 dark:bg-white/[0.04] dark:text-text-tertiary hover:bg-gray-200 dark:hover:bg-white/10'
+                        : 'text-gray-400 cursor-default'
+                    }`}
+                  >
+                    {page}
+                  </button>
+                ))}
+
+                <button
+                  onClick={() => handlePageChange(clampedPage + 1)}
+                  disabled={clampedPage === totalPages}
+                  className="p-2 rounded-lg bg-light-surface text-gray-700 dark:bg-white/[0.04] dark:text-text-tertiary hover:bg-gray-200 dark:hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <ChevronRight className="w-4 h-4" />
+                </button>
+                <button
+                  onClick={() => handlePageChange(totalPages)}
+                  disabled={clampedPage === totalPages}
+                  className="p-2 rounded-lg bg-light-surface text-gray-700 dark:bg-white/[0.04] dark:text-text-tertiary hover:bg-gray-200 dark:hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <ChevronsRight className="w-4 h-4" />
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Fork List */}
+      <div className="space-y-2">
+        {paginatedForks.length === 0 ? (
+          <div className="text-center py-12 bg-light-bg dark:bg-panel-dark/50 rounded-xl border-2 border-dashed border-black/[0.06]-alt dark:border-white/[0.04]">
+            <Package className="w-12 h-12 text-gray-400 dark:text-text-secondary mx-auto mb-3" />
+            <h3 className="text-lg font-medium text-gray-900 dark:text-text-secondary mb-1">
+              {t('无符合条件的结果', 'No matching results')}
+            </h3>
+            <p className="text-sm text-gray-500 dark:text-text-tertiary">
+              {t('没有找到匹配的 Fork', 'No matching forks found.')}
+            </p>
+            {searchQuery && (
+              <button
+                onClick={() => setForkSearchQuery('')}
+                className="mt-4 px-4 py-2 bg-brand-indigo text-white rounded-lg hover:bg-brand-hover transition-colors text-sm"
+              >
+                {t('清除搜索', 'Clear Search')}
+              </button>
+            )}
+          </div>
+        ) : (
+          paginatedForks.map((fork) => {
+            const isUnread = isForkUnread(fork.id);
+            const isWorkflowsExpanded = expandedWorkflows.has(fork.id);
+            const workflows = workflowsMap[fork.id] || [];
+            const isLoadingWf = loadingWorkflows.has(fork.id);
+            const isSyncing = syncingForks.has(fork.id);
+
+            return (
+              <ForkCard
+                key={fork.id}
+                fork={fork}
+                isUnread={isUnread}
+                isWorkflowsExpanded={isWorkflowsExpanded}
+                onToggleWorkflows={() => toggleWorkflows(fork.id)}
+                onSyncUpstream={() => handleSyncUpstream(fork)}
+                onMarkAsRead={() => markForkAsRead(fork.id)}
+                onRunWorkflow={(workflowId, workflowName, branch) => handleRunWorkflow(fork.id, workflowId, workflowName, branch)}
+                workflows={workflows}
+                isLoadingWorkflows={isLoadingWf}
+                isSyncing={isSyncing}
+                language={language}
+              />
+            );
+          })
+        )}
+      </div>
+
+      {/* Bottom Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-center mt-8">
+          <div className="flex items-center space-x-1">
+            <button
+              onClick={() => handlePageChange(1)}
+              disabled={clampedPage === 1}
+              className="p-2 rounded-lg bg-light-surface text-gray-700 dark:bg-white/[0.04] dark:text-text-tertiary hover:bg-gray-200 dark:hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <ChevronsLeft className="w-4 h-4" />
+            </button>
+            <button
+              onClick={() => handlePageChange(clampedPage - 1)}
+              disabled={clampedPage === 1}
+              className="p-2 rounded-lg bg-light-surface text-gray-700 dark:bg-white/[0.04] dark:text-text-tertiary hover:bg-gray-200 dark:hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+
+            {getPageNumbers().map((page, index) => (
+              <button
+                key={index}
+                onClick={() => typeof page === 'number' ? handlePageChange(page) : undefined}
+                disabled={typeof page !== 'number'}
+                className={`px-3 py-2 rounded-lg text-sm ${
+                  page === clampedPage
+                    ? 'bg-brand-indigo text-white'
+                    : typeof page === 'number'
+                    ? 'bg-light-surface text-gray-700 dark:bg-white/[0.04] dark:text-text-tertiary hover:bg-gray-200 dark:hover:bg-white/10'
+                    : 'text-gray-400 cursor-default'
+                }`}
+              >
+                {page}
+              </button>
+            ))}
+
+            <button
+              onClick={() => handlePageChange(clampedPage + 1)}
+              disabled={clampedPage === totalPages}
+              className="p-2 rounded-lg bg-light-surface text-gray-700 dark:bg-white/[0.04] dark:text-text-tertiary hover:bg-gray-200 dark:hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <ChevronRight className="w-4 h-4" />
+            </button>
+            <button
+              onClick={() => handlePageChange(totalPages)}
+              disabled={clampedPage === totalPages}
+              className="p-2 rounded-lg bg-light-surface text-gray-700 dark:bg-white/[0.04] dark:text-text-tertiary hover:bg-gray-200 dark:hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <ChevronsRight className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/ForkTimeline.tsx
+++ b/src/components/ForkTimeline.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { Package, Search, X, RefreshCw, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-react';
-import { ForkRepo, WorkflowRun } from '../types';
+import { ForkRepo, WorkflowDefinition } from '../types';
 import { useAppStore } from '../store/useAppStore';
 import { GitHubApiService } from '../services/githubApi';
 import { formatDistanceToNow } from 'date-fns';
@@ -33,14 +33,14 @@ export const ForkTimeline: React.FC = () => {
     setForkIsRefreshing,
   } = useAppStore();
 
-  const { toast } = useDialog();
+  const { toast, confirm } = useDialog();
 
   const [lastRefreshTime, setLastRefreshTime] = useState<string | null>(null);
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(20);
   // Workflow expansion state (local UI state)
   const [expandedWorkflows, setExpandedWorkflows] = useState<Set<number>>(new Set());
-  const [workflowsMap, setWorkflowsMap] = useState<Record<number, WorkflowRun[]>>({});
+  const [workflowsMap, setWorkflowsMap] = useState<Record<number, WorkflowDefinition[]>>({});
   const [loadingWorkflows, setLoadingWorkflows] = useState<Set<number>>(new Set());
   const [syncingForks, setSyncingForks] = useState<Set<number>>(new Set());
 
@@ -263,6 +263,25 @@ export const ForkTimeline: React.FC = () => {
       return;
     }
 
+    // Only forks (those with a parent/source) can be synced
+    if (!fork.parent && !fork.source) {
+      toast(language === 'zh'
+        ? `${fork.name} 不是 Fork 仓库，无法同步上游。`
+        : `${fork.name} is not a fork. Cannot sync upstream.`,
+        'error'
+      );
+      return;
+    }
+
+    const confirmed = await confirm(
+      language === 'zh' ? '确认同步' : 'Confirm Sync',
+      language === 'zh'
+        ? `确定要将 "${fork.name}" 同步到上游仓库 "${fork.source?.full_name || fork.parent?.full_name}" 吗？`
+        : `Sync "${fork.name}" with upstream "${fork.source?.full_name || fork.parent?.full_name}"?`,
+      { type: 'info' }
+    );
+    if (!confirmed) return;
+
     setSyncingForks(prev => new Set(prev).add(fork.id));
     try {
       const [owner, repo] = fork.full_name.split('/');
@@ -283,20 +302,33 @@ export const ForkTimeline: React.FC = () => {
         });
       }
 
-      toast(language === 'zh'
-        ? `已同步 ${fork.name} 到最新版本。`
-        : `${fork.name} synced to latest.`,
-        'success'
-      );
+      if (result.mergeType === 'none') {
+        toast(language === 'zh'
+          ? `${fork.name} 已是最新版本，无需同步。`
+          : `${fork.name} is already up to date.`,
+          'info'
+        );
+      } else {
+        toast(language === 'zh'
+          ? `已同步 ${fork.name} 到最新版本。`
+          : `${fork.name} synced to latest.`,
+          'success'
+        );
+      }
     } catch (error) {
       console.error('Sync failed:', error);
       const errorMsg = error instanceof Error ? error.message : String(error);
-      // 409 means already up to date
-      if (errorMsg.includes('409') || errorMsg.toLowerCase().includes('already up to date')) {
+      if (errorMsg === 'NOT_A_FORK') {
         toast(language === 'zh'
-          ? `${fork.name} 已是最新版本。`
-          : `${fork.name} is already up to date.`,
-          'info'
+          ? `${fork.name} 不是 Fork 仓库，无法同步上游。`
+          : `${fork.name} is not a fork. Cannot sync upstream.`,
+          'error'
+        );
+      } else if (errorMsg === 'MERGE_CONFLICT') {
+        toast(language === 'zh'
+          ? `同步失败：${fork.name} 与上游仓库存在合并冲突，请手动解决后重试。`
+          : `Sync failed: ${fork.name} has merge conflicts with upstream. Please resolve manually.`,
+          'error'
         );
       } else {
         toast(language === 'zh'
@@ -314,7 +346,7 @@ export const ForkTimeline: React.FC = () => {
     }
   };
 
-  const handleRunWorkflow = async (forkId: number, workflowPath: string, workflowName: string, branch: string) => {
+  const handleRunWorkflow = async (forkId: number, workflowPath: string, workflowName: string) => {
     if (!githubToken) {
       toast(language === 'zh' ? 'GitHub token 未找到，请重新登录。' : 'GitHub token not found. Please login again.', 'error');
       return;
@@ -323,6 +355,7 @@ export const ForkTimeline: React.FC = () => {
     const fork = forks.find(f => f.id === forkId);
     if (!fork) return;
 
+    const branch = fork.default_branch || 'main';
     try {
       const [owner, repo] = fork.full_name.split('/');
       const githubApi = new GitHubApiService(githubToken);
@@ -565,7 +598,7 @@ export const ForkTimeline: React.FC = () => {
                 onToggleWorkflows={() => toggleWorkflows(fork.id)}
                 onSyncUpstream={() => handleSyncUpstream(fork)}
                 onMarkAsRead={() => markForkAsRead(fork.id)}
-                onRunWorkflow={(workflowId, workflowName, branch) => handleRunWorkflow(fork.id, workflowId, workflowName, branch)}
+                onRunWorkflow={(workflowPath, workflowName) => handleRunWorkflow(fork.id, workflowPath, workflowName)}
                 workflows={workflows}
                 isLoadingWorkflows={isLoadingWf}
                 isSyncing={isSyncing}

--- a/src/components/ForkTimeline.tsx
+++ b/src/components/ForkTimeline.tsx
@@ -43,6 +43,7 @@ export const ForkTimeline: React.FC = () => {
   const [workflowsMap, setWorkflowsMap] = useState<Record<number, WorkflowDefinition[]>>({});
   const [loadingWorkflows, setLoadingWorkflows] = useState<Set<number>>(new Set());
   const [syncingForks, setSyncingForks] = useState<Set<number>>(new Set());
+  const [runningWorkflows, setRunningWorkflows] = useState<Set<number>>(new Set());
 
   // Alias global state for local use
   const viewMode = forkViewMode;
@@ -356,6 +357,7 @@ export const ForkTimeline: React.FC = () => {
     if (!fork) return;
 
     const branch = fork.default_branch || 'main';
+    setRunningWorkflows(prev => new Set(prev).add(forkId));
     try {
       const [owner, repo] = fork.full_name.split('/');
       const githubApi = new GitHubApiService(githubToken);
@@ -376,6 +378,12 @@ export const ForkTimeline: React.FC = () => {
         : `Failed to run workflow.`,
         'error'
       );
+    } finally {
+      setRunningWorkflows(prev => {
+        const next = new Set(prev);
+        next.delete(forkId);
+        return next;
+      });
     }
   };
 
@@ -417,7 +425,7 @@ export const ForkTimeline: React.FC = () => {
         <div className="flex flex-col gap-4 mb-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
             <h2 className="text-2xl font-bold text-gray-900 dark:text-text-primary mb-2">
-              {t('复刻时间线', 'Fork Timeline')}
+              {t('复刻', 'Fork')}
             </h2>
             <p className="text-gray-700 dark:text-text-tertiary">
               {t(`管理您的 ${forks.length} 个Fork仓库`, `Manage your ${forks.length} forked repositories`)}
@@ -588,6 +596,7 @@ export const ForkTimeline: React.FC = () => {
             const workflows = workflowsMap[fork.id] || [];
             const isLoadingWf = loadingWorkflows.has(fork.id);
             const isSyncing = syncingForks.has(fork.id);
+            const isRunningWf = runningWorkflows.has(fork.id);
 
             return (
               <ForkCard
@@ -602,6 +611,7 @@ export const ForkTimeline: React.FC = () => {
                 workflows={workflows}
                 isLoadingWorkflows={isLoadingWf}
                 isSyncing={isSyncing}
+                isRunningWorkflow={isRunningWf}
                 language={language}
               />
             );

--- a/src/components/ForkTimeline.tsx
+++ b/src/components/ForkTimeline.tsx
@@ -264,8 +264,8 @@ export const ForkTimeline: React.FC = () => {
       return;
     }
 
-    // Only forks (those with a parent/source) can be synced
-    if (!fork.parent && !fork.source) {
+    // Only actual forks can be synced
+    if (!fork.fork) {
       toast(language === 'zh'
         ? `${fork.name} 不是 Fork 仓库，无法同步上游。`
         : `${fork.name} is not a fork. Cannot sync upstream.`,
@@ -572,7 +572,7 @@ export const ForkTimeline: React.FC = () => {
       {/* Fork List */}
       <div className="space-y-2">
         {paginatedForks.length === 0 ? (
-          <div className="text-center py-12 bg-light-bg dark:bg-panel-dark/50 rounded-xl border-2 border-dashed border-black/[0.06]-alt dark:border-white/[0.04]">
+          <div className="text-center py-12 bg-light-bg dark:bg-panel-dark/50 rounded-xl border-2 border-dashed border-black/[0.06] dark:border-white/[0.04]">
             <Package className="w-12 h-12 text-gray-400 dark:text-text-secondary mx-auto mb-3" />
             <h3 className="text-lg font-medium text-gray-900 dark:text-text-secondary mb-1">
               {t('无符合条件的结果', 'No matching results')}

--- a/src/components/ForkTimeline.tsx
+++ b/src/components/ForkTimeline.tsx
@@ -258,8 +258,6 @@ export const ForkTimeline: React.FC = () => {
   const loadWorkflows = async (forkId: number) => {
     const fork = forks.find(f => f.id === forkId);
     if (!fork || !githubToken) return;
-    const fork = forks.find(f => f.id === forkId);
-    if (!fork) return;
 
     setLoadingWorkflows(prev => new Set(prev).add(forkId));
     try {

--- a/src/components/ForkTimeline.tsx
+++ b/src/components/ForkTimeline.tsx
@@ -204,13 +204,25 @@ export const ForkTimeline: React.FC = () => {
         const [owner, repo] = fork.full_name.split('/');
         const branch = fork.default_branch || 'main';
         try {
-          const needsSync = await githubApi.checkForkSyncNeeded(
+          const result = await githubApi.checkForkSyncNeeded(
             owner, 
             repo, 
             branch, 
             fork.parent?.full_name || fork.source?.full_name
           );
-          setNeedsSyncMap(prev => ({ ...prev, [fork.id]: needsSync }));
+          setNeedsSyncMap(prev => ({ ...prev, [fork.id]: result.needsSync }));
+          
+          if (result.parentFullName && result.parentHtmlUrl && !fork.parent && !fork.source) {
+            setForks(prev => prev.map(f => f.id === fork.id ? { 
+              ...f, 
+              parent: { 
+                id: 0, 
+                full_name: result.parentFullName as string, 
+                name: (result.parentFullName as string).split('/')[1], 
+                html_url: result.parentHtmlUrl as string 
+              } 
+            } : f));
+          }
         } catch {
           setNeedsSyncMap(prev => ({ ...prev, [fork.id]: false }));
         }

--- a/src/components/ForkTimeline.tsx
+++ b/src/components/ForkTimeline.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
-import { Package, Search, X, RefreshCw, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight } from 'lucide-react';
+import { Package, Search, X, RefreshCw, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, Loader2, GitFork } from 'lucide-react';
 import { ForkRepo, WorkflowDefinition } from '../types';
 import { useAppStore } from '../store/useAppStore';
 import { GitHubApiService } from '../services/githubApi';
 import { formatDistanceToNow } from 'date-fns';
 import ForkCard from './ForkCard';
 import { useDialog } from '../hooks/useDialog';
-import { GitFork } from 'lucide-react';
+import { Modal } from './Modal';
 
 export const ForkTimeline: React.FC = () => {
   const {
@@ -46,6 +46,25 @@ export const ForkTimeline: React.FC = () => {
   const [runningWorkflows, setRunningWorkflows] = useState<Set<number>>(new Set());
   // Track which forks need sync (out-of-date vs already-up-to-date)
   const [needsSyncMap, setNeedsSyncMap] = useState<Record<number, boolean>>({});
+
+  // Sync Modal state
+  const [syncModal, setSyncModal] = useState<{
+    isOpen: boolean;
+    forkId: number | null;
+    owner: string;
+    repo: string;
+    branch: string;
+    full_name: string;
+  }>({
+    isOpen: false,
+    forkId: null,
+    owner: '',
+    repo: '',
+    branch: 'main',
+    full_name: ''
+  });
+  const [syncModalBranches, setSyncModalBranches] = useState<string[]>([]);
+  const [isFetchingBranches, setIsFetchingBranches] = useState(false);
 
   // Alias global state for local use
   const viewMode = forkViewMode;
@@ -213,7 +232,8 @@ export const ForkTimeline: React.FC = () => {
           setNeedsSyncMap(prev => ({ ...prev, [fork.id]: result.needsSync }));
           
           if (result.parentFullName && result.parentHtmlUrl && !fork.parent && !fork.source) {
-            setForks(prev => prev.map(f => f.id === fork.id ? { 
+            const currentForks = useAppStore.getState().forks;
+            setForks(currentForks.map(f => f.id === fork.id ? { 
               ...f, 
               parent: { 
                 id: 0, 
@@ -299,20 +319,46 @@ export const ForkTimeline: React.FC = () => {
       return;
     }
 
-    const confirmed = await confirm(
-      language === 'zh' ? 'Update branch' : 'Update branch',
-      language === 'zh'
-        ? `将 ${fork.name} 的 ${fork.default_branch || 'main'} 分支更新到上游仓库的最新版本？`
-        : `Update ${fork.name}'s ${fork.default_branch || 'main'} branch by merging upstream changes?`,
-      { type: 'info' }
-    );
-    if (!confirmed) return;
-
-    setSyncingForks(prev => new Set(prev).add(fork.id));
+    const defaultBranch = fork.default_branch || 'main';
+    const [owner, repo] = fork.full_name.split('/');
+    
+    setSyncModal({
+      isOpen: true,
+      forkId: fork.id,
+      owner,
+      repo,
+      branch: defaultBranch,
+      full_name: fork.full_name
+    });
+    setSyncModalBranches([]);
+    setIsFetchingBranches(true);
+    
     try {
-      const [owner, repo] = fork.full_name.split('/');
       const githubApi = new GitHubApiService(githubToken);
-      const result = await githubApi.syncFork(owner, repo, fork.default_branch || 'main');
+      const branches = await githubApi.getBranches(owner, repo);
+      setSyncModalBranches(branches);
+      if (branches.length > 0 && !branches.includes(defaultBranch)) {
+        setSyncModal(prev => ({ ...prev, branch: branches[0] }));
+      }
+    } finally {
+      setIsFetchingBranches(false);
+    }
+  };
+
+  const confirmSyncUpstream = async () => {
+    if (!githubToken || !syncModal.forkId) return;
+
+    const fork = forks.find(f => f.id === syncModal.forkId);
+    if (!fork) return;
+
+    const { owner, repo, branch } = syncModal;
+
+    setSyncModal(prev => ({ ...prev, isOpen: false }));
+    setSyncingForks(prev => new Set(prev).add(fork.id));
+    
+    try {
+      const githubApi = new GitHubApiService(githubToken);
+      const result = await githubApi.syncFork(owner, repo, branch);
 
       // Mark fork as up-to-date in UI
       setNeedsSyncMap(prev => ({ ...prev, [fork.id]: false }));
@@ -325,8 +371,8 @@ export const ForkTimeline: React.FC = () => {
         );
       } else {
         toast(language === 'zh'
-          ? `已将 ${fork.name} 更新到上游最新版本。`
-          : `${fork.name} has been updated from upstream.`,
+          ? `已将 ${fork.name} 成功更新到上游最新版本。`
+          : `${fork.name} has been successfully updated from upstream.`,
           'success'
         );
       }
@@ -688,6 +734,63 @@ export const ForkTimeline: React.FC = () => {
           </div>
         </div>
       )}
+
+      {/* Sync Branch Modal */}
+      <Modal
+        isOpen={syncModal.isOpen}
+        onClose={() => setSyncModal(prev => ({ ...prev, isOpen: false }))}
+        title={language === 'zh' ? '同步上游代码 (Sync upstream)' : 'Sync Upstream'}
+      >
+        <div className="space-y-4">
+          <p className="text-sm text-gray-600 dark:text-text-tertiary">
+            {language === 'zh' 
+              ? `选择要将上游变更合并到的分支 (${syncModal.full_name})：`
+              : `Select the branch to merge upstream changes into for ${syncModal.full_name}:`}
+          </p>
+
+          <div className="flex flex-col space-y-2">
+            <label className="text-sm font-medium text-gray-900 dark:text-text-secondary">
+              {language === 'zh' ? '目标分支 (Target Branch)' : 'Target Branch'}
+            </label>
+            {isFetchingBranches ? (
+              <div className="flex items-center space-x-2 text-sm text-gray-500 dark:text-text-tertiary py-2">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                <span>{language === 'zh' ? '加载分支列表中...' : 'Loading branches...'}</span>
+              </div>
+            ) : (
+              <select
+                value={syncModal.branch}
+                onChange={(e) => setSyncModal(prev => ({ ...prev, branch: e.target.value }))}
+                className="w-full px-3 py-2 bg-white dark:bg-panel-dark border border-gray-300 dark:border-white/[0.08] rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-brand-indigo focus:border-transparent dark:text-text-primary"
+              >
+                {syncModalBranches.length > 0 ? (
+                  syncModalBranches.map(b => (
+                    <option key={b} value={b}>{b}</option>
+                  ))
+                ) : (
+                  <option value={syncModal.branch}>{syncModal.branch}</option>
+                )}
+              </select>
+            )}
+          </div>
+
+          <div className="flex justify-end space-x-3 pt-4">
+            <button
+              onClick={() => setSyncModal(prev => ({ ...prev, isOpen: false }))}
+              className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-text-secondary bg-gray-100 dark:bg-white/[0.04] hover:bg-gray-200 dark:hover:bg-white/[0.08] rounded-lg transition-colors"
+            >
+              {language === 'zh' ? '取消' : 'Cancel'}
+            </button>
+            <button
+              onClick={confirmSyncUpstream}
+              disabled={isFetchingBranches || !syncModal.branch}
+              className="px-4 py-2 text-sm font-medium text-white bg-brand-indigo hover:bg-brand-hover rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {language === 'zh' ? '确认同步' : 'Sync Branch'}
+            </button>
+          </div>
+        </div>
+      </Modal>
     </div>
   );
 };

--- a/src/components/ForkTimeline.tsx
+++ b/src/components/ForkTimeline.tsx
@@ -44,6 +44,8 @@ export const ForkTimeline: React.FC = () => {
   const [loadingWorkflows, setLoadingWorkflows] = useState<Set<number>>(new Set());
   const [syncingForks, setSyncingForks] = useState<Set<number>>(new Set());
   const [runningWorkflows, setRunningWorkflows] = useState<Set<number>>(new Set());
+  // Track which forks need sync (out-of-date vs already-up-to-date)
+  const [needsSyncMap, setNeedsSyncMap] = useState<Record<number, boolean>>({});
 
   // Alias global state for local use
   const viewMode = forkViewMode;
@@ -60,6 +62,9 @@ export const ForkTimeline: React.FC = () => {
   // Filter and sort forks
   const filteredForks = useMemo(() => {
     let filtered = [...forks];
+
+    // Only show actual forks (not user-created repos)
+    filtered = filtered.filter(fork => fork.fork === true);
 
     // Sort by source.updated_at desc (upstream latest update first)
     filtered.sort((a, b) => {
@@ -193,6 +198,20 @@ export const ForkTimeline: React.FC = () => {
       const now = new Date().toISOString();
       setLastRefreshTime(now);
 
+      // Pre-check sync status for all forks (out-of-date vs already up-to-date)
+      const syncChecks: Promise<void>[] = updatedForks.map(async (fork) => {
+        if (!fork.fork) return;
+        const [owner, repo] = fork.full_name.split('/');
+        const branch = fork.default_branch || 'main';
+        try {
+          const needsSync = await githubApi.checkForkSyncNeeded(owner, repo, branch);
+          setNeedsSyncMap(prev => ({ ...prev, [fork.id]: needsSync }));
+        } catch {
+          setNeedsSyncMap(prev => ({ ...prev, [fork.id]: false }));
+        }
+      });
+      await Promise.all(syncChecks);
+
       // Count new forks
       const newCount = newForks.filter(f => !existingForkMap.has(f.id)).length;
       if (newCount > 0) {
@@ -237,7 +256,8 @@ export const ForkTimeline: React.FC = () => {
   };
 
   const loadWorkflows = async (forkId: number) => {
-    if (!githubToken) return;
+    const fork = forks.find(f => f.id === forkId);
+    if (!fork || !githubToken) return;
     const fork = forks.find(f => f.id === forkId);
     if (!fork) return;
 
@@ -264,21 +284,11 @@ export const ForkTimeline: React.FC = () => {
       return;
     }
 
-    // Only actual forks can be synced
-    if (!fork.fork) {
-      toast(language === 'zh'
-        ? `${fork.name} 不是 Fork 仓库，无法同步上游。`
-        : `${fork.name} is not a fork. Cannot sync upstream.`,
-        'error'
-      );
-      return;
-    }
-
     const confirmed = await confirm(
-      language === 'zh' ? '确认同步' : 'Confirm Sync',
+      language === 'zh' ? 'Update branch' : 'Update branch',
       language === 'zh'
-        ? `确定要将 "${fork.name}" 同步到上游仓库 "${fork.source?.full_name || fork.parent?.full_name}" 吗？`
-        : `Sync "${fork.name}" with upstream "${fork.source?.full_name || fork.parent?.full_name}"?`,
+        ? `将 ${fork.name} 的 ${fork.default_branch || 'main'} 分支更新到上游仓库的最新版本？`
+        : `Update ${fork.name}'s ${fork.default_branch || 'main'} branch by merging upstream changes?`,
       { type: 'info' }
     );
     if (!confirmed) return;
@@ -289,30 +299,19 @@ export const ForkTimeline: React.FC = () => {
       const githubApi = new GitHubApiService(githubToken);
       const result = await githubApi.syncFork(owner, repo, fork.default_branch || 'main');
 
-      // Update fork's upstream_updated_at and clear unread badge (user took action)
-      if (result.sourceUpdatedAt) {
-        updateFork({
-          ...fork,
-          upstream_updated_at: result.sourceUpdatedAt,
-        });
-        // Clear unread badge after sync
-        useAppStore.setState(state => {
-          const newReadForks = new Set(state.readForks);
-          newReadForks.add(fork.id);
-          return { readForks: newReadForks };
-        });
-      }
+      // Mark fork as up-to-date in UI
+      setNeedsSyncMap(prev => ({ ...prev, [fork.id]: false }));
 
       if (result.mergeType === 'none') {
         toast(language === 'zh'
-          ? `${fork.name} 已是最新版本，无需同步。`
+          ? `${fork.name} 已是最新版本，无需更新。`
           : `${fork.name} is already up to date.`,
           'info'
         );
       } else {
         toast(language === 'zh'
-          ? `已同步 ${fork.name} 到最新版本。`
-          : `${fork.name} synced to latest.`,
+          ? `已将 ${fork.name} 更新到上游最新版本。`
+          : `${fork.name} has been updated from upstream.`,
           'success'
         );
       }
@@ -597,6 +596,7 @@ export const ForkTimeline: React.FC = () => {
             const isLoadingWf = loadingWorkflows.has(fork.id);
             const isSyncing = syncingForks.has(fork.id);
             const isRunningWf = runningWorkflows.has(fork.id);
+            const needsSync = needsSyncMap[fork.id] ?? true;
 
             return (
               <ForkCard
@@ -612,6 +612,7 @@ export const ForkTimeline: React.FC = () => {
                 isLoadingWorkflows={isLoadingWf}
                 isSyncing={isSyncing}
                 isRunningWorkflow={isRunningWf}
+                needsSync={needsSync}
                 language={language}
               />
             );

--- a/src/components/ForkTimeline.tsx
+++ b/src/components/ForkTimeline.tsx
@@ -204,7 +204,12 @@ export const ForkTimeline: React.FC = () => {
         const [owner, repo] = fork.full_name.split('/');
         const branch = fork.default_branch || 'main';
         try {
-          const needsSync = await githubApi.checkForkSyncNeeded(owner, repo, branch);
+          const needsSync = await githubApi.checkForkSyncNeeded(
+            owner, 
+            repo, 
+            branch, 
+            fork.parent?.full_name || fork.source?.full_name
+          );
           setNeedsSyncMap(prev => ({ ...prev, [fork.id]: needsSync }));
         } catch {
           setNeedsSyncMap(prev => ({ ...prev, [fork.id]: false }));
@@ -425,7 +430,7 @@ export const ForkTimeline: React.FC = () => {
               {t('复刻', 'Fork')}
             </h2>
             <p className="text-gray-700 dark:text-text-tertiary">
-              {t(`管理您的 ${forks.length} 个Fork仓库`, `Manage your ${forks.length} forked repositories`)}
+              {t(`管理您的 ${forks.filter(f => f.fork).length} 个Fork仓库`, `Manage your ${forks.filter(f => f.fork).length} forked repositories`)}
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-2 sm:gap-3">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { Settings, Calendar, Search, Moon, Sun, LogOut, RefreshCw, TrendingUp } from 'lucide-react';
+import { Settings, Calendar, Search, Moon, Sun, LogOut, RefreshCw, TrendingUp, GitFork } from 'lucide-react';
 import { useAppStore } from '../store/useAppStore';
 import { GitHubApiService } from '../services/githubApi';
 import { useDialog } from '../hooks/useDialog';
@@ -208,6 +208,19 @@ export const Header: React.FC = () => {
               {!isTextWrapped && t('发布', 'Releases')}
             </button>
             <button
+              onClick={() => setCurrentView('forks')}
+              aria-label={isTextWrapped ? t('复刻', 'Forks') : undefined}
+              title={isTextWrapped ? t('复刻', 'Forks') : undefined}
+              className={`${isTextWrapped ? 'p-2.5' : 'px-4 py-2'} rounded-lg font-medium transition-colors ${
+                currentView === 'forks'
+                  ? 'bg-white dark:bg-white/[0.1] text-gray-900 dark:text-text-primary shadow-sm border border-black/[0.06] dark:border-white/[0.04]'
+                  : 'text-gray-700 dark:text-text-secondary hover:bg-light-surface dark:hover:bg-white/5'
+              }`}
+            >
+              <GitFork className={`${isTextWrapped ? 'w-5 h-5' : 'w-4 h-4'} ${isTextWrapped ? '' : 'inline mr-2'}`} />
+              {!isTextWrapped && t('复刻', 'Forks')}
+            </button>
+            <button
               onClick={() => setCurrentView('subscription')}
               className={`${isTextWrapped ? 'p-2.5' : 'px-4 py-2'} rounded-lg font-medium transition-colors ${
                 currentView === 'subscription'
@@ -256,6 +269,17 @@ export const Header: React.FC = () => {
               title={t('发布', 'Releases')}
             >
               <Calendar className="w-5 h-5" />
+            </button>
+            <button
+              onClick={() => setCurrentView('forks')}
+              className={`p-2.5 rounded-lg transition-colors ${
+                currentView === 'forks'
+                  ? 'bg-white dark:bg-white/[0.1] text-gray-900 dark:text-text-primary shadow-sm border border-black/[0.06] dark:border-white/[0.04]'
+                  : 'text-gray-700 dark:text-text-secondary hover:bg-light-surface dark:hover:bg-white/5'
+              }`}
+              title={t('复刻', 'Forks')}
+            >
+              <GitFork className="w-5 h-5" />
             </button>
             <button
               onClick={() => setCurrentView('subscription')}
@@ -320,6 +344,22 @@ export const Header: React.FC = () => {
                   <div className="flex items-center">
                     <Calendar className="w-5 h-5 mr-3" />
                     {t('发布', 'Releases')}
+                  </div>
+                </button>
+                <button
+                  onClick={() => {
+                    setCurrentView('forks');
+                    setMobileMenuOpen(false);
+                  }}
+                  className={`flex items-center justify-between px-4 py-3 rounded-lg font-medium transition-colors ${
+                    currentView === 'forks'
+                      ? 'bg-white dark:bg-white/[0.1] text-gray-900 dark:text-text-primary shadow-sm border border-black/[0.06] dark:border-white/[0.04]'
+                      : 'text-gray-700 dark:text-text-secondary hover:bg-light-surface dark:hover:bg-white/5'
+                  }`}
+                >
+                  <div className="flex items-center">
+                    <GitFork className="w-5 h-5 mr-3" />
+                    {t('复刻', 'Forks')}
                   </div>
                 </button>
                 <button

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -983,7 +983,7 @@ async getUserForks(): Promise<ForkRepo[]> {
     // Use GitHub's merge upstream API to sync the fork with its upstream
     try {
       const result = await this.makeRequest<{ merge_type: string; message?: string }>(
-        `/repos/${owner}/${repo}/merge_upstream`,
+        `/repos/${owner}/${repo}/merge-upstream`,
         {
           method: 'POST',
           body: JSON.stringify({ branch }),

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -1008,18 +1008,25 @@ async getUserForks(): Promise<ForkRepo[]> {
   }
 
   // Check if a fork's branch is behind its upstream — returns true if "out-of-date"
-  async checkForkSyncNeeded(owner: string, repo: string, branch: string): Promise<boolean> {
+  async checkForkSyncNeeded(owner: string, repo: string, branch: string, parentFullName?: string): Promise<boolean> {
     try {
-      await this.makeRequest<{ merge_type: string }>(
-        `/repos/${owner}/${repo}/merge_upstream`,
-        { method: 'POST', body: JSON.stringify({ ref: branch }) }
-      );
-      return true;
-    } catch (error) {
-      if (error instanceof Error && error.message.includes('422')) {
-        return false;
+      let parentOwner = '';
+      if (parentFullName) {
+        parentOwner = parentFullName.split('/')[0];
+      } else {
+        const repoData = await this.makeRequest<{ parent?: { owner: { login: string } } }>(`/repos/${owner}/${repo}`);
+        if (!repoData.parent) return false;
+        parentOwner = repoData.parent.owner.login;
       }
-      throw error;
+
+      const compareData = await this.makeRequest<{ behind_by: number }>(
+        `/repos/${owner}/${repo}/compare/${parentOwner}:${branch}...${owner}:${branch}`
+      );
+      
+      return compareData.behind_by > 0;
+    } catch (error) {
+      console.warn(`Failed to check sync status for ${owner}/${repo}:`, error);
+      return false;
     }
   }
 

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -1006,6 +1006,14 @@ async getUserForks(): Promise<ForkRepo[]> {
         if (msg.includes('409')) {
           throw new Error('MERGE_CONFLICT');
         }
+        // 422: branch is already up to date (GitHub returns 422 Unprocessable Entity for this)
+        if (msg.includes('422')) {
+          return {
+            hasUpdates: false,
+            sourceUpdatedAt: null,
+            mergeType: 'none',
+          };
+        }
       }
       throw error;
     }

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -14,7 +14,7 @@ import {
   GitHubSearchUserResponse,
   GitHubUserDetail,
   ForkRepo,
-  WorkflowRun,
+  WorkflowDefinition,
 } from '../types';
 
 interface GitHubStarredItem {
@@ -956,21 +956,17 @@ export class GitHubApiService {
 
 async getUserForks(): Promise<ForkRepo[]> {
     try {
-      // Use the search API to find all forks owned by the authenticated user
-      // The /user/forks endpoint doesn't exist; use search: user:{login} fork:true
-      const user = await this.makeRequest<{ login: string }>('/user');
-      const login = user.login;
-
+      // Use /user/repos?type=forks to get only repositories the user has forked
       let allForks: ForkRepo[] = [];
       let page = 1;
       const perPage = 100;
 
       while (true) {
-        const data = await this.makeRequest<{ items: ForkRepo[]; total_count: number }>(
-          `/search/repositories?q=user:${login}+fork:true&sort=updated&per_page=${perPage}&page=${page}`
+        const forks = await this.makeRequest<ForkRepo[]>(
+          `/user/repos?type=forks&sort=updated&per_page=${perPage}&page=${page}`
         );
-        allForks = [...allForks, ...data.items];
-        if (data.items.length < perPage) break;
+        allForks = [...allForks, ...forks];
+        if (forks.length < perPage) break;
         page++;
         // Rate limiting protection
         await new Promise(resolve => setTimeout(resolve, 100));
@@ -983,10 +979,10 @@ async getUserForks(): Promise<ForkRepo[]> {
     }
   }
 
-  async syncFork(owner: string, repo: string, branch: string): Promise<{ hasUpdates: boolean; sourceUpdatedAt: string | null }> {
+  async syncFork(owner: string, repo: string, branch: string): Promise<{ hasUpdates: boolean; sourceUpdatedAt: string | null; mergeType?: string }> {
     // Use GitHub's merge upstream API to sync the fork with its upstream
     try {
-      await this.makeRequest<{ message: string }>(
+      const result = await this.makeRequest<{ merge_type: string; message?: string }>(
         `/repos/${owner}/${repo}/merge_upstream`,
         {
           method: 'POST',
@@ -994,32 +990,45 @@ async getUserForks(): Promise<ForkRepo[]> {
         }
       );
       return {
-        hasUpdates: false,
+        hasUpdates: result.merge_type !== 'none',
         sourceUpdatedAt: new Date().toISOString(),
+        mergeType: result.merge_type,
       };
     } catch (error) {
-      // 409 Conflict means nothing to merge (already up to date) - not an error
-      // Any other error should be thrown
+      if (error instanceof Error) {
+        // Check for HTTP status in error message
+        const msg = error.message;
+        // 404: not a fork (no upstream configured) — treat as not syncable
+        if (msg.includes('404')) {
+          throw new Error('NOT_A_FORK');
+        }
+        // 409: merge conflict — can't auto-merge
+        if (msg.includes('409')) {
+          throw new Error('MERGE_CONFLICT');
+        }
+      }
       throw error;
     }
   }
 
-  async getRepositoryWorkflows(owner: string, repo: string): Promise<WorkflowRun[]> {
+  async getRepositoryWorkflows(owner: string, repo: string): Promise<WorkflowDefinition[]> {
     try {
-      // Use expand=run to include workflow path and definition ID in the response
-      const runs = await this.makeRequest<{ workflow_runs: WorkflowRun[] }>(
-        `/repos/${owner}/${repo}/actions/runs?per_page=20&expand=run`
+      // GET /repos/{owner}/{repo}/actions/workflows lists workflow files (definitions), not runs
+      const data = await this.makeRequest<{ workflows: WorkflowDefinition[] }>(
+        `/repos/${owner}/${repo}/actions/workflows?per_page=100`
       );
-      return runs.workflow_runs || [];
+      return data.workflows || [];
     } catch (error) {
       console.warn(`Failed to fetch workflows for ${owner}/${repo}:`, error);
       return [];
     }
   }
 
-  async triggerWorkflowRun(owner: string, repo: string, workflowId: string, branch: string): Promise<void> {
+  async triggerWorkflowRun(owner: string, repo: string, workflowPath: string, branch: string): Promise<void> {
+    // workflowPath is the file path (e.g. ".github/workflows/ci.yml") — URL-encode it
+    const encodedPath = encodeURIComponent(workflowPath);
     await this.makeRequest<void>(
-      `/repos/${owner}/${repo}/actions/workflows/${workflowId}/dispatches`,
+      `/repos/${owner}/${repo}/actions/workflows/${encodedPath}/dispatches`,
       {
         method: 'POST',
         body: JSON.stringify({ ref: branch }),

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -996,24 +996,28 @@ async getUserForks(): Promise<ForkRepo[]> {
       };
     } catch (error) {
       if (error instanceof Error) {
-        // Check for HTTP status in error message
         const msg = error.message;
-        // 404: not a fork (no upstream configured) — treat as not syncable
-        if (msg.includes('404')) {
-          throw new Error('NOT_A_FORK');
-        }
-        // 409: merge conflict — can't auto-merge
-        if (msg.includes('409')) {
-          throw new Error('MERGE_CONFLICT');
-        }
-        // 422: branch is already up to date (GitHub returns 422 Unprocessable Entity for this)
+        if (msg.includes('404')) throw new Error('NOT_A_FORK');
+        if (msg.includes('409')) throw new Error('MERGE_CONFLICT');
         if (msg.includes('422')) {
-          return {
-            hasUpdates: false,
-            sourceUpdatedAt: null,
-            mergeType: 'none',
-          };
+          return { hasUpdates: false, sourceUpdatedAt: null, mergeType: 'none' };
         }
+      }
+      throw error;
+    }
+  }
+
+  // Check if a fork's branch is behind its upstream — returns true if "out-of-date"
+  async checkForkSyncNeeded(owner: string, repo: string, branch: string): Promise<boolean> {
+    try {
+      await this.makeRequest<{ merge_type: string }>(
+        `/repos/${owner}/${repo}/merge_upstream`,
+        { method: 'POST', body: JSON.stringify({ ref: branch }) }
+      );
+      return true;
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('422')) {
+        return false;
       }
       throw error;
     }

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -956,22 +956,41 @@ export class GitHubApiService {
 
 async getUserForks(): Promise<ForkRepo[]> {
     try {
-      const forks = await this.makeRequest<ForkRepo[]>(`/user/forks?per_page=100&sort=updated`);
-      return forks;
+      // Use the search API to find all forks owned by the authenticated user
+      // The /user/forks endpoint doesn't exist; use search: user:{login} fork:true
+      const user = await this.makeRequest<{ login: string }>('/user');
+      const login = user.login;
+
+      let allForks: ForkRepo[] = [];
+      let page = 1;
+      const perPage = 100;
+
+      while (true) {
+        const data = await this.makeRequest<{ items: ForkRepo[]; total_count: number }>(
+          `/search/repositories?q=user:${login}+fork:true&sort=updated&per_page=${perPage}&page=${page}`
+        );
+        allForks = [...allForks, ...data.items];
+        if (data.items.length < perPage) break;
+        page++;
+        // Rate limiting protection
+        await new Promise(resolve => setTimeout(resolve, 100));
+      }
+
+      return allForks;
     } catch (error) {
       console.warn('Failed to fetch user forks:', error);
       throw error;
     }
   }
 
-  async syncFork(owner: string, repo: string): Promise<{ hasUpdates: boolean; sourceUpdatedAt: string | null }> {
+  async syncFork(owner: string, repo: string, branch: string): Promise<{ hasUpdates: boolean; sourceUpdatedAt: string | null }> {
     // Use GitHub's merge upstream API to sync the fork with its upstream
     try {
-      const result = await this.makeRequest<{ message: string }>(
+      await this.makeRequest<{ message: string }>(
         `/repos/${owner}/${repo}/merge_upstream`,
         {
           method: 'POST',
-          body: JSON.stringify({ ref: 'main' }),
+          body: JSON.stringify({ ref: branch }),
         }
       );
       return {
@@ -987,8 +1006,9 @@ async getUserForks(): Promise<ForkRepo[]> {
 
   async getRepositoryWorkflows(owner: string, repo: string): Promise<WorkflowRun[]> {
     try {
+      // Use expand=run to include workflow path and definition ID in the response
       const runs = await this.makeRequest<{ workflow_runs: WorkflowRun[] }>(
-        `/repos/${owner}/${repo}/actions/runs?per_page=20`
+        `/repos/${owner}/${repo}/actions/runs?per_page=20&expand=run`
       );
       return runs.workflow_runs || [];
     } catch (error) {
@@ -997,8 +1017,8 @@ async getUserForks(): Promise<ForkRepo[]> {
     }
   }
 
-  async triggerWorkflowRun(owner: string, repo: string, workflowId: string, branch: string): Promise<{ id: number }> {
-    return this.makeRequest<{ id: number }>(
+  async triggerWorkflowRun(owner: string, repo: string, workflowId: string, branch: string): Promise<void> {
+    await this.makeRequest<void>(
       `/repos/${owner}/${repo}/actions/workflows/${workflowId}/dispatches`,
       {
         method: 'POST',

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -986,7 +986,7 @@ async getUserForks(): Promise<ForkRepo[]> {
         `/repos/${owner}/${repo}/merge_upstream`,
         {
           method: 'POST',
-          body: JSON.stringify({ ref: branch }),
+          body: JSON.stringify({ branch }),
         }
       );
       return {
@@ -1008,25 +1008,34 @@ async getUserForks(): Promise<ForkRepo[]> {
   }
 
   // Check if a fork's branch is behind its upstream — returns true if "out-of-date"
-  async checkForkSyncNeeded(owner: string, repo: string, branch: string, parentFullName?: string): Promise<boolean> {
+  async checkForkSyncNeeded(owner: string, repo: string, branch: string, parentFullName?: string): Promise<{ needsSync: boolean, parentFullName?: string, parentHtmlUrl?: string }> {
     try {
       let parentOwner = '';
+      let resultParentFullName = parentFullName;
+      let resultParentHtmlUrl: string | undefined = undefined;
+
       if (parentFullName) {
         parentOwner = parentFullName.split('/')[0];
       } else {
-        const repoData = await this.makeRequest<{ parent?: { owner: { login: string } } }>(`/repos/${owner}/${repo}`);
-        if (!repoData.parent) return false;
+        const repoData = await this.makeRequest<{ parent?: { owner: { login: string }, full_name: string, html_url: string } }>(`/repos/${owner}/${repo}`);
+        if (!repoData.parent) return { needsSync: false };
         parentOwner = repoData.parent.owner.login;
+        resultParentFullName = repoData.parent.full_name;
+        resultParentHtmlUrl = repoData.parent.html_url;
       }
 
       const compareData = await this.makeRequest<{ behind_by: number }>(
         `/repos/${owner}/${repo}/compare/${parentOwner}:${branch}...${owner}:${branch}`
       );
       
-      return compareData.behind_by > 0;
+      return { 
+        needsSync: compareData.behind_by > 0,
+        parentFullName: resultParentFullName,
+        parentHtmlUrl: resultParentHtmlUrl
+      };
     } catch (error) {
       console.warn(`Failed to check sync status for ${owner}/${repo}:`, error);
-      return false;
+      return { needsSync: false };
     }
   }
 

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -1039,6 +1039,16 @@ async getUserForks(): Promise<ForkRepo[]> {
     }
   }
 
+  async getBranches(owner: string, repo: string): Promise<string[]> {
+    try {
+      const branches = await this.makeRequest<{ name: string }[]>(`/repos/${owner}/${repo}/branches?per_page=100`);
+      return branches.map(b => b.name);
+    } catch (error) {
+      console.warn(`Failed to fetch branches for ${owner}/${repo}:`, error);
+      return [];
+    }
+  }
+
   async getRepositoryWorkflows(owner: string, repo: string): Promise<WorkflowDefinition[]> {
     try {
       // GET /repos/{owner}/{repo}/actions/workflows lists workflow files (definitions), not runs

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -12,7 +12,9 @@ import {
   SubscriptionRepo,
   SubscriptionDev,
   GitHubSearchUserResponse,
-  GitHubUserDetail
+  GitHubUserDetail,
+  ForkRepo,
+  WorkflowRun,
 } from '../types';
 
 interface GitHubStarredItem {
@@ -952,6 +954,58 @@ export class GitHubApiService {
 
 
 
+async getUserForks(): Promise<ForkRepo[]> {
+    try {
+      const forks = await this.makeRequest<ForkRepo[]>(`/user/forks?per_page=100&sort=updated`);
+      return forks;
+    } catch (error) {
+      console.warn('Failed to fetch user forks:', error);
+      throw error;
+    }
+  }
+
+  async syncFork(owner: string, repo: string): Promise<{ hasUpdates: boolean; sourceUpdatedAt: string | null }> {
+    // Use GitHub's merge upstream API to sync the fork with its upstream
+    try {
+      const result = await this.makeRequest<{ message: string }>(
+        `/repos/${owner}/${repo}/merge_upstream`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ ref: 'main' }),
+        }
+      );
+      return {
+        hasUpdates: false,
+        sourceUpdatedAt: new Date().toISOString(),
+      };
+    } catch (error) {
+      // 409 Conflict means nothing to merge (already up to date) - not an error
+      // Any other error should be thrown
+      throw error;
+    }
+  }
+
+  async getRepositoryWorkflows(owner: string, repo: string): Promise<WorkflowRun[]> {
+    try {
+      const runs = await this.makeRequest<{ workflow_runs: WorkflowRun[] }>(
+        `/repos/${owner}/${repo}/actions/runs?per_page=20`
+      );
+      return runs.workflow_runs || [];
+    } catch (error) {
+      console.warn(`Failed to fetch workflows for ${owner}/${repo}:`, error);
+      return [];
+    }
+  }
+
+  async triggerWorkflowRun(owner: string, repo: string, workflowId: string, branch: string): Promise<{ id: number }> {
+    return this.makeRequest<{ id: number }>(
+      `/repos/${owner}/${repo}/actions/workflows/${workflowId}/dispatches`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ ref: branch }),
+      }
+    );
+  }
 }
 
 export const createGitHubOAuthUrl = (clientId: string, redirectUri: string): string => {

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -1,9 +1,10 @@
 import { create } from 'zustand';
 import { persist, PersistStorage, StorageValue } from 'zustand/middleware';
-import { 
-  AppState, 
-  Repository, 
-  Release, 
+import {
+  AppState,
+  Repository,
+  Release,
+  ForkRepo,
   AIConfig, 
   WebDAVConfig, 
   SearchFilters, 
@@ -118,6 +119,13 @@ interface AppActions {
   removeReleasesByRepoId: (repoId: number) => void;
   markReleaseAsRead: (releaseId: number) => void;
   markAllReleasesAsRead: () => void;
+
+  // Fork actions
+  setForks: (forks: ForkRepo[]) => void;
+  addForks: (forks: ForkRepo[]) => void;
+  updateFork: (fork: ForkRepo) => void;
+  markForkAsRead: (forkId: number) => void;
+  markAllForksAsRead: () => void;
   
   // Category actions
   addCustomCategory: (category: Category) => void;
@@ -140,7 +148,7 @@ interface AppActions {
   
   // UI actions
   setTheme: (theme: 'light' | 'dark') => void;
-  setCurrentView: (view: 'repositories' | 'releases' | 'settings' | 'subscription') => void;
+  setCurrentView: (view: 'repositories' | 'releases' | 'forks' | 'settings' | 'subscription') => void;
   setSelectedCategory: (category: string) => void;
   setLanguage: (language: 'zh' | 'en') => void;
   setSidebarCollapsed: (collapsed: boolean) => void;
@@ -169,6 +177,16 @@ interface AppActions {
   setReleaseExpandedRepositories: (repoIds: Set<number>) => void;
   setReleaseIsRefreshing: (refreshing: boolean) => void;
   setIncludePreRelease: (include: boolean) => void;
+
+  // Fork Timeline View actions
+  setForkViewMode: (mode: 'timeline' | 'repository') => void;
+  setForkSelectedFilters: (filters: string[]) => void;
+  toggleForkSelectedFilter: (filterId: string) => void;
+  clearForkSelectedFilters: () => void;
+  setForkSearchQuery: (query: string) => void;
+  toggleForkExpandedRepository: (repoId: number) => void;
+  setForkExpandedRepositories: (repoIds: Set<number>) => void;
+  setForkIsRefreshing: (refreshing: boolean) => void;
 
   // Discovery actions
   setSelectedDiscoveryChannel: (channel: DiscoveryChannelId) => void;
@@ -233,6 +251,11 @@ type PersistedAppState = Partial<
     | 'language'
     | 'searchFilters'
     | 'isSidebarCollapsed'
+    | 'forks'
+    | 'forkViewMode'
+    | 'forkSelectedFilters'
+    | 'forkSearchQuery'
+    | 'forkExpandedRepositories'
     | 'releaseViewMode'
     | 'releaseSelectedFilters'
     | 'releaseSearchQuery'
@@ -256,7 +279,9 @@ type PersistedAppState = Partial<
 > & {
   releaseSubscriptions?: unknown;
   readReleases?: unknown;
+  readForks?: unknown;
   releaseExpandedRepositories?: unknown;
+  forkExpandedRepositories?: unknown;
 };
 
 const normalizeNumberSet = (value: unknown): Set<number> => {
@@ -316,6 +341,12 @@ const normalizePersistedState = (
     searchResults: migratedRepositories,
     releaseSubscriptions: normalizeNumberSet(safePersisted.releaseSubscriptions),
     readReleases: normalizeNumberSet(safePersisted.readReleases),
+    readForks: normalizeNumberSet(safePersisted.readForks),
+    forks: Array.isArray(safePersisted.forks) ? safePersisted.forks : [],
+    forkViewMode: safePersisted.forkViewMode || 'timeline',
+    forkSelectedFilters: Array.isArray(safePersisted.forkSelectedFilters) ? safePersisted.forkSelectedFilters : [],
+    forkSearchQuery: typeof safePersisted.forkSearchQuery === 'string' ? safePersisted.forkSearchQuery : '',
+    forkExpandedRepositories: normalizeNumberSet(safePersisted.forkExpandedRepositories),
     releaseExpandedRepositories: normalizeNumberSet(safePersisted.releaseExpandedRepositories),
     includePreRelease,
     searchFilters: {
@@ -665,6 +696,8 @@ export const useAppStore = create<AppState & AppActions>()(
       releases: [],
       releaseSubscriptions: new Set<number>(),
       readReleases: new Set<number>(),
+      readForks: new Set<number>(),
+      forks: [],
       customCategories: [],
       hiddenDefaultCategoryIds: [],
       defaultCategoryOverrides: {},
@@ -687,6 +720,14 @@ export const useAppStore = create<AppState & AppActions>()(
       releaseExpandedRepositories: new Set<number>(),
       releaseIsRefreshing: false,
       includePreRelease: true,
+
+      forks: [],
+      readForks: new Set<number>(),
+      forkViewMode: 'timeline',
+      forkSelectedFilters: [],
+      forkSearchQuery: '',
+      forkExpandedRepositories: new Set<number>(),
+      forkIsRefreshing: false,
 
       discoveryChannels: defaultDiscoveryChannels,
       discoveryRepos: { 'trending': [], 'hot-release': [], 'most-popular': [], 'topic': [], 'search': [] },
@@ -730,6 +771,8 @@ export const useAppStore = create<AppState & AppActions>()(
         releases: [],
         releaseSubscriptions: new Set(),
         readReleases: new Set(),
+        forks: [],
+        readForks: new Set(),
         analyzingRepositoryIds: new Set(),
         searchResults: [],
         lastSync: null,
@@ -1217,6 +1260,48 @@ export const useAppStore = create<AppState & AppActions>()(
       setReleaseIsRefreshing: (releaseIsRefreshing) => set({ releaseIsRefreshing }),
       setIncludePreRelease: (includePreRelease) => set({ includePreRelease }),
 
+      // Fork actions
+      setForks: (forks) => set({ forks }),
+      addForks: (newForks) => set((state) => {
+        const existingIds = new Set(state.forks.map(f => f.id));
+        const uniqueForks = newForks.filter(f => !existingIds.has(f.id));
+        return { forks: [...state.forks, ...uniqueForks] };
+      }),
+      updateFork: (fork) => set((state) => ({
+        forks: state.forks.map(f => f.id === fork.id ? fork : f),
+      })),
+      markForkAsRead: (forkId) => set((state) => {
+        const newReadForks = new Set(state.readForks);
+        newReadForks.add(forkId);
+        return { readForks: newReadForks };
+      }),
+      markAllForksAsRead: () => set((state) => {
+        const allForkIds = new Set(state.forks.map(f => f.id));
+        return { readForks: allForkIds };
+      }),
+
+      // Fork Timeline View actions
+      setForkViewMode: (forkViewMode) => set({ forkViewMode }),
+      setForkSelectedFilters: (forkSelectedFilters) => set({ forkSelectedFilters }),
+      toggleForkSelectedFilter: (filterId) => set((state) => ({
+        forkSelectedFilters: state.forkSelectedFilters.includes(filterId)
+          ? state.forkSelectedFilters.filter(id => id !== filterId)
+          : [...state.forkSelectedFilters, filterId]
+      })),
+      clearForkSelectedFilters: () => set({ forkSelectedFilters: [] }),
+      setForkSearchQuery: (forkSearchQuery) => set({ forkSearchQuery }),
+      toggleForkExpandedRepository: (repoId) => set((state) => {
+        const newSet = new Set(state.forkExpandedRepositories);
+        if (newSet.has(repoId)) {
+          newSet.delete(repoId);
+        } else {
+          newSet.add(repoId);
+        }
+        return { forkExpandedRepositories: newSet };
+      }),
+      setForkExpandedRepositories: (forkExpandedRepositories) => set({ forkExpandedRepositories }),
+      setForkIsRefreshing: (forkIsRefreshing) => set({ forkIsRefreshing }),
+
     // Discovery actions
     setSelectedDiscoveryChannel: (selectedDiscoveryChannel) => set((state) => ({
       selectedDiscoveryChannel,
@@ -1332,6 +1417,10 @@ export const useAppStore = create<AppState & AppActions>()(
         readReleases: Array.from(state.readReleases),
         releases: state.releases,
 
+        // 持久化Fork数据
+        forks: state.forks,
+        readForks: Array.from(state.readForks),
+
         // 持久化自定义分类
         customCategories: state.customCategories,
         hiddenDefaultCategoryIds: state.hiddenDefaultCategoryIds,
@@ -1363,6 +1452,12 @@ export const useAppStore = create<AppState & AppActions>()(
         releaseSearchQuery: state.releaseSearchQuery,
         releaseExpandedRepositories: Array.from(state.releaseExpandedRepositories),
         includePreRelease: state.includePreRelease,
+
+        // 持久化Fork页面视图设置
+        forkViewMode: state.forkViewMode,
+        forkSelectedFilters: state.forkSelectedFilters,
+        forkSearchQuery: state.forkSearchQuery,
+        forkExpandedRepositories: Array.from(state.forkExpandedRepositories),
 
       // 持久化发现设置
       discoveryChannels: state.discoveryChannels,

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -696,8 +696,6 @@ export const useAppStore = create<AppState & AppActions>()(
       releases: [],
       releaseSubscriptions: new Set<number>(),
       readReleases: new Set<number>(),
-      readForks: new Set<number>(),
-      forks: [],
       customCategories: [],
       hiddenDefaultCategoryIds: [],
       defaultCategoryOverrides: {},

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -76,6 +76,7 @@ export interface ForkRepo {
   created_at: string;
   updated_at: string;
   pushed_at: string;
+  default_branch: string;
   owner: {
     login: string;
     avatar_url: string;
@@ -116,6 +117,8 @@ export interface WorkflowRun {
   updated_at: string;
   run_number: number;
   event: string;
+  path: string; // workflow file path, e.g. ".github/workflows/ci.yml"
+  workflow_id: number; // workflow definition ID (not the run ID)
 }
 
 export interface GitHubUser {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -66,6 +66,7 @@ export interface Release {
 export interface ForkRepo {
   id: number;
   name: string;
+  fork: boolean;
   full_name: string;
   description: string | null;
   html_url: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -62,6 +62,62 @@ export interface Release {
   is_read?: boolean;
 }
 
+// Fork types
+export interface ForkRepo {
+  id: number;
+  name: string;
+  full_name: string;
+  description: string | null;
+  html_url: string;
+  stargazers_count: number;
+  forks_count: number;
+  forks: number;
+  language: string | null;
+  created_at: string;
+  updated_at: string;
+  pushed_at: string;
+  owner: {
+    login: string;
+    avatar_url: string;
+  };
+  source: {
+    id: number;
+    full_name: string;
+    name: string;
+    description: string | null;
+    html_url: string;
+    stargazers_count: number;
+    forks_count: number;
+    updated_at: string;
+    owner: {
+      login: string;
+      avatar_url: string;
+    };
+  };
+  parent?: {
+    id: number;
+    full_name: string;
+    name: string;
+    html_url: string;
+  };
+  has_unread?: boolean;
+  upstream_updated_at?: string; // last time we checked/fetched upstream updates
+}
+
+export interface WorkflowRun {
+  id: number;
+  name: string;
+  status: string;
+  conclusion: string | null;
+  head_branch: string;
+  head_sha: string;
+  html_url: string;
+  created_at: string;
+  updated_at: string;
+  run_number: number;
+  event: string;
+}
+
 export interface GitHubUser {
   id: number;
   login: string;
@@ -176,7 +232,7 @@ export interface AppState {
   
   // UI
   theme: 'light' | 'dark';
-  currentView: 'repositories' | 'releases' | 'settings' | 'subscription';
+  currentView: 'repositories' | 'releases' | 'forks' | 'settings' | 'subscription';
   selectedCategory: string;
   language: 'zh' | 'en';
   isSidebarCollapsed: boolean;
@@ -190,6 +246,17 @@ export interface AppState {
 
   // Backend
   backendApiSecret: string | null;
+
+  // Fork Timeline View
+  forks: ForkRepo[];
+  readForks: Set<number>;
+
+  // Fork Timeline View State
+  forkViewMode: 'timeline' | 'repository';
+  forkSelectedFilters: string[];
+  forkSearchQuery: string;
+  forkExpandedRepositories: Set<number>;
+  forkIsRefreshing: boolean;
 
   // Release Timeline View
   releaseViewMode: 'timeline' | 'repository';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -105,20 +105,16 @@ export interface ForkRepo {
   upstream_updated_at?: string; // last time we checked/fetched upstream updates
 }
 
-export interface WorkflowRun {
+export interface WorkflowDefinition {
   id: number;
   name: string;
-  status: string;
-  conclusion: string | null;
-  head_branch: string;
-  head_sha: string;
-  html_url: string;
+  path: string; // workflow file path, e.g. ".github/workflows/ci.yml"
+  state: string; // "active" | "disabled" | "warning"
   created_at: string;
   updated_at: string;
-  run_number: number;
-  event: string;
-  path: string; // workflow file path, e.g. ".github/workflows/ci.yml"
-  workflow_id: number; // workflow definition ID (not the run ID)
+  url: string;
+  html_url: string;
+  badge_url: string;
 }
 
 export interface GitHubUser {


### PR DESCRIPTION
## Summary
- 在顶栏「发布」与「趋势」之间新增「复刻」(Forks) 标签页
- Fork 列表按上游仓库最新更新时间降序排列
- 每次点击刷新按钮时检测上游仓库是否有更新，如有更新则显示未读徽标
- 用户点击仓库卡片或对仓库有任何操作时，未读徽标消失
- 「资产」下拉替换为「工作流」下拉，可查看并触发运行工作流
- 「同步上游仓库」按钮调用 GitHub merge upstream API 同步 Fork
- 搜索与分页交互与 Release 页一致，无过滤器

## Test plan
- [ ] 切换到 Fork 标签页，点击刷新按钮拉取 Fork 列表
- [ ] 确认 Fork 列表按上游仓库更新时间排序
- [ ] 展开工作流下拉，确认能看到最近的工作流运行记录
- [ ] 点击同步按钮，确认 Fork 与上游仓库同步
- [ ] 搜索框搜索 Fork，确认过滤功能正常
- [ ] 分页切换确认正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New Forks view with navigation button to browse and manage your forked repositories.
  * Per-fork cards showing language badge, source/parent info, unread pulse, relative update times, and external repo link.
  * Expandable workflows per fork with loading/empty states, workflow status dots, Run actions, and per-fork running indicators.
  * "Sync upstream" action with progress and localized success/error toasts, search, pagination, refresh with last-refresh time, and persisted view/search/preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->