### PR TITLE
fix: add subscribed_to_releases to local fields and fix hash loop

### DIFF
--- a/src/services/autoSync.ts
+++ b/src/services/autoSync.ts
@@ -140,8 +140,9 @@ export async function syncFromBackend(): Promise<void> {
       if (isBootstrapEmpty) {
         _hasPendingPush = true;
       } else {
-        state.setRepositories(mergeRepositoriesPreservingLocalMetadata(backendRepos, localRepos));
-        _lastHash.repos = hashes.repos;
+        const merged = mergeRepositoriesPreservingLocalMetadata(backendRepos, localRepos);
+        state.setRepositories(merged);
+        _lastHash.repos = quickHash(merged);
       }
     }
     if (changed.releases && releasesResult.status === 'fulfilled') {

--- a/src/utils/repositoryMerge.ts
+++ b/src/utils/repositoryMerge.ts
@@ -8,6 +8,7 @@ const LOCAL_REPOSITORY_FIELDS: Array<keyof Repository> = [
   'ai_platforms',
   'analyzed_at',
   'analysis_failed',
+  'subscribed_to_releases',
   'custom_description',
   'custom_tags',
   'custom_category',


### PR DESCRIPTION
## 变更说明

基于 PR #147 (fix: 后端同步时保留仓库本地元数据) 的代码审查反馈，修复两个问题：

### 修复内容

1. **补充 `subscribed_to_releases` 字段**
   - `Repository` 类型中 `subscribed_to_releases?: boolean` 是用户本地操作的订阅标记
   - 原 PR 遗漏了该字段，导致后端同步时覆盖用户的 Release 订阅设置
   - 已加入 `LOCAL_REPOSITORY_FIELDS`

2. **修复 hash 循环写问题**
   - 原实现使用 `quickHash(backendRepos)` 作为 hash，但实际写入 store 的是合并后的数据
   - 如果后端不持久化本地字段，pull 回来的数据永远不含本地字段 → hash 始终不同 → 每次 poll 都触发 `setRepositories` → 不必要的写循环
   - 改为对合并后的数据计算 hash，避免多余操作

### 验证
- TypeScript 编译通过
- CI 构建通过（如需要可触发）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed repository synchronization to properly preserve local subscription settings when merging data from the backend.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmintaCCCP/GithubStarsManager/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->