### PR TITLE
fix: releases SQL placeholder, settings serialization, and Gemini thinking model support

### DIFF
--- a/server/src/routes/configs.ts
+++ b/server/src/routes/configs.ts
@@ -456,7 +456,15 @@ router.put('/api/settings', (req, res) => {
           value = encrypt(value, config.encryptionKey);
         }
 
-        stmt.run(key, value ?? null);
+        // better-sqlite3 interprets objects/arrays as named parameter maps,
+        // causing RangeError. Serialize non-primitive values to JSON strings.
+        const serialized =
+          value === null || value === undefined
+            ? null
+            : typeof value === 'object'
+              ? JSON.stringify(value)
+              : value;
+        stmt.run(key, serialized);
       }
     });
 

--- a/server/src/routes/releases.ts
+++ b/server/src/routes/releases.ts
@@ -100,7 +100,7 @@ router.put('/api/releases', (req, res) => {
         prerelease, draft, is_read, assets,
         repo_id, repo_full_name, repo_name,
         zipball_url, tarball_url
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
 
     const upsert = db.transaction(() => {

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -250,9 +250,12 @@ ${options.user}` : options.user;
 
     const candidates = (data as { candidates?: unknown }).candidates;
     if (Array.isArray(candidates) && candidates.length > 0) {
-      const parts = (candidates[0] as { content?: { parts?: unknown } }).content?.parts;
+      const candidate = candidates[0] as { content?: { parts?: unknown }; finishReason?: string };
+      const parts = candidate.content?.parts;
       if (Array.isArray(parts)) {
+        // Skip thought parts emitted by Gemini thinking models (e.g. gemini-2.5-pro)
         const text = parts
+          .filter((p) => p && typeof p === 'object' && !(p as { thought?: boolean }).thought)
           .map((p) => {
             if (!p || typeof p !== 'object') return '';
             const part = p as { text?: unknown };
@@ -476,7 +479,7 @@ Focus on practicality and accurate categorization to help users quickly understa
 
   async testConnection(): Promise<ConnectionTestResult> {
     const apiType = this.getApiType();
-    const timeoutMs = apiType === 'openai-responses' || this.config.reasoningEffort ? 30000 : 10000;
+    const timeoutMs = apiType === 'openai-responses' || apiType === 'gemini' || this.config.reasoningEffort ? 30000 : 10000;
 
     try {
       const base = new URL(this.config.baseUrl);
@@ -497,7 +500,7 @@ Focus on practicality and accurate categorization to help users quickly understa
           system: 'You are a connection test assistant.',
           user: 'Reply with exactly one word: OK',
           temperature: 0,
-          maxTokens: 50,
+          maxTokens: 2048,
           signal: controller.signal,
         });
         if (content) {


### PR DESCRIPTION
## Summary

Three independent bugs found during deployment on a self-hosted instance:

### 1. `server/src/routes/releases.ts` — SQL INSERT crash

The `INSERT OR REPLACE INTO releases` statement lists **15 columns** but only has **14 `?` placeholders**, causing `SqliteError: 14 values for 15 columns` on every release sync.

```diff
- ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
```

### 2. `server/src/routes/configs.ts` — `better-sqlite3` RangeError on settings save

`better-sqlite3` treats a plain object passed as a positional parameter as a **named-parameter map**, throwing `RangeError: Too few parameter values were provided` when saving AI or WebDAV config objects. Fix: serialize object/array values with `JSON.stringify` before the `stmt.run()` call.

### 3. `src/services/aiService.ts` — Gemini thinking models (e.g. `gemini-2.5-pro`)

Three related issues when using a Gemini thinking model:

| Issue | Root cause | Fix |
|---|---|---|
| "No content received" on connection test | `maxTokens: 50` is consumed entirely by the thinking phase, leaving zero tokens for the actual reply — response returns `finishReason: MAX_TOKENS` with no `parts` | Raise `maxTokens` to **2048** |
| Connection test times out | Timeout was 10 s for all Gemini calls; thinking models routinely take 15–30 s | Extend timeout to **30 s** for `apiType === 'gemini'` |
| Thinking trace mixed into output | Response `parts` include items with `thought: true` (internal reasoning); concatenating all parts returns the model's chain-of-thought as part of the answer | Filter out `thought: true` parts before joining |

## Test plan

- [ ] Sync releases from GitHub — no `SqliteError` crash
- [ ] Save AI or WebDAV settings — no `RangeError` crash
- [ ] Set API type to `gemini`, model to `gemini-2.5-pro`, click **Test Connection** — returns "Connection successful" within 30 s
- [ ] Run a repository analysis with `gemini-2.5-pro` — summary contains only the model's reply, not its internal reasoning trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed data serialization in configuration storage to properly handle complex value types and prevent data corruption
  * Enhanced AI service connectivity testing with intelligent timeout adjustments based on model selection and improved diagnostic response capacity
  * Streamlined Gemini model response processing by filtering unnecessary content for better performance

* **Chores**
  * Minor SQL statement formatting refinements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmintaCCCP/GithubStarsManager/pull/140)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->