### PR TITLE
fix: include AI API error response body in error messages

### DIFF
--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -83,6 +83,20 @@ export class AIService {
     return this.config.model.trim().toLowerCase().includes('mimo');
   }
 
+  private async extractErrorDetail(response: Response): Promise<string> {
+    try {
+      const text = await response.text();
+      try {
+        const errorBody = JSON.parse(text);
+        return typeof errorBody === 'object' ? JSON.stringify(errorBody) : String(errorBody);
+      } catch {
+        return text;
+      }
+    } catch {
+      return '';
+    }
+  }
+
   private async requestText(options: {
     system: string;
     user: string;
@@ -137,20 +151,7 @@ export class AIService {
           signal: options.signal,
         });
         if (!response.ok) {
-          let errorDetail = '';
-          try {
-            const text = await response.text();
-            try {
-              const errorBody = JSON.parse(text);
-              errorDetail = typeof errorBody === 'object'
-                ? JSON.stringify(errorBody)
-                : String(errorBody);
-            } catch {
-              errorDetail = text;
-            }
-          } catch {
-            // ignore
-          }
+          const errorDetail = await this.extractErrorDetail(response);
           throw new Error(`AI API error: ${response.status} ${response.statusText}${errorDetail ? ` - ${errorDetail}` : ''}`);
         }
         data = await response.json();
@@ -209,20 +210,7 @@ export class AIService {
           signal: options.signal,
         });
         if (!response.ok) {
-          let errorDetail = '';
-          try {
-            const text = await response.text();
-            try {
-              const errorBody = JSON.parse(text);
-              errorDetail = typeof errorBody === 'object'
-                ? JSON.stringify(errorBody)
-                : String(errorBody);
-            } catch {
-              errorDetail = text;
-            }
-          } catch {
-            // ignore
-          }
+          const errorDetail = await this.extractErrorDetail(response);
           throw new Error(`AI API error: ${response.status} ${response.statusText}${errorDetail ? ` - ${errorDetail}` : ''}`);
         }
         data = await response.json();
@@ -278,7 +266,8 @@ ${options.user}` : options.user;
         signal: options.signal,
       });
       if (!response.ok) {
-        throw new Error(`AI API error: ${response.status} ${response.statusText}`);
+        const errorDetail = await this.extractErrorDetail(response);
+        throw new Error(`AI API error: ${response.status} ${response.statusText}${errorDetail ? ` - ${errorDetail}` : ''}`);
       }
       data = await response.json();
     }

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -137,7 +137,21 @@ export class AIService {
           signal: options.signal,
         });
         if (!response.ok) {
-          throw new Error(`AI API error: ${response.status} ${response.statusText}`);
+          let errorDetail = '';
+          try {
+            const text = await response.text();
+            try {
+              const errorBody = JSON.parse(text);
+              errorDetail = typeof errorBody === 'object'
+                ? JSON.stringify(errorBody)
+                : String(errorBody);
+            } catch {
+              errorDetail = text;
+            }
+          } catch {
+            // ignore
+          }
+          throw new Error(`AI API error: ${response.status} ${response.statusText}${errorDetail ? ` - ${errorDetail}` : ''}`);
         }
         data = await response.json();
       }
@@ -195,7 +209,21 @@ export class AIService {
           signal: options.signal,
         });
         if (!response.ok) {
-          throw new Error(`AI API error: ${response.status} ${response.statusText}`);
+          let errorDetail = '';
+          try {
+            const text = await response.text();
+            try {
+              const errorBody = JSON.parse(text);
+              errorDetail = typeof errorBody === 'object'
+                ? JSON.stringify(errorBody)
+                : String(errorBody);
+            } catch {
+              errorDetail = text;
+            }
+          } catch {
+            // ignore
+          }
+          throw new Error(`AI API error: ${response.status} ${response.statusText}${errorDetail ? ` - ${errorDetail}` : ''}`);
         }
         data = await response.json();
       }

--- a/src/services/backendAdapter.ts
+++ b/src/services/backendAdapter.ts
@@ -112,11 +112,20 @@ class BackendAdapter {
   }
   private async throwTranslatedError(res: Response, fallbackPrefix: string): Promise<never> {
     let code: string | undefined;
+    let detail = '';
     try {
       const data = await res.json();
       code = data.code;
+      // Extract nested error details (e.g., DeepSeek returns { error: { message, type, code } })
+      if (data.error) {
+        const err = data.error;
+        detail = typeof err === 'string' ? err : (err.message || JSON.stringify(err));
+      } else if (data.message) {
+        detail = data.message;
+      }
     } catch { /* body not JSON */ }
-    throw new Error(translateBackendError(code, `${fallbackPrefix}: ${res.status}`));
+    const translated = translateBackendError(code, `${fallbackPrefix}: ${res.status}`);
+    throw new Error(detail ? `${translated} - ${detail}` : translated);
   }
 
   // === GitHub Proxy ===


### PR DESCRIPTION
## Summary
- AI API 返回 4xx/5xx 错误时，现在会在错误信息中包含 response body 的详细内容（如 DeepSeek 返回的具体错误原因）
- 后端代理路径现在会正确提取 DeepSeek 嵌套的 `error.message` 字段
- 解决了 #153 中报告的问题：分析失败时无法得知具体原因

## Changes
- `src/services/aiService.ts`: 在 OpenAI 和 Claude 两条请求路径中，非 OK 响应时读取 response body 并附带到错误信息
- `src/services/backendAdapter.ts`: `throwTranslatedError` 现在会提取 `data.error.message` 或 `data.message` 等嵌套错误详情

## Before → After
```
之前: AI API error: 400 Bad Request
之后: AI API error: 400 Bad Request - {"error":{"message":"...","type":"...","code":"..."}}

之前: AI代理请求失败: 400
之后: AI代理请求失败: 400 - Invalid request: ...
```

## Test plan
- [ ] 重新分析 #153 中失败的两个仓库（FoldCraftLauncher, i-hate-regex），确认错误信息中包含 DeepSeek 返回的具体原因
- [ ] 验证正常分析流程不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for external API failures: responses now include additional response-body details (when available) to provide clearer context and actionable information for troubleshooting failed AI and backend requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmintaCCCP/GithubStarsManager/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->