### PR TITLE
fix: 同步功能 ERR_CONNECTION_RESET 修复

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -40,9 +40,11 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_read_timeout 120s;
-            proxy_send_timeout 120s;
-            client_max_body_size 50m;
+            proxy_read_timeout 300s;
+            proxy_send_timeout 300s;
+            proxy_connect_timeout 30s;
+            proxy_buffering off;
+            client_max_body_size 100m;
         }
 
 

--- a/src/services/backendAdapter.ts
+++ b/src/services/backendAdapter.ts
@@ -76,6 +76,33 @@ class BackendAdapter {
       clearTimeout(timeoutId);
     }
   }
+
+  /**
+   * Retry wrapper with exponential backoff for transient network errors
+   * (ERR_CONNECTION_RESET, timeouts, abort).
+   */
+  private async fetchWithRetry(url: string, options?: RequestInit, timeoutMs = 30000, maxRetries = 3): Promise<Response> {
+    let lastError: Error | undefined;
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        return await this.fetchWithTimeout(url, options, timeoutMs);
+      } catch (err) {
+        lastError = err as Error;
+        const isRetryable =
+          lastError.name === 'AbortError' ||
+          lastError.message?.includes('ERR_CONNECTION_RESET') ||
+          lastError.message?.includes('ERR_CONNECTION_CLOSED') ||
+          lastError.message?.includes('Failed to fetch') ||
+          lastError.message?.includes('NetworkError');
+        if (!isRetryable || attempt === maxRetries) throw lastError;
+        // Exponential backoff: 1s, 2s, 4s
+        const delay = Math.min(1000 * Math.pow(2, attempt), 4000);
+        console.warn(`⚠️ Sync request failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms...`, lastError.message);
+        await new Promise(resolve => setTimeout(resolve, delay));
+      }
+    }
+    throw lastError!;
+  }
   private async throwTranslatedError(res: Response, fallbackPrefix: string): Promise<never> {
     let code: string | undefined;
     try {
@@ -201,20 +228,20 @@ class BackendAdapter {
   async syncRepositories(repos: Repository[]): Promise<void> {
     if (!this._backendUrl) return;
 
-    const res = await this.fetchWithTimeout(`${this._backendUrl}/repositories`, {
+    const res = await this.fetchWithRetry(`${this._backendUrl}/repositories`, {
       method: 'PUT',
       headers: this.getAuthHeaders(),
       body: JSON.stringify({ repositories: repos, isFullSync: true })
-    });
+    }, 120000, 3);
     if (!res.ok) await this.throwTranslatedError(res, 'Sync repositories error');
   }
 
   async fetchRepositories(): Promise<{ repositories: Repository[]; total: number }> {
     if (!this._backendUrl) throw new Error('Backend not available');
 
-    const res = await this.fetchWithTimeout(`${this._backendUrl}/repositories?limit=10000`, {
+    const res = await this.fetchWithRetry(`${this._backendUrl}/repositories?limit=10000`, {
       headers: this.getAuthHeaders()
-    });
+    }, 120000, 3);
     if (!res.ok) await this.throwTranslatedError(res, 'Fetch error');
     return res.json() as Promise<{ repositories: Repository[]; total: number }>;
   }
@@ -222,20 +249,20 @@ class BackendAdapter {
   async syncReleases(releases: Release[]): Promise<void> {
     if (!this._backendUrl) return;
 
-    const res = await this.fetchWithTimeout(`${this._backendUrl}/releases`, {
+    const res = await this.fetchWithRetry(`${this._backendUrl}/releases`, {
       method: 'PUT',
       headers: this.getAuthHeaders(),
       body: JSON.stringify({ releases })
-    });
+    }, 120000, 3);
     if (!res.ok) await this.throwTranslatedError(res, 'Sync releases error');
   }
 
   async fetchReleases(): Promise<{ releases: Release[]; total: number }> {
     if (!this._backendUrl) throw new Error('Backend not available');
 
-    const res = await this.fetchWithTimeout(`${this._backendUrl}/releases?limit=10000`, {
+    const res = await this.fetchWithRetry(`${this._backendUrl}/releases?limit=10000`, {
       headers: this.getAuthHeaders()
-    });
+    }, 120000, 3);
     if (!res.ok) await this.throwTranslatedError(res, 'Fetch error');
     return res.json() as Promise<{ releases: Release[]; total: number }>;
   }

--- a/src/services/backendAdapter.ts
+++ b/src/services/backendAdapter.ts
@@ -78,8 +78,8 @@ class BackendAdapter {
   }
 
   /**
-   * Retry wrapper with exponential backoff for transient network errors
-   * (ERR_CONNECTION_RESET, timeouts, abort).
+   * Retry wrapper with exponential backoff for transient network errors.
+   * Covers browser fetch (Chrome/Firefox/Safari) and Node.js undici fetch.
    */
   private async fetchWithRetry(url: string, options?: RequestInit, timeoutMs = 30000, maxRetries = 3): Promise<Response> {
     let lastError: Error | undefined;
@@ -90,10 +90,17 @@ class BackendAdapter {
         lastError = err as Error;
         const isRetryable =
           lastError.name === 'AbortError' ||
-          lastError.message?.includes('ERR_CONNECTION_RESET') ||
-          lastError.message?.includes('ERR_CONNECTION_CLOSED') ||
+          // Browser messages: Chrome/Edge "Failed to fetch", Firefox "NetworkError...", Safari "Load failed"
           lastError.message?.includes('Failed to fetch') ||
-          lastError.message?.includes('NetworkError');
+          lastError.message?.includes('NetworkError') ||
+          lastError.message?.includes('Load failed') ||
+          // Node.js undici: message is "fetch failed", real code is in error.cause
+          lastError.message === 'fetch failed' ||
+          (lastError as { cause?: { code?: string } }).cause?.code === 'ECONNRESET' ||
+          (lastError as { cause?: { code?: string } }).cause?.code === 'ECONNREFUSED' ||
+          (lastError as { cause?: { code?: string } }).cause?.code === 'UND_ERR_SOCKET' ||
+          (lastError as { cause?: { code?: string } }).cause?.code === 'UND_ERR_CONNECT_TIMEOUT' ||
+          (lastError as { cause?: { code?: string } }).cause?.code === 'UND_ERR_HEADERS_TIMEOUT';
         if (!isRetryable || attempt === maxRetries) throw lastError;
         // Exponential backoff: 1s, 2s, 4s
         const delay = Math.min(1000 * Math.pow(2, attempt), 4000);
@@ -101,7 +108,7 @@ class BackendAdapter {
         await new Promise(resolve => setTimeout(resolve, delay));
       }
     }
-    throw lastError!;
+    throw lastError!; // eslint-disable-line @typescript-eslint/no-unnecessary-type-assertion -- TypeScript control flow can't prove this is unreachable
   }
   private async throwTranslatedError(res: Response, fallbackPrefix: string): Promise<never> {
     let code: string | undefined;


### PR DESCRIPTION
## 问题

Docker 部署环境下，同步功能频繁出现 `ERR_CONNECTION_RESET` 错误，导致数据同步大概率失败。(#133)

## 根本原因

1. **前端超时太短** — fetchWithTimeout 默认 30 秒，但同步上千个 repo 时，DELETE + INSERT 的 SQLite 事务 + 网络传输很容易超时
2. **无重试机制** — 网络抖动或连接重置后直接失败，没有自动恢复能力
3. **Nginx 超时不足** — 原来 120 秒，对大数据量不够
4. **连接缓冲** — nginx 默认开启 proxy_buffering，大响应体会先缓冲到磁盘再转发，增加延迟和内存占用

## 修复内容

### src/services/backendAdapter.ts
- 新增 fetchWithRetry() 方法，支持指数退避重试（1s → 2s → 4s，最多 3 次）
- 识别可重试错误类型：ERR_CONNECTION_RESET、ERR_CONNECTION_CLOSED、AbortError（超时）、Failed to fetch、NetworkError
- 所有数据同步方法（syncRepositories、fetchRepositories、syncReleases、fetchReleases）改用 fetchWithRetry，超时从 30s → 120s

### nginx.conf
- proxy_read_timeout 120s → **300s**
- proxy_send_timeout 120s → **300s**
- 新增 proxy_connect_timeout 30s
- 新增 proxy_buffering off（流式转发，不缓冲到磁盘）
- client_max_body_size 50m → **100m**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added automatic retry with exponential backoff for transient network failures during repository and release syncs, improving resilience.
  * Increased API proxy timeouts, disabled proxy buffering, and raised allowed request body size to better support long-running requests and large uploads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmintaCCCP/GithubStarsManager/pull/144)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->