### PR TITLE
fix: upgrade frontend Dockerfile to Node 22 for Vite compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:18-alpine AS build
+FROM node:22-alpine AS build
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- Upgrade frontend `Dockerfile` build stage from `node:18-alpine` to `node:22-alpine` to satisfy Vite's Node.js version requirement (20.19+ or 22.12+)
- Aligns with `server/Dockerfile` which already uses `node:22-alpine`

## Related

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build environment to Node.js version 22 (previously version 18) for the build stage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmintaCCCP/GithubStarsManager/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->