### PR TITLE
fix:后端同步时保留仓库本地元数据

### DIFF
--- a/src/services/autoSync.ts
+++ b/src/services/autoSync.ts
@@ -1,5 +1,6 @@
 import { backend } from './backendAdapter';
 import { useAppStore } from '../store/useAppStore';
+import { mergeRepositoriesPreservingLocalMetadata } from '../utils/repositoryMerge';
 
 // Prevent sync loops: when we pull data FROM backend and update store,
 // the store subscription would trigger a push TO backend. This flag blocks that.
@@ -139,7 +140,7 @@ export async function syncFromBackend(): Promise<void> {
       if (isBootstrapEmpty) {
         _hasPendingPush = true;
       } else {
-        state.setRepositories(backendRepos);
+        state.setRepositories(mergeRepositoriesPreservingLocalMetadata(backendRepos, localRepos));
         _lastHash.repos = hashes.repos;
       }
     }

--- a/src/utils/repositoryMerge.ts
+++ b/src/utils/repositoryMerge.ts
@@ -1,0 +1,41 @@
+import type { Repository } from '../types';
+
+const LOCAL_REPOSITORY_FIELDS: Array<keyof Repository> = [
+  'has_fetched_releases',
+  'last_release_fetch_time',
+  'ai_summary',
+  'ai_tags',
+  'ai_platforms',
+  'analyzed_at',
+  'analysis_failed',
+  'custom_description',
+  'custom_tags',
+  'custom_category',
+  'category_locked',
+  'last_edited',
+];
+
+export function mergeRepositoriesPreservingLocalMetadata(
+  incomingRepositories: Repository[],
+  localRepositories: Repository[]
+): Repository[] {
+  const localRepositoryMap = new Map(localRepositories.map(repo => [repo.id, repo]));
+
+  return incomingRepositories.map(incomingRepository => {
+    const localRepository = localRepositoryMap.get(incomingRepository.id);
+    if (!localRepository) {
+      return incomingRepository;
+    }
+
+    const mergedRepository: Repository = { ...incomingRepository };
+
+    for (const field of LOCAL_REPOSITORY_FIELDS) {
+      const localValue = localRepository[field];
+      if (localValue !== undefined) {
+        (mergedRepository as Record<keyof Repository, unknown>)[field] = localValue;
+      }
+    }
+
+    return mergedRepository;
+  });
+}


### PR DESCRIPTION
## 变更说明

修复后端同步仓库列表时，本地已有的仓库级元数据被覆盖的问题。

当前自动同步从后端拉取 repositories 后会直接调用 `setRepositories(backendRepos)`，如果后端返回的仓库对象缺少本地已有字段，会导致已完成的 AI 分析信息丢失，例如：

- `ai_summary`
- `ai_tags`
- `ai_platforms`
- `analyzed_at`
- `analysis_failed`

本次修改在后端仓库列表写入本地 store 前，对同一 `repo.id` 的仓库进行合并：仍以后端返回的仓库信息为基础，但保留本地已有的 AI 分析字段和仓库级本地元数据。

## 保留的本地字段

- AI 分析信息
- 自定义描述、标签、分类
- 分类锁定状态
- 最近编辑时间
- release 同步状态

## 行为说明

- 后端返回的仓库列表仍然是权威列表
- 新增 star 的仓库会正常加入
- 已不在后端返回列表中的仓库不会被本地数据恢复
- 不修改 AI 配置、WebDAV 配置、登录信息、主题等用户配置同步逻辑

## 验证
已在windows本地进行覆盖安装验证，由于mac不在身边，麻烦你来验证了

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed synchronization to preserve local repository metadata—including custom descriptions, tags, analysis status, and other user-created data—when syncing updates from the backend, preventing unintended data loss during sync operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmintaCCCP/GithubStarsManager/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->