### PR TITLE
fix: AI config form test fails with CORS network error

### DIFF
--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -137,6 +137,12 @@ router.post('/api/proxy/ai', async (req, res) => {
       baseUrl = aiConfig.base_url as string;
       model = aiConfig.model as string;
       reasoningEffort = normalizeReasoningEffort(aiConfig.reasoning_effort);
+      try {
+        const parsed = new URL(baseUrl);
+        if (parsed.protocol !== 'https:') {
+          console.warn(`[Proxy] ⚠️ AI API key transmitted over ${parsed.protocol} (not HTTPS). Consider using HTTPS for security.`);
+        }
+      } catch { /* invalid URL, will be caught by validateUrl later */ }
     } else {
       res.status(400).json({ error: 'configId or config required', code: 'CONFIG_ID_REQUIRED' });
       return;

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -85,30 +85,62 @@ router.post('/api/proxy/github/*', async (req, res) => {
   }
 });
 
+function normalizeReasoningEffort(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  return value === 'minimal' ? 'low' : value;
+}
+
 // POST /api/proxy/ai
+// Accepts either { configId, body } (lookup from DB) or { config, body } (inline config for one-time requests)
 router.post('/api/proxy/ai', async (req, res) => {
   try {
     const db = getDb();
-    const { configId, body: requestBody } = req.body as { configId: string; body: Record<string, unknown> };
+    const { configId, config: inlineConfig, body: requestBody } = req.body as {
+      configId?: string;
+      config?: { apiType?: string; baseUrl: string; apiKey: string; model: string; reasoningEffort?: string };
+      body: Record<string, unknown>;
+    };
 
-    if (!configId) {
-      res.status(400).json({ error: 'configId required', code: 'CONFIG_ID_REQUIRED' });
+    let apiKey: string;
+    let apiType: string;
+    let baseUrl: string;
+    let model: string;
+    let reasoningEffort: string | null;
+
+    if (inlineConfig && !configId) {
+      // Inline config path (for form tests without a saved config ID)
+      apiKey = inlineConfig.apiKey;
+      apiType = inlineConfig.apiType || 'openai';
+      baseUrl = inlineConfig.baseUrl;
+      model = inlineConfig.model;
+      reasoningEffort = normalizeReasoningEffort(inlineConfig.reasoningEffort);
+      if (!baseUrl || !apiKey || !model) {
+        res.status(400).json({ error: 'baseUrl, apiKey, and model are required', code: 'INVALID_REQUEST' });
+        return;
+      }
+      // Warn if API key is transmitted over non-HTTPS connection
+      try {
+        const parsed = new URL(baseUrl);
+        if (parsed.protocol !== 'https:') {
+          console.warn(`[Proxy] ⚠️ AI API key transmitted over ${parsed.protocol} (not HTTPS). Consider using HTTPS for security.`);
+        }
+      } catch { /* invalid URL, will be caught by validateUrl later */ }
+    } else if (configId) {
+      // DB lookup path (for saved configs)
+      const aiConfig = db.prepare('SELECT * FROM ai_configs WHERE id = ?').get(configId) as Record<string, unknown> | undefined;
+      if (!aiConfig) {
+        res.status(404).json({ error: 'AI config not found', code: 'AI_CONFIG_NOT_FOUND' });
+        return;
+      }
+      apiKey = decrypt(aiConfig.api_key_encrypted as string, config.encryptionKey);
+      apiType = (aiConfig.api_type as string) || 'openai';
+      baseUrl = aiConfig.base_url as string;
+      model = aiConfig.model as string;
+      reasoningEffort = normalizeReasoningEffort(aiConfig.reasoning_effort);
+    } else {
+      res.status(400).json({ error: 'configId or config required', code: 'CONFIG_ID_REQUIRED' });
       return;
     }
-
-    const aiConfig = db.prepare('SELECT * FROM ai_configs WHERE id = ?').get(configId) as Record<string, unknown> | undefined;
-    if (!aiConfig) {
-      res.status(404).json({ error: 'AI config not found', code: 'AI_CONFIG_NOT_FOUND' });
-      return;
-    }
-
-    const apiKey = decrypt(aiConfig.api_key_encrypted as string, config.encryptionKey);
-    const apiType = (aiConfig.api_type as string) || 'openai';
-    const baseUrl = aiConfig.base_url as string;
-    const model = aiConfig.model as string;
-    const reasoningEffort = aiConfig.reasoning_effort === 'minimal'
-      ? 'low'
-      : aiConfig.reasoning_effort as string | null | undefined;
 
     let targetUrl: string;
     const headers: Record<string, string> = {

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -155,9 +155,9 @@ export class AIService {
       let data: Record<string, unknown>;
       if (backend.isAvailable) {
         if (this.config.id) {
-          data = await backend.proxyAIRequest(this.config.id, requestBody) as Record<string, unknown>;
+          data = await backend.proxyAIRequest(this.config.id, requestBody, options.signal) as Record<string, unknown>;
         } else {
-          data = await backend.proxyAIRequestWithConfig(this.config, requestBody) as Record<string, unknown>;
+          data = await backend.proxyAIRequestWithConfig(this.config, requestBody, options.signal) as Record<string, unknown>;
         }
       } else {
         const url = buildFinalApiUrl(this.config.baseUrl, apiType);
@@ -217,9 +217,9 @@ export class AIService {
       let data: unknown;
       if (backend.isAvailable) {
         if (this.config.id) {
-          data = await backend.proxyAIRequest(this.config.id, requestBody);
+          data = await backend.proxyAIRequest(this.config.id, requestBody, options.signal);
         } else {
-          data = await backend.proxyAIRequestWithConfig(this.config, requestBody);
+          data = await backend.proxyAIRequestWithConfig(this.config, requestBody, options.signal);
         }
       } else {
         const url = buildApiUrl(this.config.baseUrl, 'v1/messages');
@@ -277,9 +277,9 @@ ${options.user}` : options.user;
     let data: unknown;
     if (backend.isAvailable) {
       if (this.config.id) {
-        data = await backend.proxyAIRequest(this.config.id, requestBody);
+        data = await backend.proxyAIRequest(this.config.id, requestBody, options.signal);
       } else {
-        data = await backend.proxyAIRequestWithConfig(this.config, requestBody);
+        data = await backend.proxyAIRequestWithConfig(this.config, requestBody, options.signal);
       }
     } else {
       const path = `v1beta/models/${encodeURIComponent(model)}:generateContent`;

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -153,8 +153,12 @@ export class AIService {
           };
 
       let data: Record<string, unknown>;
-      if (backend.isAvailable && this.config.id) {
-        data = await backend.proxyAIRequest(this.config.id, requestBody) as Record<string, unknown>;
+      if (backend.isAvailable) {
+        if (this.config.id) {
+          data = await backend.proxyAIRequest(this.config.id, requestBody) as Record<string, unknown>;
+        } else {
+          data = await backend.proxyAIRequestWithConfig(this.config, requestBody) as Record<string, unknown>;
+        }
       } else {
         const url = buildFinalApiUrl(this.config.baseUrl, apiType);
         const response = await fetch(url, {
@@ -211,8 +215,12 @@ export class AIService {
       };
 
       let data: unknown;
-      if (backend.isAvailable && this.config.id) {
-        data = await backend.proxyAIRequest(this.config.id, requestBody);
+      if (backend.isAvailable) {
+        if (this.config.id) {
+          data = await backend.proxyAIRequest(this.config.id, requestBody);
+        } else {
+          data = await backend.proxyAIRequestWithConfig(this.config, requestBody);
+        }
       } else {
         const url = buildApiUrl(this.config.baseUrl, 'v1/messages');
         const response = await fetch(url, {
@@ -267,8 +275,12 @@ ${options.user}` : options.user;
     };
 
     let data: unknown;
-    if (backend.isAvailable && this.config.id) {
-      data = await backend.proxyAIRequest(this.config.id, requestBody);
+    if (backend.isAvailable) {
+      if (this.config.id) {
+        data = await backend.proxyAIRequest(this.config.id, requestBody);
+      } else {
+        data = await backend.proxyAIRequestWithConfig(this.config, requestBody);
+      }
     } else {
       const path = `v1beta/models/${encodeURIComponent(model)}:generateContent`;
       const urlObj = new URL(buildApiUrl(this.config.baseUrl, path));

--- a/src/services/backendAdapter.ts
+++ b/src/services/backendAdapter.ts
@@ -227,6 +227,18 @@ class BackendAdapter {
     return res.json();
   }
 
+  async proxyAIRequestWithConfig(aiConfig: { apiType?: string; baseUrl: string; apiKey: string; model: string; reasoningEffort?: string }, body: object): Promise<unknown> {
+    if (!this._backendUrl) throw new Error('Backend not available');
+
+    const res = await this.fetchWithTimeout(`${this._backendUrl}/proxy/ai`, {
+      method: 'POST',
+      headers: this.getAuthHeaders(),
+      body: JSON.stringify({ config: aiConfig, body })
+    }, 120000);
+    if (!res.ok) await this.throwTranslatedError(res, 'AI proxy error');
+    return res.json();
+  }
+
   // === WebDAV Proxy ===
 
   async proxyWebDAV(configId: string, method: string, path: string, body?: string, headers?: Record<string, string>): Promise<Response> {

--- a/src/services/backendAdapter.ts
+++ b/src/services/backendAdapter.ts
@@ -70,6 +70,17 @@ class BackendAdapter {
   private async fetchWithTimeout(url: string, options?: RequestInit, timeoutMs = 30000): Promise<Response> {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+    // If the caller provides a signal, forward its abort to our internal controller
+    const callerSignal = options?.signal;
+    if (callerSignal) {
+      if (callerSignal.aborted) {
+        controller.abort();
+      } else {
+        callerSignal.addEventListener('abort', () => controller.abort(), { once: true });
+      }
+    }
+
     try {
       return await fetch(url, { ...options, signal: controller.signal });
     } finally {
@@ -215,25 +226,27 @@ class BackendAdapter {
 
   // === AI Proxy ===
 
-  async proxyAIRequest(configId: string, body: object): Promise<unknown> {
+  async proxyAIRequest(configId: string, body: object, signal?: AbortSignal): Promise<unknown> {
     if (!this._backendUrl) throw new Error('Backend not available');
 
     const res = await this.fetchWithTimeout(`${this._backendUrl}/proxy/ai`, {
       method: 'POST',
       headers: this.getAuthHeaders(),
-      body: JSON.stringify({ configId, body })
+      body: JSON.stringify({ configId, body }),
+      signal,
     }, 120000);
     if (!res.ok) await this.throwTranslatedError(res, 'AI proxy error');
     return res.json();
   }
 
-  async proxyAIRequestWithConfig(aiConfig: { apiType?: string; baseUrl: string; apiKey: string; model: string; reasoningEffort?: string }, body: object): Promise<unknown> {
+  async proxyAIRequestWithConfig(aiConfig: { apiType?: string; baseUrl: string; apiKey: string; model: string; reasoningEffort?: string }, body: object, signal?: AbortSignal): Promise<unknown> {
     if (!this._backendUrl) throw new Error('Backend not available');
 
     const res = await this.fetchWithTimeout(`${this._backendUrl}/proxy/ai`, {
       method: 'POST',
       headers: this.getAuthHeaders(),
-      body: JSON.stringify({ config: aiConfig, body })
+      body: JSON.stringify({ config: aiConfig, body }),
+      signal,
     }, 120000);
     if (!res.ok) await this.throwTranslatedError(res, 'AI proxy error');
     return res.json();


### PR DESCRIPTION
## Summary

Fixes #156 — AI config "Test Connection" button fails with "网络连接失败" (Network connection failed) for `openai-compatible` endpoints.

**Root cause:** `handleTestForm()` creates a temp config with `id: ''`, and `requestText()` only routes through the backend proxy when `config.id` is truthy. Empty string is falsy, so form tests always fell through to direct browser fetch, which fails due to CORS policy.

## Changes

- **`server/src/routes/proxy.ts`**: Accept inline config `{ config, body }` in addition to `{ configId, body }`. Extracted `normalizeReasoningEffort()` helper, added input validation, added HTTPS warning.
- **`src/services/backendAdapter.ts`**: Added `proxyAIRequestWithConfig()` for one-time proxy requests without a stored config ID.
- **`src/services/aiService.ts`**: Route form tests through backend proxy when available, even without a saved config ID.

## Test plan

- [ ] Create/edit an AI config with `openai-compatible` type
- [ ] Click "测试连接" in the form — should succeed through backend proxy
- [ ] Test saved config — should still work
- [ ] Test with backend unavailable — should fall back to direct fetch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for using inline AI configuration as an alternative to stored configurations.

* **Improvements**
  * Clearer validation and distinct error responses for missing or invalid AI config.
  * Normalized reasoning effort values for consistent behavior.
  * Request cancellation/timeout now honored for AI requests routed through the backend proxy.
  * Console warning emitted when a non-HTTPS base URL is supplied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmintaCCCP/GithubStarsManager/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->