### PR TITLE
fix: empty CSC_LINK causes macOS build to fail

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -555,7 +555,25 @@ jobs:
         chmod -R 755 dist/ || echo "Could not set dist permissions"
         chmod -R 755 electron/ || echo "Could not set electron permissions"
         chmod -R 755 build/ || echo "Could not set build permissions"
-        
+
+    - name: Configure macOS signing
+      if: matrix.os == 'macos-latest'
+      shell: bash
+      run: |
+        # Only set CSC_LINK when a signing certificate is actually configured.
+        # An empty CSC_LINK causes electron-builder to treat CWD as a cert
+        # file and fail with "not a file".
+        if [ -n "$CSC_LINK_SECRET" ]; then
+          echo "CSC_LINK=$CSC_LINK_SECRET" >> "$GITHUB_ENV"
+          echo "CSC_KEY_PASSWORD=$CSC_KEY_PASSWORD_SECRET" >> "$GITHUB_ENV"
+          echo "Signing certificate configured"
+        else
+          echo "No signing certificate — electron-builder will ad-hoc sign"
+        fi
+      env:
+        CSC_LINK_SECRET: ${{ secrets.CSC_LINK }}
+        CSC_KEY_PASSWORD_SECRET: ${{ secrets.CSC_KEY_PASSWORD }}
+
     - name: Build Electron app
       run: npm run dist
       env:
@@ -564,13 +582,7 @@ jobs:
         DEBUG: electron-builder
         # Linux 特定环境变量
         ELECTRON_BUILDER_ALLOW_UNRESOLVED_DEPENDENCIES: true
-        # macOS signing and notarization
-        CSC_LINK: ${{ secrets.CSC_LINK }}
-        CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-        APPLE_ID: ${{ secrets.APPLE_ID }}
-        APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        
+
     - name: List build output
       shell: bash
       run: |

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -564,8 +564,18 @@ jobs:
         # An empty CSC_LINK causes electron-builder to treat CWD as a cert
         # file and fail with "not a file".
         if [ -n "$CSC_LINK_SECRET" ]; then
-          echo "CSC_LINK=$CSC_LINK_SECRET" >> "$GITHUB_ENV"
-          echo "CSC_KEY_PASSWORD=$CSC_KEY_PASSWORD_SECRET" >> "$GITHUB_ENV"
+          {
+            echo "CSC_LINK<<__EOF__"
+            echo "$CSC_LINK_SECRET"
+            echo "__EOF__"
+          } >> "$GITHUB_ENV"
+          if [ -n "$CSC_KEY_PASSWORD_SECRET" ]; then
+            {
+              echo "CSC_KEY_PASSWORD<<__EOF__"
+              echo "$CSC_KEY_PASSWORD_SECRET"
+              echo "__EOF__"
+            } >> "$GITHUB_ENV"
+          fi
           echo "Signing certificate configured"
         else
           echo "No signing certificate — electron-builder will ad-hoc sign"


### PR DESCRIPTION
## Summary

- Fixes macOS CI build failure: `not a file` error caused by empty `CSC_LINK` environment variable
- Fixes #151: ensures release builds produce properly ad-hoc signed apps (no "app damaged" error)

## Root Cause

When `CSC_LINK` secret is not configured, GitHub Actions passes an empty string. electron-builder treats `CSC_LINK=""` as a certificate file path and fails with `not a file`.

## Changes

- Move `CSC_LINK` / `CSC_KEY_PASSWORD` from unconditional `env:` block into a conditional step that only sets them when secrets actually exist
- Remove `APPLE_ID` / `APPLE_APP_SPECIFIC_PASSWORD` / `APPLE_TEAM_ID` (no Apple Developer account configured, not needed)

## Expected Behavior

- **CI build**: electron-builder skips certificate import, auto ad-hoc signs → build succeeds
- **Release install**: ad-hoc signed app → users right-click → Open on first launch (no "app damaged" error)

## Test Plan

- [ ] macOS CI build passes
- [ ] Windows CI build passes
- [ ] Linux CI build passes
- [ ] Release .dmg opens via right-click → Open on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated desktop build workflow to add a macOS-specific signing step that conditionally uses signing credentials and avoids injecting macOS signing/notarization secrets unconditionally, improving build reliability and security.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmintaCCCP/GithubStarsManager/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->