### PR TITLE
fix: WebDAV 优先走后端代理，解决浏览器 CORS 跨域问题

### DIFF
--- a/src/services/webdavService.ts
+++ b/src/services/webdavService.ts
@@ -1,10 +1,29 @@
 import { WebDAVConfig } from '../types';
+import { backend } from './backendAdapter';
 
 export class WebDAVService {
   private config: WebDAVConfig;
 
   constructor(config: WebDAVConfig) {
     this.config = config;
+  }
+
+  private get useProxy(): boolean {
+    return backend.isAvailable;
+  }
+
+  private get basePath(): string {
+    return this.config.path.endsWith('/') ? this.config.path : `${this.config.path}/`;
+  }
+
+  // 通过后端代理发送请求，避免浏览器 CORS 限制
+  private async proxyFetch(
+    method: string,
+    fullPath: string,
+    body?: string,
+    headers?: Record<string, string>,
+  ): Promise<Response> {
+    return backend.proxyWebDAV(this.config.id, method, fullPath, body, headers);
   }
 
   // 压缩JSON数据，减少传输大小
@@ -78,13 +97,16 @@ export class WebDAVService {
   }
 
   private getFullPath(filename: string): string {
-    const basePath = this.config.path.endsWith('/') ? this.config.path : `${this.config.path}/`;
-    return `${this.config.url}${basePath}${filename}`;
+    return `${this.config.url}${this.basePath}${filename}`;
+  }
+
+  private getRelativePath(filename: string): string {
+    return `${this.basePath}${filename}`;
   }
 
   private handleNetworkError(error: unknown, operation: string): never {
     console.error(`WebDAV ${operation} failed:`, error);
-    
+
     const err = error as Error;
     const isCorsError = (
       (err.name === 'TypeError' && err.message.includes('Failed to fetch')) ||
@@ -122,7 +144,7 @@ export class WebDAVService {
 
 技术详情: ${err.message}`);
     }
-    
+
     throw new Error(`WebDAV ${operation} 失败: ${err.message || '未知错误'}`);
   }
 
@@ -133,12 +155,27 @@ export class WebDAVService {
         throw new Error('WebDAV URL必须以 http:// 或 https:// 开头');
       }
 
-      // 构建用于测试的目录URL（优先测试配置中的 path）
+      // 优先走后端代理，避免 CORS
+      if (this.useProxy) {
+        try {
+          // HEAD 请求检测可达性
+          const headResponse = await this.proxyFetch('HEAD', this.config.path);
+          if (headResponse.ok) return true;
+
+          // 回退 PROPFIND
+          const propfindResponse = await this.proxyFetch('PROPFIND', this.config.path, undefined, { Depth: '0' });
+          return propfindResponse.ok || propfindResponse.status === 207;
+        } catch (proxyErr) {
+          console.warn('代理连接测试失败，回退到直连:', proxyErr);
+          // 回退到浏览器直连
+        }
+      }
+
+      // 浏览器直连（回退方案）
       const dirUrl = `${this.config.url}${this.config.path}`;
 
-      // 先尝试 HEAD 请求检测基本可达性（某些服务器对 PROPFIND/OPTIONS 支持较差）
       const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 10000); // 10秒超时
+      const timeoutId = setTimeout(() => controller.abort(), 10000);
 
       try {
         const headResponse = await fetch(dirUrl, {
@@ -153,7 +190,6 @@ export class WebDAVService {
 
         if (headResponse.ok) return true;
 
-        // HEAD 不可用时，尝试 PROPFIND（不少服务器返回 207 Multi-Status 表示成功）
         const propfindResponse = await fetch(dirUrl, {
           method: 'PROPFIND',
           headers: {
@@ -165,11 +201,11 @@ export class WebDAVService {
         return propfindResponse.ok || propfindResponse.status === 207;
       } catch (fetchError: unknown) {
         clearTimeout(timeoutId);
-        
+
         if ((fetchError as Error).name === 'AbortError') {
           throw new Error('连接超时。请检查WebDAV服务器是否可访问。');
         }
-        
+
         throw fetchError;
       }
     } catch (error: unknown) {
@@ -197,12 +233,30 @@ export class WebDAVService {
       // 确保目录存在
       await this.ensureDirectoryExists();
 
-      // 动态计算超时时间：基于压缩后文件大小，最小60秒，最大300秒
-      const finalSizeKB = Math.round(compressedContent.length / 1024);
-      const dynamicTimeout = Math.max(60000, Math.min(300000, finalSizeKB * 100)); // 每KB 100ms
-      console.log(`设置超时时间: ${dynamicTimeout}ms`);
-
       const uploadOperation = async (): Promise<boolean> => {
+        if (this.useProxy) {
+          const response = await this.proxyFetch(
+            'PUT',
+            this.getRelativePath(filename),
+            compressedContent,
+            { 'Content-Type': 'application/json' },
+          );
+
+          if (!response.ok) {
+            if (response.status === 401) throw new Error('身份验证失败。请检查用户名和密码。');
+            if (response.status === 403) throw new Error('访问被拒绝。请检查指定路径的权限。');
+            if (response.status === 404) throw new Error('路径未找到。请验证WebDAV URL和路径是否正确。');
+            if (response.status === 507) throw new Error('服务器存储空间不足。');
+            throw new Error(`上传失败，HTTP状态码 ${response.status}`);
+          }
+
+          return true;
+        }
+
+        // 浏览器直连（回退方案）
+        const finalSizeKB = Math.round(compressedContent.length / 1024);
+        const dynamicTimeout = Math.max(60000, Math.min(300000, finalSizeKB * 100));
+
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), dynamicTimeout);
 
@@ -220,18 +274,10 @@ export class WebDAVService {
           clearTimeout(timeoutId);
 
           if (!response.ok) {
-            if (response.status === 401) {
-              throw new Error('身份验证失败。请检查用户名和密码。');
-            }
-            if (response.status === 403) {
-              throw new Error('访问被拒绝。请检查指定路径的权限。');
-            }
-            if (response.status === 404) {
-              throw new Error('路径未找到。请验证WebDAV URL和路径是否正确。');
-            }
-            if (response.status === 507) {
-              throw new Error('服务器存储空间不足。');
-            }
+            if (response.status === 401) throw new Error('身份验证失败。请检查用户名和密码。');
+            if (response.status === 403) throw new Error('访问被拒绝。请检查指定路径的权限。');
+            if (response.status === 404) throw new Error('路径未找到。请验证WebDAV URL和路径是否正确。');
+            if (response.status === 507) throw new Error('服务器存储空间不足。');
             throw new Error(`上传失败，HTTP状态码 ${response.status}: ${response.statusText}`);
           }
 
@@ -250,8 +296,8 @@ export class WebDAVService {
       return await this.retryUpload(uploadOperation);
     } catch (error: unknown) {
       const err = error as Error;
-      if (err.message.includes('身份验证失败') || 
-          err.message.includes('访问被拒绝') || 
+      if (err.message.includes('身份验证失败') ||
+          err.message.includes('访问被拒绝') ||
           err.message.includes('路径未找到') ||
           err.message.includes('存储空间不足') ||
           err.message.includes('上传失败，HTTP状态码') ||
@@ -266,46 +312,72 @@ export class WebDAVService {
   private async ensureDirectoryExists(): Promise<void> {
     try {
       if (!this.config.path || this.config.path === '/') {
-        return; // 根目录总是存在
+        return;
       }
 
-      // 逐级创建目录，避免服务器因中间目录不存在而返回 409/403
-      const cleanedPath = this.config.path.replace(/\/+$/, ''); // 去掉末尾斜杠
-      const segments = cleanedPath.split('/').filter(Boolean); // 去掉空段
+      const cleanedPath = this.config.path.replace(/\/+$/, '');
+      const segments = cleanedPath.split('/').filter(Boolean);
       let currentPath = '';
 
       for (const seg of segments) {
         currentPath += `/${seg}`;
-        const full = `${this.config.url}${currentPath}`;
-        try {
-          const res = await fetch(full, {
-            method: 'MKCOL',
-            headers: { 'Authorization': this.getAuthHeader() },
-          });
 
-          // 201 Created（新建）或 405 Method Not Allowed（已存在）都视为成功
-          if (!res.ok && res.status !== 405) {
-            // 某些服务器对已存在目录返回 409 Conflict
-            if (res.status !== 409) {
+        if (this.useProxy) {
+          try {
+            const res = await this.proxyFetch('MKCOL', currentPath);
+            if (!res.ok && res.status !== 405 && res.status !== 409) {
               console.warn(`无法创建目录 ${currentPath}，状态码: ${res.status}`);
-              break; // 不再继续往下建
+              break;
             }
+          } catch (e) {
+            console.warn(`创建目录 ${currentPath} 发生异常:`, e);
+            break;
           }
-        } catch (e) {
-          console.warn(`创建目录 ${currentPath} 发生异常:`, e);
-          break;
+        } else {
+          const full = `${this.config.url}${currentPath}`;
+          try {
+            const res = await fetch(full, {
+              method: 'MKCOL',
+              headers: { 'Authorization': this.getAuthHeader() },
+            });
+
+            if (!res.ok && res.status !== 405) {
+              if (res.status !== 409) {
+                console.warn(`无法创建目录 ${currentPath}，状态码: ${res.status}`);
+                break;
+              }
+            }
+          } catch (e) {
+            console.warn(`创建目录 ${currentPath} 发生异常:`, e);
+            break;
+          }
         }
       }
     } catch (error) {
       console.warn('目录创建检查失败:', error);
-      // 不在这里抛出错误，因为目录可能已经存在
     }
   }
 
   async downloadFile(filename: string): Promise<string | null> {
     try {
+      if (this.useProxy) {
+        const response = await this.proxyFetch('GET', this.getRelativePath(filename));
+
+        if (response.ok) {
+          const data: unknown = await response.json();
+          // 后端代理返回的是 JSON 包装的数据，可能是已解析的对象或字符串
+          if (typeof data === 'string') return data;
+          return JSON.stringify(data);
+        }
+
+        if (response.status === 404) return null;
+        if (response.status === 401) throw new Error('身份验证失败。请检查用户名和密码。');
+        throw new Error(`下载失败，HTTP状态码 ${response.status}`);
+      }
+
+      // 浏览器直连（回退方案）
       const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 30000); // 30秒超时
+      const timeoutId = setTimeout(() => controller.abort(), 30000);
 
       try {
         const response = await fetch(this.getFullPath(filename), {
@@ -315,34 +387,34 @@ export class WebDAVService {
           },
           signal: controller.signal,
         });
-        
+
         clearTimeout(timeoutId);
 
         if (response.ok) {
           return await response.text();
         }
-        
+
         if (response.status === 404) {
-          return null; // 文件未找到是预期行为
+          return null;
         }
-        
+
         if (response.status === 401) {
           throw new Error('身份验证失败。请检查用户名和密码。');
         }
-        
+
         throw new Error(`下载失败，HTTP状态码 ${response.status}: ${response.statusText}`);
       } catch (fetchError: unknown) {
         clearTimeout(timeoutId);
-        
+
         if ((fetchError as Error).name === 'AbortError') {
           throw new Error('下载超时。请检查网络连接。');
         }
-        
+
         throw fetchError;
       }
     } catch (error: unknown) {
       const err = error as Error;
-      if (err.message.includes('身份验证失败') || 
+      if (err.message.includes('身份验证失败') ||
           err.message.includes('下载超时')) {
         throw error;
       }
@@ -355,8 +427,13 @@ export class WebDAVService {
 
   async fileExists(filename: string): Promise<boolean> {
     try {
+      if (this.useProxy) {
+        const response = await this.proxyFetch('HEAD', this.getRelativePath(filename));
+        return response.ok;
+      }
+
       const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 10000); // 10秒超时
+      const timeoutId = setTimeout(() => controller.abort(), 10000);
 
       const response = await fetch(this.getFullPath(filename), {
         method: 'HEAD',
@@ -376,13 +453,36 @@ export class WebDAVService {
 
   async listFiles(): Promise<string[]> {
     try {
+      if (this.useProxy) {
+        const response = await this.proxyFetch(
+          'PROPFIND',
+          this.config.path,
+          `<?xml version="1.0" encoding="utf-8" ?>
+            <D:propfind xmlns:D="DAV:">
+              <D:prop>
+                <D:displayname/>
+                <D:getlastmodified/>
+                <D:getcontentlength/>
+              </D:prop>
+            </D:propfind>`,
+          { Depth: '1', 'Content-Type': 'application/xml' },
+        );
+
+        if (response.ok || response.status === 207) {
+          const data: unknown = await response.json();
+          const xmlText = typeof data === 'string' ? data : JSON.stringify(data);
+          return this.parsePropfindXml(xmlText);
+        }
+        if (response.status === 401) throw new Error('身份验证失败。请检查用户名和密码。');
+        throw new Error(`列出文件失败，HTTP状态码 ${response.status}`);
+      }
+
+      // 浏览器直连（回退方案）
       const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 15000); // 15秒超时
+      const timeoutId = setTimeout(() => controller.abort(), 15000);
 
       try {
-        // 确保目录URL以斜杠结尾，避免部分服务器对集合路径的歧义
-        const basePath = this.config.path.endsWith('/') ? this.config.path : `${this.config.path}/`;
-        const collectionUrl = `${this.config.url}${basePath}`;
+        const collectionUrl = `${this.config.url}${this.basePath}`;
 
         const response = await fetch(collectionUrl, {
           method: 'PROPFIND',
@@ -406,78 +506,24 @@ export class WebDAVService {
 
         if (response.ok || response.status === 207) {
           const xmlText = await response.text();
-
-          // 优先用 DOMParser 解析（更可靠，兼容 displayname 缺失的服务端）
-          try {
-            const parser = new DOMParser();
-            const xml = parser.parseFromString(xmlText, 'application/xml');
-            const responses = Array.from(xml.getElementsByTagNameNS('DAV:', 'response'));
-
-            const results: string[] = [];
-
-            for (const res of responses) {
-              const hrefEl = res.getElementsByTagNameNS('DAV:', 'href')[0];
-              if (!hrefEl || !hrefEl.textContent) continue;
-              let href = hrefEl.textContent;
-
-              // 过滤掉集合自身（目录本身）
-              // 有的服务返回绝对URL，有的返回相对路径，统一去比较末尾路径
-              const normalizedCollection = collectionUrl.replace(/^https?:\/\//, '').replace(/\/+$/, '/');
-              const normalizedHref = href.replace(/^https?:\/\//, '');
-              if (normalizedHref.endsWith(normalizedCollection)) continue;
-
-              // 提取文件名
-              try {
-                // 去掉末尾斜杠（目录）
-                href = href.replace(/\/+$/, '');
-                const parts = href.split('/').filter(Boolean);
-                if (parts.length === 0) continue;
-                const last = decodeURIComponent(parts[parts.length - 1]);
-                if (last.toLowerCase().endsWith('.json')) {
-                  results.push(last.trim());
-                }
-              } catch {
-                // 忽略单个条目解析失败
-              }
-            }
-
-            if (results.length > 0) return results;
-          } catch {
-            // DOMParser 失败时降级为正则提取 href/displayname
-            const namesFromDisplay = (xmlText.match(/<D:displayname>([^<]+)<\/D:displayname>/gi) || [])
-              .map(m => m.replace(/<\/?D:displayname>/gi, ''))
-              .map(s => s.trim())
-              .filter(name => name.toLowerCase().endsWith('.json'));
-
-            if (namesFromDisplay.length > 0) return namesFromDisplay;
-
-            const namesFromHref = (xmlText.match(/<D:href>([^<]+)<\/D:href>/gi) || [])
-              .map(m => m.replace(/<\/?D:href>/gi, ''))
-              .map(s => s.replace(/\/+$/, ''))
-              .map(s => decodeURIComponent(s.split('/').filter(Boolean).pop() || ''))
-              .map(s => s.trim())
-              .filter(name => name.toLowerCase().endsWith('.json'));
-
-            if (namesFromHref.length > 0) return namesFromHref;
-          }
-        } else if (response.status === 401) {
-          throw new Error('身份验证失败。请检查用户名和密码。');
-        } else {
-          throw new Error(`列出文件失败，HTTP状态码 ${response.status}: ${response.statusText}`);
+          return this.parsePropfindXml(xmlText);
         }
-        return [];
+        if (response.status === 401) {
+          throw new Error('身份验证失败。请检查用户名和密码。');
+        }
+        throw new Error(`列出文件失败，HTTP状态码 ${response.status}: ${response.statusText}`);
       } catch (fetchError: unknown) {
         clearTimeout(timeoutId);
-        
+
         if ((fetchError as Error).name === 'AbortError') {
           throw new Error('列出文件超时。请检查网络连接。');
         }
-        
+
         throw fetchError;
       }
     } catch (error: unknown) {
       const err = error as Error;
-      if (err.message.includes('身份验证失败') || 
+      if (err.message.includes('身份验证失败') ||
           err.message.includes('列出文件超时')) {
         throw error;
       }
@@ -485,7 +531,64 @@ export class WebDAVService {
     }
   }
 
-  // 新增：验证配置的静态方法
+  private parsePropfindXml(xmlText: string): string[] {
+    const collectionUrl = `${this.config.url}${this.basePath}`;
+
+    // 优先用 DOMParser 解析
+    try {
+      const parser = new DOMParser();
+      const xml = parser.parseFromString(xmlText, 'application/xml');
+      const responses = Array.from(xml.getElementsByTagNameNS('DAV:', 'response'));
+
+      const results: string[] = [];
+
+      for (const res of responses) {
+        const hrefEl = res.getElementsByTagNameNS('DAV:', 'href')[0];
+        if (!hrefEl || !hrefEl.textContent) continue;
+        let href = hrefEl.textContent;
+
+        const normalizedCollection = collectionUrl.replace(/^https?:\/\//, '').replace(/\/+$/, '/');
+        const normalizedHref = href.replace(/^https?:\/\//, '');
+        if (normalizedHref.endsWith(normalizedCollection)) continue;
+
+        try {
+          href = href.replace(/\/+$/, '');
+          const parts = href.split('/').filter(Boolean);
+          if (parts.length === 0) continue;
+          const last = decodeURIComponent(parts[parts.length - 1]);
+          if (last.toLowerCase().endsWith('.json')) {
+            results.push(last.trim());
+          }
+        } catch {
+          // 忽略单个条目解析失败
+        }
+      }
+
+      if (results.length > 0) return results;
+    } catch {
+      // DOMParser 失败时降级为正则提取
+    }
+
+    const namesFromDisplay = (xmlText.match(/<D:displayname>([^<]+)<\/D:displayname>/gi) || [])
+      .map(m => m.replace(/<\/?D:displayname>/gi, ''))
+      .map(s => s.trim())
+      .filter(name => name.toLowerCase().endsWith('.json'));
+
+    if (namesFromDisplay.length > 0) return namesFromDisplay;
+
+    const namesFromHref = (xmlText.match(/<D:href>([^<]+)<\/D:href>/gi) || [])
+      .map(m => m.replace(/<\/?D:href>/gi, ''))
+      .map(s => s.replace(/\/+$/, ''))
+      .map(s => decodeURIComponent(s.split('/').filter(Boolean).pop() || ''))
+      .map(s => s.trim())
+      .filter(name => name.toLowerCase().endsWith('.json'));
+
+    if (namesFromHref.length > 0) return namesFromHref;
+
+    return [];
+  }
+
+  // 验证配置的静态方法
   static validateConfig(config: Partial<WebDAVConfig>): string[] {
     const errors: string[] = [];
 
@@ -512,7 +615,7 @@ export class WebDAVService {
     return errors;
   }
 
-  // 新增：获取服务器信息
+  // 获取服务器信息
   async getServerInfo(): Promise<{ server?: string; davLevel?: string }> {
     try {
       const response = await fetch(this.config.url, {
@@ -531,7 +634,7 @@ export class WebDAVService {
     } catch (error) {
       console.warn('无法获取服务器信息:', error);
     }
-    
+
     return {};
   }
 }


### PR DESCRIPTION
当后端可用时，WebDAVService 通过 POST /api/proxy/webdav 代理请求， 避免浏览器直接跨域访问 WebDAV 服务器。后端不可用时回退到浏览器直连。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * WebDAV file operations now support proxy-based routing for enhanced compatibility
  * Enhanced error handling with HTTP status mapping and clearer timeout messages
  * Improved XML parsing reliability for directory listing and file operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->