### PR TITLE
fix: disable macOS code signing to prevent 'app damaged' error

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -505,9 +505,8 @@ jobs:
             ],
             icon: 'build/icon.png',
             category: 'public.app-category.productivity',
-            hardenedRuntime: true,
             gatekeeperAssess: false,
-            identity: null
+
           };
           packageJson.build.dmg = {
             title: 'GitHub Stars Manager',

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -41,9 +41,6 @@ mac:
         - arm64
   icon: dist/vite.svg
   category: public.app-category.productivity
-  hardenedRuntime: true
-  entitlements: build/entitlements.mac.plist
-  entitlementsInherit: build/entitlements.mac.inherit.plist
 
 dmg:
   title: GitHub Stars Manager


### PR DESCRIPTION
## Summary

Fixes macOS "app is damaged, cannot open" error reported in #151.

### Root Cause

The build config sets `identity: null` (skip signing) but keeps `hardenedRuntime: true`, causing electron-builder to produce an ad-hoc signed binary with no Sealed Resources. Gatekeeper on macOS rejects this as "damaged":

```
flags=0x20002(adhoc,linker-signed)
Sealed Resources=none
Signature=adhoc
```

### Changes

- **electron-builder.yml**: Remove `hardenedRuntime`, `entitlements`, `entitlementsInherit`; add `sign: false`
- **build-desktop.yml**: Remove `hardenedRuntime: true`; add `sign: false` alongside existing `identity: null`

### User Impact

After this fix, macOS users can open the app by right-clicking → Open on first launch. No code signing certificate required.

Closes #151


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated macOS packaging/signing configuration for the desktop app: removed hardened runtime and entitlements directives while keeping gatekeeper assessment disabled.


<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmintaCCCP/GithubStarsManager/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->