### PR TITLE
fix: sanitize prompt content to prevent AI API JSON parse errors

### DIFF
--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -74,8 +74,10 @@ export class AIService {
   private sanitizeForPrompt(content: string): string {
     // 移除 null 字节和控制字符（保留换行、回车、制表符）
     let sanitized = content.replace(/[\0-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
-    // 替换孤立高位代理 (U+D800-U+DBFF) 和孤立低位代理 (U+DC00-U+DFFF)
-    sanitized = sanitized.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, '�');
+    // 替换孤立代理项：先移除未配对的高位代理，再移除未配对的低位代理
+    // 避免使用 lookbehind 以兼容 Safari 12+
+    sanitized = sanitized.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/g, '�');
+    sanitized = sanitized.replace(/[\uDC00-\uDFFF]/g, '�');
     return sanitized;
   }
 
@@ -344,7 +346,7 @@ ${this.language === 'zh' ? 'Star数' : 'Stars'}: ${repository.stargazers_count}
 ${this.language === 'zh' ? '主题标签' : 'Topics'}: ${repository.topics?.join(', ') || (this.language === 'zh' ? '无' : 'None')}
 
 ${this.language === 'zh' ? 'README内容 (前2000字符)' : 'README Content (first 2000 characters)'}:
-${this.sanitizeForPrompt(readmeContent).substring(0, 2000)}
+${this.sanitizeForPrompt(readmeContent.substring(0, 2000))}
     `.trim();
 
     const categoriesInfo = customCategories && customCategories.length > 0 
@@ -369,7 +371,7 @@ ${this.language === 'zh' ? 'Star数' : 'Stars'}: ${repository.stargazers_count}
 ${this.language === 'zh' ? '主题标签' : 'Topics'}: ${repository.topics?.join(', ') || (this.language === 'zh' ? '无' : 'None')}
 
 ${this.language === 'zh' ? 'README内容 (前2000字符)' : 'README Content (first 2000 characters)'}:
-${this.sanitizeForPrompt(readmeContent).substring(0, 2000)}
+${this.sanitizeForPrompt(readmeContent.substring(0, 2000))}
     `.trim();
 
     const categoriesInfo = customCategories && customCategories.length > 0 

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -66,6 +66,19 @@ export class AIService {
     this.language = language;
   }
 
+  /**
+   * 清理用户内容中可能导致 JSON 序列化问题的字符
+   * - 移除 null 字节和控制字符（保留 \n \r \t）
+   * - 替换孤立代理项（lone surrogates），避免某些 JSON 解析器报错
+   */
+  private sanitizeForPrompt(content: string): string {
+    // 移除 null 字节和控制字符（保留换行、回车、制表符）
+    let sanitized = content.replace(/[\0-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
+    // 替换孤立高位代理 (U+D800-U+DBFF) 和孤立低位代理 (U+DC00-U+DFFF)
+    sanitized = sanitized.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, '�');
+    return sanitized;
+  }
+
   private getApiType(): AIApiType {
     return this.config.apiType || 'openai';
   }
@@ -325,13 +338,13 @@ ${options.user}` : options.user;
   private createCustomAnalysisPrompt(repository: Repository, readmeContent: string, customCategories?: string[]): string {
     const repoInfo = `
 ${this.language === 'zh' ? '仓库名称' : 'Repository Name'}: ${repository.full_name}
-${this.language === 'zh' ? '描述' : 'Description'}: ${repository.description || (this.language === 'zh' ? '无描述' : 'No description')}
+${this.language === 'zh' ? '描述' : 'Description'}: ${this.sanitizeForPrompt(repository.description || (this.language === 'zh' ? '无描述' : 'No description'))}
 ${this.language === 'zh' ? '编程语言' : 'Programming Language'}: ${repository.language || (this.language === 'zh' ? '未知' : 'Unknown')}
 ${this.language === 'zh' ? 'Star数' : 'Stars'}: ${repository.stargazers_count}
 ${this.language === 'zh' ? '主题标签' : 'Topics'}: ${repository.topics?.join(', ') || (this.language === 'zh' ? '无' : 'None')}
 
 ${this.language === 'zh' ? 'README内容 (前2000字符)' : 'README Content (first 2000 characters)'}:
-${readmeContent.substring(0, 2000)}
+${this.sanitizeForPrompt(readmeContent).substring(0, 2000)}
     `.trim();
 
     const categoriesInfo = customCategories && customCategories.length > 0 
@@ -350,13 +363,13 @@ ${readmeContent.substring(0, 2000)}
   private createAnalysisPrompt(repository: Repository, readmeContent: string, customCategories?: string[]): string {
     const repoInfo = `
 ${this.language === 'zh' ? '仓库名称' : 'Repository Name'}: ${repository.full_name}
-${this.language === 'zh' ? '描述' : 'Description'}: ${repository.description || (this.language === 'zh' ? '无描述' : 'No description')}
+${this.language === 'zh' ? '描述' : 'Description'}: ${this.sanitizeForPrompt(repository.description || (this.language === 'zh' ? '无描述' : 'No description'))}
 ${this.language === 'zh' ? '编程语言' : 'Programming Language'}: ${repository.language || (this.language === 'zh' ? '未知' : 'Unknown')}
 ${this.language === 'zh' ? 'Star数' : 'Stars'}: ${repository.stargazers_count}
 ${this.language === 'zh' ? '主题标签' : 'Topics'}: ${repository.topics?.join(', ') || (this.language === 'zh' ? '无' : 'None')}
 
 ${this.language === 'zh' ? 'README内容 (前2000字符)' : 'README Content (first 2000 characters)'}:
-${readmeContent.substring(0, 2000)}
+${this.sanitizeForPrompt(readmeContent).substring(0, 2000)}
     `.trim();
 
     const categoriesInfo = customCategories && customCategories.length > 0 

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -73,11 +73,13 @@ export class AIService {
    */
   private sanitizeForPrompt(content: string): string {
     // 移除 null 字节和控制字符（保留换行、回车、制表符）
+    // eslint-disable-next-line no-control-regex
     let sanitized = content.replace(/[\0-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
-    // 替换孤立代理项：先移除未配对的高位代理，再移除未配对的低位代理
-    // 避免使用 lookbehind 以兼容 Safari 12+
-    sanitized = sanitized.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/g, '�');
-    sanitized = sanitized.replace(/[\uDC00-\uDFFF]/g, '�');
+    // 替换孤立代理项，同时保留合法代理对（避免 lookbehind 以兼容 Safari 12+）
+    sanitized = sanitized.replace(
+      /([\uD800-\uDBFF][\uDC00-\uDFFF])|[\uD800-\uDBFF]|[\uDC00-\uDFFF]/g,
+      (m, pair) => (pair ? m : '�')
+    );
     return sanitized;
   }
 


### PR DESCRIPTION
## Summary
- 新增 `sanitizeForPrompt()` 方法，在 README 内容和仓库描述插入 prompt 前清理可能导致 JSON 序列化问题的字符
- 移除 null 字节和控制字符（保留换行/回车/制表符）
- 替换孤立代理项（lone surrogates）为 `�`，避免部分 AI API 的 JSON 解析器报错

## 问题背景
使用 DeepSeek 等模型分析某些仓库时，AI API 返回 400 错误：
> unexpected end of hex escape at line 1 column X

原因是 README 或仓库描述中的异常字符（孤立代理项、控制字符等）经过 JSON 序列化 → Express proxy 反序列化 → 再次序列化的链路后，部分 JSON 解析器无法处理。

## Test plan
- [ ] 使用 deepseek-v4-flash 分析 `FCL-Team/FoldCraftLauncher`，验证不再报 JSON 解析错误
- [ ] 使用 deepseek-v4-flash 分析 `geongeorge/i-hate-regex`，验证不再报 JSON 解析错误
- [ ] 验证正常仓库的 AI 分析功能不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of AI analysis by sanitizing repository descriptions and the first 2,000 characters of README content: problematic control characters are removed or replaced while preserving newlines, carriage returns and tabs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmintaCCCP/GithubStarsManager/pull/159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->