### PR TITLE
fix: persist GitHub star sync immediately and guard against empty-backend overwrite

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { Settings, Calendar, Search, Moon, Sun, LogOut, RefreshCw, TrendingUp, G
 import { useAppStore } from '../store/useAppStore';
 import { GitHubApiService } from '../services/githubApi';
 import { useDialog } from '../hooks/useDialog';
+import { forceSyncToBackend } from '../services/autoSync';
 
 export const Header: React.FC = () => {
   const {
@@ -100,6 +101,9 @@ export const Header: React.FC = () => {
       });
 
       setRepositories(mergedRepositories);
+
+      // Force-push to backend immediately (bypass 2s debounce) so data survives a page refresh
+      void forceSyncToBackend();
 
       // Note: Release fetching is now handled by the Refresh button in Release Timeline
       // Header sync only syncs the starred repos list

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -103,7 +103,7 @@ export const Header: React.FC = () => {
       setRepositories(mergedRepositories);
 
       // Force-push to backend immediately (bypass 2s debounce) so data survives a page refresh
-      void forceSyncToBackend();
+      forceSyncToBackend().catch(console.error);
 
       // Note: Release fetching is now handled by the Refresh button in Release Timeline
       // Header sync only syncs the starred repos list

--- a/src/services/autoSync.ts
+++ b/src/services/autoSync.ts
@@ -128,8 +128,15 @@ export async function syncFromBackend(): Promise<void> {
 
     // Update store then commit hash — hash only changes if setter succeeds
     if (changed.repos && reposResult.status === 'fulfilled') {
-      state.setRepositories(reposResult.value.repositories);
-      _lastHash.repos = hashes.repos;
+      const backendRepos = reposResult.value.repositories;
+      const localRepos = state.repositories;
+      // Don't overwrite a non-empty local store with an empty backend response.
+      // This prevents the initial syncFromBackend call from wiping locally-cached
+      // repos before the user has had a chance to push them to the backend.
+      if (backendRepos.length > 0 || localRepos.length === 0) {
+        state.setRepositories(backendRepos);
+        _lastHash.repos = hashes.repos;
+      }
     }
     if (changed.releases && releasesResult.status === 'fulfilled') {
       state.setReleases(releasesResult.value.releases);

--- a/src/services/autoSync.ts
+++ b/src/services/autoSync.ts
@@ -130,10 +130,15 @@ export async function syncFromBackend(): Promise<void> {
     if (changed.repos && reposResult.status === 'fulfilled') {
       const backendRepos = reposResult.value.repositories;
       const localRepos = state.repositories;
-      // Don't overwrite a non-empty local store with an empty backend response.
-      // This prevents the initial syncFromBackend call from wiping locally-cached
-      // repos before the user has had a chance to push them to the backend.
-      if (backendRepos.length > 0 || localRepos.length === 0) {
+      // Distinguish first-ever sync (bootstrap) from an authoritative empty backend.
+      // On bootstrap the hash is still '' — preserve local cache and push it to backend.
+      // On subsequent syncs, accept the backend state even if empty (e.g. user cleared
+      // stars from another device).
+      const isBootstrapEmpty =
+        backendRepos.length === 0 && localRepos.length > 0 && _lastHash.repos === '';
+      if (isBootstrapEmpty) {
+        _hasPendingPush = true;
+      } else {
         state.setRepositories(backendRepos);
         _lastHash.repos = hashes.repos;
       }


### PR DESCRIPTION
## Summary

Two related data-loss bugs when the backend sync feature is enabled. Both were found during a self-hosted deployment and reproduce reliably.

### Bug 1 — Starred repos lost if page is refreshed within 2 seconds of sync (`Header.tsx`)

After fetching starred repos from GitHub, the new repository list is written to the Zustand store but only flushed to the backend after a **2-second debounce**. If the user refreshes the page within that window:

1. The debounce timer is destroyed.
2. `PUT /api/repositories` never fires.
3. On the next load, `syncFromBackend` fetches the still-empty backend and overwrites the local store.
4. All just-synced repos disappear.

**Fix:** call `forceSyncToBackend()` immediately after `setRepositories()` in `Header.tsx`, so the data reaches the backend before the user can navigate away.

### Bug 2 — Empty backend silently wipes locally-cached repos (`autoSync.ts`)

On every page load, `syncFromBackend` fetches repos from the backend and unconditionally overwrites the Zustand store — even when the backend returns an empty array. This triggers in several scenarios:

- First-time backend configuration (backend has no data yet)
- Backend was reset or migrated
- Bug 1 race above (backend was never populated)

Any repos cached in `localStorage` from a previous session are silently cleared.

**Fix:** skip `setRepositories` when the backend returns zero repositories but the local store is non-empty, so locally-cached data is never replaced by an empty backend response.

## Reproduction

1. Enable backend sync (set `API_SECRET`).
2. Click **Sync** to fetch starred repos.
3. Refresh the page within ~2 seconds. → All repos are gone (Bug 1).

Or:

1. Configure a fresh backend (no data).
2. In a previous browser session with repos in `localStorage`, open the app. → Repos disappear immediately after `syncFromBackend` runs (Bug 2).

## Test plan

- [ ] Sync starred repos → refresh immediately → repos still present after reload
- [ ] Open app with a fresh/empty backend but repos in localStorage → repos are not wiped on load
- [ ] Normal flow (backend already has repos) → repos still load correctly from backend on refresh
- [ ] Unstar a repo → refresh → repo correctly absent (deletion still propagates to backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented local repository data from being overwritten by an empty backend bootstrap; local cache is preserved and a push is queued instead.
  * Trigger immediate backend sync after local repository updates (fire-and-forget) to ensure changes are sent promptly; errors are safely logged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmintaCCCP/GithubStarsManager/pull/142)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->