### PR TITLE
fix: disable thinking chain for Xiaomi MiMo models

### DIFF
--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -79,6 +79,10 @@ export class AIService {
     return this.getApiType() === 'openai' && this.config.model.trim() === 'deepseek-reasoner';
   }
 
+  private isMiMoModel(): boolean {
+    return this.config.model.trim().toLowerCase().includes('mimo');
+  }
+
   private async requestText(options: {
     system: string;
     user: string;
@@ -97,6 +101,7 @@ export class AIService {
         { role: 'user', content: options.user },
       ];
       const isDeepSeekReasoner = this.isDeepSeekReasonerModel();
+      const isMiMoModel = this.isMiMoModel();
 
       const requestBody = apiType === 'openai-responses'
         ? {
@@ -105,6 +110,7 @@ export class AIService {
             temperature: options.temperature,
             max_output_tokens: options.maxTokens,
             ...(reasoning ? { reasoning } : {}),
+            ...(isMiMoModel ? { thinking: { type: 'disabled' } } : {}),
           }
         : {
             model: this.config.model,
@@ -112,6 +118,7 @@ export class AIService {
             max_tokens: options.maxTokens,
             ...(!isDeepSeekReasoner ? { temperature: options.temperature } : {}),
             ...(!isDeepSeekReasoner && reasoning && apiType !== 'openai-compatible' ? { reasoning } : {}),
+            ...(isMiMoModel ? { thinking: { type: 'disabled' } } : {}),
           };
 
       let data: Record<string, unknown>;


### PR DESCRIPTION
## 问题描述

Fixes #127

小米 MiMo 模型支持思维链（Thinking Mode）功能，当启用时，API 响应会返回 `reasoning_content` 字段（包含推理过程）和 `content` 字段（最终结果）。

当前代码在解析响应时，如果 `content` 为空，会返回 `reasoning_content`，导致用户看到的是模型的推理过程而不是最终分析结果。

## 修复方案

在请求小米 MiMo API 时，明确传 `thinking: { type: 'disabled' }` 禁用思维链功能。

### 改动内容

1. **添加 `isMiMoModel()` 方法**：检测模型名称是否包含 'mimo'
2. **修改请求体构建逻辑**：如果是小米 MiMo 模型，添加 `thinking: { type: 'disabled' }` 参数

## 影响范围

- ✅ **小米 MiMo 模型**：禁用思维链，返回标准格式响应
- ✅ **其他模型**：不受影响（DeepSeek、OpenAI、Claude、Gemini 等）
- ✅ **现有功能**：仓库分析、连接测试等功能保持不变

## 测试建议

1. 使用小米 MiMo 模型进行仓库分析，确认不再显示思维链内容
2. 使用其他模型（如 GPT-4、Claude）确认功能正常
3. 测试连接功能是否正常

## 相关文档

- [小米 MiMo API 文档](https://platform.xiaomimimo.com/static/docs/api/chat/openai-api.md)
- [思维链回传说明](https://platform.xiaomimimo.com/static/docs/usage-guide/passing-back-reasoning_content.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with MiMo model variants by adjusting API request configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmintaCCCP/GithubStarsManager/pull/143)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->