### PR TITLE
feat: show AI analysis failure reason on hover

### DIFF
--- a/src/components/DiscoveryView.tsx
+++ b/src/components/DiscoveryView.tsx
@@ -826,6 +826,7 @@ export const DiscoveryView: React.FC = React.memo(() => {
               category_locked: wasCategoryLocked,
               analyzed_at: new Date().toISOString(),
               analysis_failed: false,
+              analysis_error: undefined,
             };
             updateDiscoveryRepo(updatedRepo);
             discoveryAnalysisStorage.saveAnalysis(updatedRepo.id, {
@@ -834,6 +835,7 @@ export const DiscoveryView: React.FC = React.memo(() => {
               ai_platforms: result.platforms,
               analyzed_at: updatedRepo.analyzed_at,
               analysis_failed: false,
+              analysis_error: undefined,
             });
           } else if (!result.success && result.repo) {
             const failedRepo: DiscoveryRepo = {
@@ -843,11 +845,13 @@ export const DiscoveryView: React.FC = React.memo(() => {
               platform: discoveryPlatform,
               analyzed_at: new Date().toISOString(),
               analysis_failed: true,
+              analysis_error: result.error?.message || undefined,
             };
             updateDiscoveryRepo(failedRepo);
             discoveryAnalysisStorage.saveAnalysis(failedRepo.id, {
               analyzed_at: failedRepo.analyzed_at,
               analysis_failed: true,
+              analysis_error: failedRepo.analysis_error,
             });
           }
         }

--- a/src/components/DiscoveryView.tsx
+++ b/src/components/DiscoveryView.tsx
@@ -601,6 +601,7 @@ export const DiscoveryView: React.FC = React.memo(() => {
             ai_platforms: existingRepo.ai_platforms,
             analyzed_at: existingRepo.analyzed_at,
             analysis_failed: existingRepo.analysis_failed,
+            analysis_error: existingRepo.analysis_error,
           };
         }
         const persisted = persistedAnalyses.get(newRepo.id);
@@ -612,6 +613,7 @@ export const DiscoveryView: React.FC = React.memo(() => {
             ai_platforms: persisted.ai_platforms,
             analyzed_at: persisted.analyzed_at,
             analysis_failed: persisted.analysis_failed,
+            analysis_error: persisted.analysis_error,
           };
         }
         return newRepo;

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import { createPortal } from 'react-dom';
-import { GripVertical, Star, StarOff, ExternalLink, Calendar, Bell, BellOff, Bot, Sparkles, Monitor, Smartphone, Globe, Terminal, Package, Edit3, BookOpen, Apple, Square, CheckSquare, Loader2 } from 'lucide-react';
+import { GripVertical, Star, StarOff, ExternalLink, Calendar, Bell, BellOff, Bot, Sparkles, Monitor, Smartphone, Globe, Terminal, Package, Edit3, BookOpen, Apple, Square, CheckSquare, Loader2, HelpCircle } from 'lucide-react';
 import { Repository, Category } from '../types';
 import { useAppStore } from '../store/useAppStore';
 import { getAICategory, getDefaultCategory } from '../utils/categoryUtils';
@@ -327,7 +327,8 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
         custom_category: result.custom_category,
         category_locked: result.category_locked,
         analyzed_at: result.analyzed_at,
-        analysis_failed: result.analysis_failed
+        analysis_failed: result.analysis_failed,
+        analysis_error: undefined,
       };
 
       updateRepository(updatedRepo);
@@ -341,11 +342,15 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
       if (!controller.signal.aborted) {
         console.error('AI analysis failed:', error);
 
-        const failedResult = createFailedAnalysisResult();
+        const errorMsg = error instanceof Error && error.message
+          ? error.message
+          : (language === 'zh' ? 'AI分析失败，请检查AI配置和网络连接' : 'AI analysis failed, please check AI configuration and network connection');
+        const failedResult = createFailedAnalysisResult(errorMsg);
         const failedRepo = {
           ...repository,
           analyzed_at: failedResult.analyzed_at,
-          analysis_failed: failedResult.analysis_failed
+          analysis_failed: failedResult.analysis_failed,
+          analysis_error: failedResult.analysis_error,
         };
 
         updateRepository(failedRepo);
@@ -913,6 +918,15 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
             <div className="flex items-center space-x-1 text-xs text-status-red dark:text-status-red" title={language === 'zh' ? 'AI分析失败，点击AI按钮重新分析' : 'AI analysis failed, click AI button to retry'}>
               <Bot className="w-3 h-3" />
               <span>{language === 'zh' ? '分析失败' : 'Failed'}</span>
+              <div className="group relative">
+                <HelpCircle className="w-3 h-3 text-status-red/70 dark:text-status-red/70 cursor-help" />
+                <div className="absolute left-0 top-full mt-2 w-72 max-w-xs p-3 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-900 dark:text-white text-xs rounded-lg shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-[9999] whitespace-normal break-words">
+                  <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
+                    {repository.analysis_error || (language === 'zh' ? 'AI分析失败，请检查AI配置和网络连接' : 'AI analysis failed, please check AI configuration and network connection')}
+                  </p>
+                  <div className="absolute top-[-4px] left-3 w-2 h-2 bg-white dark:bg-gray-800 border-l border-t border-gray-200 dark:border-gray-700 transform rotate-45"></div>
+                </div>
+              </div>
             </div>
           ) : displayContent.isAnalyzed ? (
             <div 

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -1067,6 +1067,7 @@ export const RepositoryCard = React.memo(RepositoryCardComponent, (prevProps, ne
     prevProps.repository.id === nextProps.repository.id &&
     prevProps.repository.analyzed_at === nextProps.repository.analyzed_at &&
     prevProps.repository.analysis_failed === nextProps.repository.analysis_failed &&
+    prevProps.repository.analysis_error === nextProps.repository.analysis_error &&
     prevProps.repository.ai_summary === nextProps.repository.ai_summary &&
     prevProps.repository.ai_tags === nextProps.repository.ai_tags &&
     prevProps.repository.ai_platforms === nextProps.repository.ai_platforms &&

--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -377,6 +377,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
             category_locked: wasCategoryLocked,
             analyzed_at: new Date().toISOString(),
             analysis_failed: false,
+            analysis_error: undefined,
           });
           successCount++;
         } else {
@@ -384,6 +385,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
             ...result.repo,
             analyzed_at: new Date().toISOString(),
             analysis_failed: true,
+            analysis_error: result.error?.message || undefined,
           });
           failedCount++;
         }
@@ -527,6 +529,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
             updatedRepo.ai_summary = undefined;
             updatedRepo.analyzed_at = undefined;
             updatedRepo.analysis_failed = undefined;
+            updatedRepo.analysis_error = undefined;
           }
         }
 
@@ -537,6 +540,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
             updatedRepo.ai_platforms = undefined;
             updatedRepo.analyzed_at = undefined;
             updatedRepo.analysis_failed = undefined;
+            updatedRepo.analysis_error = undefined;
           }
         }
 
@@ -548,6 +552,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
             updatedRepo.ai_platforms = undefined;
             updatedRepo.analyzed_at = undefined;
             updatedRepo.analysis_failed = undefined;
+            updatedRepo.analysis_error = undefined;
           }
         }
 
@@ -724,6 +729,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
                   category_locked: shouldKeepLocked || wasCategoryLocked,
                   analyzed_at: new Date().toISOString(),
                   analysis_failed: false,
+                  analysis_error: undefined,
                 });
                 successCount++;
               } else {
@@ -731,6 +737,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
                   ...result.repo,
                   analyzed_at: new Date().toISOString(),
                   analysis_failed: true,
+                  analysis_error: result.error?.message || undefined,
                 });
                 failedCount++;
               }

--- a/src/components/SubscriptionRepoCard.tsx
+++ b/src/components/SubscriptionRepoCard.tsx
@@ -251,6 +251,7 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
         ai_platforms: result.platforms,
         analyzed_at: result.analyzed_at,
         analysis_failed: result.analysis_failed,
+        analysis_error: undefined,
       };
       updateDiscoveryRepo(updatedRepo);
       
@@ -260,11 +261,15 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
     } catch (error) {
       if (!controller.signal.aborted) {
         console.error('AI analysis error:', error);
-        const failedResult = createFailedAnalysisResult();
+        const errorMsg = error instanceof Error && error.message
+          ? error.message
+          : t('AI分析失败，请检查AI配置和网络连接', 'AI analysis failed, please check AI configuration and network connection');
+        const failedResult = createFailedAnalysisResult(errorMsg);
         const failedRepo: DiscoveryRepo = {
           ...repo,
           analyzed_at: failedResult.analyzed_at,
           analysis_failed: failedResult.analysis_failed,
+          analysis_error: failedResult.analysis_error,
         };
         updateDiscoveryRepo(failedRepo);
         toast(t('AI分析失败，请检查AI配置。', 'AI analysis failed. Please check your AI configuration.'), 'error');

--- a/src/services/aiAnalysisHelper.ts
+++ b/src/services/aiAnalysisHelper.ts
@@ -12,6 +12,7 @@ export interface AIAnalysisResult {
   category_locked?: boolean;
   analyzed_at: string;
   analysis_failed: boolean;
+  analysis_error?: string;
 }
 
 export interface AnalyzeRepositoryOptions {
@@ -61,12 +62,13 @@ export const analyzeRepository = async (options: AnalyzeRepositoryOptions): Prom
   };
 };
 
-export const createFailedAnalysisResult = (): AIAnalysisResult => ({
+export const createFailedAnalysisResult = (error?: string): AIAnalysisResult => ({
   summary: '',
   tags: [],
   platforms: [],
   analyzed_at: new Date().toISOString(),
   analysis_failed: true,
+  analysis_error: error || undefined,
 });
 
 export const getDefaultCategoryNames = (customCategories: Category[], language: string = 'zh'): string[] => {

--- a/src/services/discoveryAnalysisStorage.ts
+++ b/src/services/discoveryAnalysisStorage.ts
@@ -4,6 +4,7 @@ export interface DiscoveryAnalysisData {
   ai_platforms?: string[];
   analyzed_at?: string;
   analysis_failed?: boolean;
+  analysis_error?: string;
 }
 
 const DB_NAME = 'github-stars-discovery-analysis';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,6 +22,7 @@ export interface Repository {
   ai_platforms?: string[];
   analyzed_at?: string;
   analysis_failed?: boolean;
+  analysis_error?: string;
   subscribed_to_releases?: boolean;
   custom_description?: string;
   custom_tags?: string[];


### PR DESCRIPTION
## Summary
- AI分析失败时，在"分析失败"旁新增问号图标，鼠标悬停显示具体失败原因
- 失败原因来自接口返回的错误信息（如 `AI API error: 401 Unauthorized`），网络等无返回的场景使用默认兜底文案
- 样式与"AI搜索"按钮右侧的叹号提示一致（CSS group-hover tooltip）
- 错误信息持久化到 IndexedDB，刷新页面后仍可查看

## Changes
- `Repository` / `AIAnalysisResult` / `DiscoveryAnalysisData` 接口新增 `analysis_error` 字段
- 所有分析失败路径（单个分析、批量分析、Discovery 分析）均捕获并存储错误信息
- 所有分析成功/重置路径清除 `analysis_error`

## Test plan
- [ ] 配置错误的 AI API key，触发单个仓库分析失败 → 问号图标出现，hover 显示具体错误
- [ ] 断开网络，触发批量分析 → 批量失败的仓库显示错误原因
- [ ] 重新分析成功 → 问号图标消失
- [ ] 刷新页面 → 错误原因仍然保留

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * AI analysis now captures and displays specific error messages when failures occur, making failure reasons visible in the UI tooltip.
  * Successful analyses explicitly clear prior error messages so stale errors no longer linger.
  * Bulk restore and single-repo flows now clear analysis error state when reverting AI-generated fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmintaCCCP/GithubStarsManager/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->