### PR TITLE
ci: upgrade GitHub Actions to Node 24–compatible versions

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -20,10 +20,10 @@ jobs:
         
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v6
       with:
         node-version: '24'
         cache: 'npm'
@@ -603,7 +603,7 @@ jobs:
         
     - name: Upload artifacts (Windows)
       if: matrix.os == 'windows-latest' && success()
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: windows-app
         path: |
@@ -613,7 +613,7 @@ jobs:
         
     - name: Upload artifacts (macOS)
       if: matrix.os == 'macos-latest' && success()
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: macos-app
         path: release/*.dmg
@@ -621,7 +621,7 @@ jobs:
         
     - name: Upload artifacts (Linux)
       if: matrix.os == 'ubuntu-latest' && success()
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: linux-app
         path: release/*.AppImage
@@ -636,7 +636,7 @@ jobs:
     
     steps:
     - name: Download all artifacts
-      uses: actions/download-artifact@v5
+      uses: actions/download-artifact@v8
       continue-on-error: true
       
     - name: List downloaded files

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v5
       with:
-        node-version: '22'
+        node-version: '24'
         cache: 'npm'
         
     - name: Install dependencies

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -20,10 +20,10 @@ jobs:
         
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '22'
         cache: 'npm'
@@ -603,7 +603,7 @@ jobs:
         
     - name: Upload artifacts (Windows)
       if: matrix.os == 'windows-latest' && success()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: windows-app
         path: |
@@ -613,7 +613,7 @@ jobs:
         
     - name: Upload artifacts (macOS)
       if: matrix.os == 'macos-latest' && success()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: macos-app
         path: release/*.dmg
@@ -621,7 +621,7 @@ jobs:
         
     - name: Upload artifacts (Linux)
       if: matrix.os == 'ubuntu-latest' && success()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: linux-app
         path: release/*.AppImage
@@ -636,7 +636,7 @@ jobs:
     
     steps:
     - name: Download all artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       continue-on-error: true
       
     - name: List downloaded files


### PR DESCRIPTION
## 变更内容

升级 CI workflow 中的 GitHub Actions 版本，解决 Node.js 20 弃用警告：

- `actions/checkout@v4` → `@v5`
- `actions/setup-node@v4` → `@v5`
- `actions/upload-artifact@v4` → `@v5`（3处）
- `actions/download-artifact@v4` → `@v5`

## 背景

GitHub Actions runner 将于 **2026年6月2日** 默认使用 Node.js 24 运行 JavaScript actions，**2026年9月16日** 移除 Node.js 20 支持。v5 版本的 actions 已适配 Node.js 24。

> 参考：https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI build workflow: refreshed action versions, upgraded Node runtime to v24, and standardized artifact upload/download across platforms for build and release jobs.
* **Note**
  * No user-facing changes; purely maintenance to build infrastructure. Build and release steps remain functionally unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmintaCCCP/GithubStarsManager/pull/145)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->