### PR TITLE
feat: add network proxy settings (HTTP/SOCKS5)

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -419,27 +419,73 @@ jobs:
           '  return loadProxyConfig();\\n' +
           '});\\n\\n' +
           'ipcMain.handle(\\'test-proxy\\', async (event, config) => {\\n' +
+          '  const net = require(\\'net\\');\\n' +
+          '  const connectToProxy = () => new Promise((resolve, reject) => {\\n' +
+          '    const socket = new net.Socket();\\n' +
+          '    socket.setTimeout(5000);\\n' +
+          '    socket.on(\\'connect\\', () => resolve(socket));\\n' +
+          '    socket.on(\\'timeout\\', () => { socket.destroy(); reject(new Error(\\'Connection timeout\\')); });\\n' +
+          '    socket.on(\\'error\\', (err) => reject(err));\\n' +
+          '    socket.connect(config.port, config.host);\\n' +
+          '  });\\n' +
           '  try {\\n' +
-          '    const net = require(\\'net\\');\\n' +
-          '    return new Promise((resolve) => {\\n' +
-          '      const socket = new net.Socket();\\n' +
-          '      socket.setTimeout(5000);\\n' +
-          '      socket.on(\\'connect\\', () => {\\n' +
-          '        socket.destroy();\\n' +
-          '        resolve({ success: true });\\n' +
+          '    if (config.type === \\'socks5\\') {\\n' +
+          '      const socket = await connectToProxy();\\n' +
+          '      return await new Promise((resolve) => {\\n' +
+          '        const greeting = config.username\\n' +
+          '          ? Buffer.from([0x05, 0x02, 0x00, 0x02])\\n' +
+          '          : Buffer.from([0x05, 0x01, 0x00]);\\n' +
+          '        socket.setTimeout(5000);\\n' +
+          '        socket.write(greeting);\\n' +
+          '        let step = 0;\\n' +
+          '        socket.on(\\'data\\', (data) => {\\n' +
+          '          if (step === 0) {\\n' +
+          '            if (data[0] !== 0x05) { socket.destroy(); resolve({ success: false, error: \\'Invalid SOCKS5 version\\' }); return; }\\n' +
+          '            if (data[1] === 0xFF) { socket.destroy(); resolve({ success: false, error: \\'No acceptable auth method\\' }); return; }\\n' +
+          '            if (data[1] === 0x02 && config.username && config.password) {\\n' +
+          '              step = 1;\\n' +
+          '              const userBuf = Buffer.from(config.username, \\'utf8\\');\\n' +
+          '              const passBuf = Buffer.from(config.password, \\'utf8\\');\\n' +
+          '              const authReq = Buffer.alloc(3 + userBuf.length + passBuf.length);\\n' +
+          '              authReq[0] = 0x01; authReq[1] = userBuf.length;\\n' +
+          '              userBuf.copy(authReq, 2);\\n' +
+          '              authReq[2 + userBuf.length] = passBuf.length;\\n' +
+          '              passBuf.copy(authReq, 3 + userBuf.length);\\n' +
+          '              socket.write(authReq);\\n' +
+          '            } else { socket.destroy(); resolve({ success: true }); }\\n' +
+          '          } else if (step === 1) {\\n' +
+          '            socket.destroy();\\n' +
+          '            resolve(data[0] === 0x01 && data[1] === 0x00\\n' +
+          '              ? { success: true }\\n' +
+          '              : { success: false, error: \\'SOCKS5 authentication failed\\' });\\n' +
+          '          }\\n' +
+          '        });\\n' +
+          '        socket.on(\\'timeout\\', () => { socket.destroy(); resolve({ success: false, error: \\'SOCKS5 handshake timeout\\' }); });\\n' +
+          '        socket.on(\\'error\\', (err) => resolve({ success: false, error: err.message }));\\n' +
           '      });\\n' +
-          '      socket.on(\\'timeout\\', () => {\\n' +
-          '        socket.destroy();\\n' +
-          '        resolve({ success: false, error: \\'Connection timeout\\' });\\n' +
+          '    } else {\\n' +
+          '      const socket = await connectToProxy();\\n' +
+          '      return await new Promise((resolve) => {\\n' +
+          '        socket.setTimeout(5000);\\n' +
+          '        const authHeader = config.username && config.password\\n' +
+          '          ? \\'Proxy-Authorization: Basic \\' + Buffer.from(config.username + \\':\\' + config.password).toString(\\'base64\\') + \\'\\\\r\\\\n\\'\\n' +
+          '          : \\'\\';\\n' +
+          '        socket.write(\\'CONNECT httpbin.org:443 HTTP/1.1\\\\r\\\\nHost: httpbin.org:443\\\\r\\\\n\\' + authHeader + \\'\\\\r\\\\n\\');\\n' +
+          '        let responseData = \\'\\';\\n' +
+          '        socket.on(\\'data\\', (data) => {\\n' +
+          '          responseData += data.toString();\\n' +
+          '          if (responseData.includes(\\'\\\\r\\\\n\\\\r\\\\n\\')) {\\n' +
+          '            socket.destroy();\\n' +
+          '            if (responseData.includes(\\'200\\')) resolve({ success: true });\\n' +
+          '            else if (responseData.includes(\\'407\\')) resolve({ success: false, error: \\'Proxy authentication required\\' });\\n' +
+          '            else resolve({ success: false, error: \\'Proxy rejected: \\' + (responseData.split(\\'\\\\r\\\\n\\')[0] || \\'Unknown\\') });\\n' +
+          '          }\\n' +
+          '        });\\n' +
+          '        socket.on(\\'timeout\\', () => { socket.destroy(); resolve({ success: false, error: \\'HTTP proxy handshake timeout\\' }); });\\n' +
+          '        socket.on(\\'error\\', (err) => resolve({ success: false, error: err.message }));\\n' +
           '      });\\n' +
-          '      socket.on(\\'error\\', (err) => {\\n' +
-          '        resolve({ success: false, error: err.message });\\n' +
-          '      });\\n' +
-          '      socket.connect(config.port, config.host);\\n' +
-          '    });\\n' +
-          '  } catch (e) {\\n' +
-          '    return { success: false, error: e.message };\\n' +
-          '  }\\n' +
+          '    }\\n' +
+          '  } catch (e) { return { success: false, error: e.message }; }\\n' +
           '});\\n\\n' +
           'app.whenReady().then(() => {\\n' +
           '  createWindow();\\n' +

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -187,7 +187,7 @@ jobs:
           fs.mkdirSync('electron', { recursive: true });
         }
         
-        const mainJsContent = 'const { app, BrowserWindow, Menu, shell, globalShortcut } = require(\\'electron\\');\\n' +
+        const mainJsContent = 'const { app, BrowserWindow, Menu, shell, globalShortcut, ipcMain } = require(\\'electron\\');\\n' +
           'const path = require(\\'path\\');\\n' +
           'const fs = require(\\'fs\\');\\n' +
           'const isDev = process.env.NODE_ENV === \\'development\\';\\n\\n' +
@@ -204,7 +204,8 @@ jobs:
           '      enableRemoteModule: false,\\n' +
           '      webSecurity: false,\\n' +
           '      allowRunningInsecureContent: true,\\n' +
-          '      devTools: true // 生产环境也允许 DevTools 便于排障\\n' +
+          '      devTools: true, // 生产环境也允许 DevTools 便于排障\\n' +
+          '      preload: path.join(__dirname, \\'preload.js\\')\\n' +
           '    },\\n' +
           '    icon: path.join(__dirname, \\'../build/icon.png\\'),\\n' +
           '    titleBarStyle: \\'default\\', // 使用默认标题栏，避免重叠问题\\n' +
@@ -375,8 +376,71 @@ jobs:
           '    mainWindow = null;\\n' +
           '  });\\n' +
           '}\\n\\n' +
+          'const PROXY_CONFIG_PATH = path.join(app.getPath(\\'userData\\'), \\'proxy-config.json\\');\\n\\n' +
+          'function loadProxyConfig() {\\n' +
+          '  try {\\n' +
+          '    if (fs.existsSync(PROXY_CONFIG_PATH)) {\\n' +
+          '      return JSON.parse(fs.readFileSync(PROXY_CONFIG_PATH, \\'utf-8\\'));\\n' +
+          '    }\\n' +
+          '  } catch (e) { console.error(\\'Failed to load proxy config:\\', e); }\\n' +
+          '  return { enabled: false, type: \\'http\\', host: \\'\\', port: 7890 };\\n' +
+          '}\\n\\n' +
+          'function saveProxyConfig(config) {\\n' +
+          '  fs.writeFileSync(PROXY_CONFIG_PATH, JSON.stringify(config, null, 2));\\n' +
+          '}\\n\\n' +
+          'async function applyProxy(config) {\\n' +
+          '  if (!mainWindow || mainWindow.isDestroyed()) return;\\n' +
+          '  if (config.enabled && config.host && config.port) {\\n' +
+          '    const proxyUrl = config.type === \\'socks5\\'\\n' +
+          '      ? \\'socks5://\\' + config.host + \\':\\' + config.port\\n' +
+          '      : \\'http://\\' + config.host + \\':\\' + config.port;\\n' +
+          '    await mainWindow.webContents.session.setProxy({\\n' +
+          '      proxyRules: proxyUrl,\\n' +
+          '      proxyBypassRules: \\'<local>;localhost;127.0.0.1\\'\\n' +
+          '    });\\n' +
+          '    console.log(\\'[Proxy] Applied:\\', proxyUrl);\\n' +
+          '  } else {\\n' +
+          '    await mainWindow.webContents.session.setProxy({ proxyRules: \\'direct:\\\\' });\\n' +
+          '    console.log(\\'[Proxy] Disabled, using direct connection\\');\\n' +
+          '  }\\n' +
+          '}\\n\\n' +
+          'ipcMain.handle(\\'set-proxy\\', async (event, config) => {\\n' +
+          '  saveProxyConfig(config);\\n' +
+          '  await applyProxy(config);\\n' +
+          '  return { success: true };\\n' +
+          '});\\n\\n' +
+          'ipcMain.handle(\\'get-proxy\\', () => {\\n' +
+          '  return loadProxyConfig();\\n' +
+          '});\\n\\n' +
+          'ipcMain.handle(\\'test-proxy\\', async (event, config) => {\\n' +
+          '  try {\\n' +
+          '    const net = require(\\'net\\');\\n' +
+          '    return new Promise((resolve) => {\\n' +
+          '      const socket = new net.Socket();\\n' +
+          '      socket.setTimeout(5000);\\n' +
+          '      socket.on(\\'connect\\', () => {\\n' +
+          '        socket.destroy();\\n' +
+          '        resolve({ success: true });\\n' +
+          '      });\\n' +
+          '      socket.on(\\'timeout\\', () => {\\n' +
+          '        socket.destroy();\\n' +
+          '        resolve({ success: false, error: \\'Connection timeout\\' });\\n' +
+          '      });\\n' +
+          '      socket.on(\\'error\\', (err) => {\\n' +
+          '        resolve({ success: false, error: err.message });\\n' +
+          '      });\\n' +
+          '      socket.connect(config.port, config.host);\\n' +
+          '    });\\n' +
+          '  } catch (e) {\\n' +
+          '    return { success: false, error: e.message };\\n' +
+          '  }\\n' +
+          '});\\n\\n' +
           'app.whenReady().then(() => {\\n' +
           '  createWindow();\\n' +
+          '  const savedProxy = loadProxyConfig();\\n' +
+          '  if (savedProxy.enabled && savedProxy.host && savedProxy.port) {\\n' +
+          '    applyProxy(savedProxy);\\n' +
+          '  }\\n' +
           '  globalShortcut.register(\\'CommandOrControl+Shift+I\\', () => {\\n' +
           '    const focused = BrowserWindow.getFocusedWindow();\\n' +
           '    if (focused && !focused.isDestroyed()) {\\n' +
@@ -399,7 +463,17 @@ jobs:
           '});';
         
         fs.writeFileSync('electron/main.js', mainJsContent);
-        
+
+        const preloadJsContent = `const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('electronAPI', {
+  setProxy: (config) => ipcRenderer.invoke('set-proxy', config),
+  getProxy: () => ipcRenderer.invoke('get-proxy'),
+  testProxy: (config) => ipcRenderer.invoke('test-proxy', config),
+});
+`;
+        fs.writeFileSync('electron/preload.js', preloadJsContent);
+
         const electronPackageJson = {
           name: 'github-stars-manager-desktop',
           version: '1.0.0',

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -187,7 +187,7 @@ jobs:
           fs.mkdirSync('electron', { recursive: true });
         }
         
-        const mainJsContent = 'const { app, BrowserWindow, Menu, shell, globalShortcut } = require(\\'electron\\');\\n' +
+        const mainJsContent = 'const { app, BrowserWindow, Menu, shell, globalShortcut, ipcMain } = require(\\'electron\\');\\n' +
           'const path = require(\\'path\\');\\n' +
           'const fs = require(\\'fs\\');\\n' +
           'const isDev = process.env.NODE_ENV === \\'development\\';\\n\\n' +
@@ -204,7 +204,8 @@ jobs:
           '      enableRemoteModule: false,\\n' +
           '      webSecurity: false,\\n' +
           '      allowRunningInsecureContent: true,\\n' +
-          '      devTools: true // 生产环境也允许 DevTools 便于排障\\n' +
+          '      devTools: true, // 生产环境也允许 DevTools 便于排障\\n' +
+          '      preload: path.join(__dirname, \\'preload.js\\')\\n' +
           '    },\\n' +
           '    icon: path.join(__dirname, \\'../build/icon.png\\'),\\n' +
           '    titleBarStyle: \\'default\\', // 使用默认标题栏，避免重叠问题\\n' +
@@ -375,8 +376,71 @@ jobs:
           '    mainWindow = null;\\n' +
           '  });\\n' +
           '}\\n\\n' +
+          'const PROXY_CONFIG_PATH = path.join(app.getPath(\\'userData\\'), \\'proxy-config.json\\');\\n\\n' +
+          'function loadProxyConfig() {\\n' +
+          '  try {\\n' +
+          '    if (fs.existsSync(PROXY_CONFIG_PATH)) {\\n' +
+          '      return JSON.parse(fs.readFileSync(PROXY_CONFIG_PATH, \\'utf-8\\'));\\n' +
+          '    }\\n' +
+          '  } catch (e) { console.error(\\'Failed to load proxy config:\\', e); }\\n' +
+          '  return { enabled: false, type: \\'http\\', host: \\'\\', port: 7890 };\\n' +
+          '}\\n\\n' +
+          'function saveProxyConfig(config) {\\n' +
+          '  fs.writeFileSync(PROXY_CONFIG_PATH, JSON.stringify(config, null, 2));\\n' +
+          '}\\n\\n' +
+          'async function applyProxy(config) {\\n' +
+          '  if (!mainWindow || mainWindow.isDestroyed()) return;\\n' +
+          '  if (config.enabled && config.host && config.port) {\\n' +
+          '    const proxyUrl = config.type === \\'socks5\\'\\n' +
+          '      ? \\'socks5://\\' + config.host + \\':\\' + config.port\\n' +
+          '      : \\'http://\\' + config.host + \\':\\' + config.port;\\n' +
+          '    await mainWindow.webContents.session.setProxy({\\n' +
+          '      proxyRules: proxyUrl,\\n' +
+          '      proxyBypassRules: \\'<local>;localhost;127.0.0.1\\'\\n' +
+          '    });\\n' +
+          '    console.log(\\'[Proxy] Applied:\\', proxyUrl);\\n' +
+          '  } else {\\n' +
+          '    await mainWindow.webContents.session.setProxy({ proxyRules: \\'direct:\\\\' });\\n' +
+          '    console.log(\\'[Proxy] Disabled, using direct connection\\');\\n' +
+          '  }\\n' +
+          '}\\n\\n' +
+          'ipcMain.handle(\\'set-proxy\\', async (event, config) => {\\n' +
+          '  saveProxyConfig(config);\\n' +
+          '  await applyProxy(config);\\n' +
+          '  return { success: true };\\n' +
+          '});\\n\\n' +
+          'ipcMain.handle(\\'get-proxy\\', () => {\\n' +
+          '  return loadProxyConfig();\\n' +
+          '});\\n\\n' +
+          'ipcMain.handle(\\'test-proxy\\', async (event, config) => {\\n' +
+          '  try {\\n' +
+          '    const net = require(\\'net\\');\\n' +
+          '    return new Promise((resolve) => {\\n' +
+          '      const socket = new net.Socket();\\n' +
+          '      socket.setTimeout(5000);\\n' +
+          '      socket.on(\\'connect\\', () => {\\n' +
+          '        socket.destroy();\\n' +
+          '        resolve({ success: true });\\n' +
+          '      });\\n' +
+          '      socket.on(\\'timeout\\', () => {\\n' +
+          '        socket.destroy();\\n' +
+          '        resolve({ success: false, error: \\'Connection timeout\\' });\\n' +
+          '      });\\n' +
+          '      socket.on(\\'error\\', (err) => {\\n' +
+          '        resolve({ success: false, error: err.message });\\n' +
+          '      });\\n' +
+          '      socket.connect(config.port, config.host);\\n' +
+          '    });\\n' +
+          '  } catch (e) {\\n' +
+          '    return { success: false, error: e.message };\\n' +
+          '  }\\n' +
+          '});\\n\\n' +
           'app.whenReady().then(() => {\\n' +
           '  createWindow();\\n' +
+          '  const savedProxy = loadProxyConfig();\\n' +
+          '  if (savedProxy.enabled && savedProxy.host && savedProxy.port) {\\n' +
+          '    applyProxy(savedProxy);\\n' +
+          '  }\\n' +
           '  globalShortcut.register(\\'CommandOrControl+Shift+I\\', () => {\\n' +
           '    const focused = BrowserWindow.getFocusedWindow();\\n' +
           '    if (focused && !focused.isDestroyed()) {\\n' +
@@ -399,7 +463,16 @@ jobs:
           '});';
         
         fs.writeFileSync('electron/main.js', mainJsContent);
-        
+
+        const preloadJsContent = 'const { contextBridge, ipcRenderer } = require(\\'electron\\');\\n' +
+          '\\n' +
+          'contextBridge.exposeInMainWorld(\\'electronAPI\\', {\\n' +
+          '  setProxy: (config) => ipcRenderer.invoke(\\'set-proxy\\', config),\\n' +
+          '  getProxy: () => ipcRenderer.invoke(\\'get-proxy\\'),\\n' +
+          '  testProxy: (config) => ipcRenderer.invoke(\\'test-proxy\\', config),\\n' +
+          '});\\n';
+        fs.writeFileSync('electron/preload.js', preloadJsContent);
+
         const electronPackageJson = {
           name: 'github-stars-manager-desktop',
           version: '1.0.0',

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -187,7 +187,7 @@ jobs:
           fs.mkdirSync('electron', { recursive: true });
         }
         
-        const mainJsContent = 'const { app, BrowserWindow, Menu, shell, globalShortcut, ipcMain } = require(\\'electron\\');\\n' +
+        const mainJsContent = 'const { app, BrowserWindow, Menu, shell, globalShortcut } = require(\\'electron\\');\\n' +
           'const path = require(\\'path\\');\\n' +
           'const fs = require(\\'fs\\');\\n' +
           'const isDev = process.env.NODE_ENV === \\'development\\';\\n\\n' +
@@ -204,8 +204,7 @@ jobs:
           '      enableRemoteModule: false,\\n' +
           '      webSecurity: false,\\n' +
           '      allowRunningInsecureContent: true,\\n' +
-          '      devTools: true, // 生产环境也允许 DevTools 便于排障\\n' +
-          '      preload: path.join(__dirname, \\'preload.js\\')\\n' +
+          '      devTools: true // 生产环境也允许 DevTools 便于排障\\n' +
           '    },\\n' +
           '    icon: path.join(__dirname, \\'../build/icon.png\\'),\\n' +
           '    titleBarStyle: \\'default\\', // 使用默认标题栏，避免重叠问题\\n' +
@@ -376,71 +375,8 @@ jobs:
           '    mainWindow = null;\\n' +
           '  });\\n' +
           '}\\n\\n' +
-          'const PROXY_CONFIG_PATH = path.join(app.getPath(\\'userData\\'), \\'proxy-config.json\\');\\n\\n' +
-          'function loadProxyConfig() {\\n' +
-          '  try {\\n' +
-          '    if (fs.existsSync(PROXY_CONFIG_PATH)) {\\n' +
-          '      return JSON.parse(fs.readFileSync(PROXY_CONFIG_PATH, \\'utf-8\\'));\\n' +
-          '    }\\n' +
-          '  } catch (e) { console.error(\\'Failed to load proxy config:\\', e); }\\n' +
-          '  return { enabled: false, type: \\'http\\', host: \\'\\', port: 7890 };\\n' +
-          '}\\n\\n' +
-          'function saveProxyConfig(config) {\\n' +
-          '  fs.writeFileSync(PROXY_CONFIG_PATH, JSON.stringify(config, null, 2));\\n' +
-          '}\\n\\n' +
-          'async function applyProxy(config) {\\n' +
-          '  if (!mainWindow || mainWindow.isDestroyed()) return;\\n' +
-          '  if (config.enabled && config.host && config.port) {\\n' +
-          '    const proxyUrl = config.type === \\'socks5\\'\\n' +
-          '      ? \\'socks5://\\' + config.host + \\':\\' + config.port\\n' +
-          '      : \\'http://\\' + config.host + \\':\\' + config.port;\\n' +
-          '    await mainWindow.webContents.session.setProxy({\\n' +
-          '      proxyRules: proxyUrl,\\n' +
-          '      proxyBypassRules: \\'<local>;localhost;127.0.0.1\\'\\n' +
-          '    });\\n' +
-          '    console.log(\\'[Proxy] Applied:\\', proxyUrl);\\n' +
-          '  } else {\\n' +
-          '    await mainWindow.webContents.session.setProxy({ proxyRules: \\'direct:\\\\' });\\n' +
-          '    console.log(\\'[Proxy] Disabled, using direct connection\\');\\n' +
-          '  }\\n' +
-          '}\\n\\n' +
-          'ipcMain.handle(\\'set-proxy\\', async (event, config) => {\\n' +
-          '  saveProxyConfig(config);\\n' +
-          '  await applyProxy(config);\\n' +
-          '  return { success: true };\\n' +
-          '});\\n\\n' +
-          'ipcMain.handle(\\'get-proxy\\', () => {\\n' +
-          '  return loadProxyConfig();\\n' +
-          '});\\n\\n' +
-          'ipcMain.handle(\\'test-proxy\\', async (event, config) => {\\n' +
-          '  try {\\n' +
-          '    const net = require(\\'net\\');\\n' +
-          '    return new Promise((resolve) => {\\n' +
-          '      const socket = new net.Socket();\\n' +
-          '      socket.setTimeout(5000);\\n' +
-          '      socket.on(\\'connect\\', () => {\\n' +
-          '        socket.destroy();\\n' +
-          '        resolve({ success: true });\\n' +
-          '      });\\n' +
-          '      socket.on(\\'timeout\\', () => {\\n' +
-          '        socket.destroy();\\n' +
-          '        resolve({ success: false, error: \\'Connection timeout\\' });\\n' +
-          '      });\\n' +
-          '      socket.on(\\'error\\', (err) => {\\n' +
-          '        resolve({ success: false, error: err.message });\\n' +
-          '      });\\n' +
-          '      socket.connect(config.port, config.host);\\n' +
-          '    });\\n' +
-          '  } catch (e) {\\n' +
-          '    return { success: false, error: e.message };\\n' +
-          '  }\\n' +
-          '});\\n\\n' +
           'app.whenReady().then(() => {\\n' +
           '  createWindow();\\n' +
-          '  const savedProxy = loadProxyConfig();\\n' +
-          '  if (savedProxy.enabled && savedProxy.host && savedProxy.port) {\\n' +
-          '    applyProxy(savedProxy);\\n' +
-          '  }\\n' +
           '  globalShortcut.register(\\'CommandOrControl+Shift+I\\', () => {\\n' +
           '    const focused = BrowserWindow.getFocusedWindow();\\n' +
           '    if (focused && !focused.isDestroyed()) {\\n' +
@@ -463,16 +399,7 @@ jobs:
           '});';
         
         fs.writeFileSync('electron/main.js', mainJsContent);
-
-        const preloadJsContent = 'const { contextBridge, ipcRenderer } = require(\\'electron\\');\\n' +
-          '\\n' +
-          'contextBridge.exposeInMainWorld(\\'electronAPI\\', {\\n' +
-          '  setProxy: (config) => ipcRenderer.invoke(\\'set-proxy\\', config),\\n' +
-          '  getProxy: () => ipcRenderer.invoke(\\'get-proxy\\'),\\n' +
-          '  testProxy: (config) => ipcRenderer.invoke(\\'test-proxy\\', config),\\n' +
-          '});\\n';
-        fs.writeFileSync('electron/preload.js', preloadJsContent);
-
+        
         const electronPackageJson = {
           name: 'github-stars-manager-desktop',
           version: '1.0.0',

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -391,9 +391,15 @@ jobs:
           'async function applyProxy(config) {\\n' +
           '  if (!mainWindow || mainWindow.isDestroyed()) return;\\n' +
           '  if (config.enabled && config.host && config.port) {\\n' +
+          '    let auth = \\'\\';\\n' +
+          '    if (config.username) {\\n' +
+          '      auth = config.password\\n' +
+          '        ? encodeURIComponent(config.username) + \\':\\' + encodeURIComponent(config.password) + \\'@\\'\\n' +
+          '        : encodeURIComponent(config.username) + \\'@\\';\\n' +
+          '    }\\n' +
           '    const proxyUrl = config.type === \\'socks5\\'\\n' +
-          '      ? \\'socks5://\\' + config.host + \\':\\' + config.port\\n' +
-          '      : \\'http://\\' + config.host + \\':\\' + config.port;\\n' +
+          '      ? \\'socks5://\\' + auth + config.host + \\':\\' + config.port\\n' +
+          '      : \\'http://\\' + auth + config.host + \\':\\' + config.port;\\n' +
           '    await mainWindow.webContents.session.setProxy({\\n' +
           '      proxyRules: proxyUrl,\\n' +
           '      proxyBypassRules: \\'<local>;localhost;127.0.0.1\\'\\n' +

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -400,7 +400,7 @@ jobs:
           '    });\\n' +
           '    console.log(\\'[Proxy] Applied:\\', proxyUrl);\\n' +
           '  } else {\\n' +
-          '    await mainWindow.webContents.session.setProxy({ proxyRules: \\'direct:\\\\' });\\n' +
+          '    await mainWindow.webContents.session.setProxy({ proxyRules: \\'direct://\\' });\\n' +
           '    console.log(\\'[Proxy] Disabled, using direct connection\\');\\n' +
           '  }\\n' +
           '}\\n\\n' +

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -464,14 +464,13 @@ jobs:
         
         fs.writeFileSync('electron/main.js', mainJsContent);
 
-        const preloadJsContent = `const { contextBridge, ipcRenderer } = require('electron');
-
-contextBridge.exposeInMainWorld('electronAPI', {
-  setProxy: (config) => ipcRenderer.invoke('set-proxy', config),
-  getProxy: () => ipcRenderer.invoke('get-proxy'),
-  testProxy: (config) => ipcRenderer.invoke('test-proxy', config),
-});
-`;
+        const preloadJsContent = 'const { contextBridge, ipcRenderer } = require(\\'electron\\');\\n' +
+          '\\n' +
+          'contextBridge.exposeInMainWorld(\\'electronAPI\\', {\\n' +
+          '  setProxy: (config) => ipcRenderer.invoke(\\'set-proxy\\', config),\\n' +
+          '  getProxy: () => ipcRenderer.invoke(\\'get-proxy\\'),\\n' +
+          '  testProxy: (config) => ipcRenderer.invoke(\\'test-proxy\\', config),\\n' +
+          '});\\n';
         fs.writeFileSync('electron/preload.js', preloadJsContent);
 
         const electronPackageJson = {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,6 +8,7 @@
       "name": "github-stars-manager-server",
       "version": "0.1.0",
       "dependencies": {
+        "axios": "^1.7.0",
         "better-sqlite3": "^11.0.0",
         "cors": "^2.8.5",
         "express": "^4.21.0",
@@ -1174,6 +1175,41 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agent-base/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -1214,8 +1250,19 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1424,7 +1471,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -1575,7 +1621,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -1702,7 +1747,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -1891,11 +1935,30 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -2079,7 +2142,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -2131,6 +2193,42 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/human-signals": {
       "version": "5.0.0",
@@ -2737,6 +2835,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/pump": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -13,7 +13,8 @@
         "cors": "^2.8.5",
         "express": "^4.21.0",
         "helmet": "^7.1.0",
-        "morgan": "^1.10.0"
+        "morgan": "^1.10.0",
+        "socks-proxy-agent": "^9.0.0"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.8",
@@ -2284,6 +2285,15 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -3234,6 +3244,76 @@
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-9.0.0.tgz",
+      "integrity": "sha512-fFlbMlfsXhK02ZB8aZY7Hwxh/IHBV9b1Oq9bvBk6tkFWXvdAxUgA0wbw/NYR5liU3Y5+KI6U4FH3kYJt9QYv0w==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "8.0.0",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-8.0.0.tgz",
+      "integrity": "sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,8 @@
     "better-sqlite3": "^11.0.0",
     "cors": "^2.8.5",
     "helmet": "^7.1.0",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "axios": "^1.7.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,8 @@
     "cors": "^2.8.5",
     "helmet": "^7.1.0",
     "morgan": "^1.10.0",
-    "axios": "^1.7.0"
+    "axios": "^1.7.0",
+    "socks-proxy-agent": "^9.0.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -424,30 +424,124 @@ router.put('/api/settings/proxy', (req, res) => {
 // POST /api/settings/proxy/test
 router.post('/api/settings/proxy/test', async (req, res) => {
   try {
-    const { host, port, type } = req.body;
+    const { host, port, type, username, password } = req.body;
     if (!host || !port) {
       res.json({ success: false, error: 'Host and port are required' });
       return;
     }
 
-    // Test TCP connectivity to the proxy server
     const net = await import('net');
-    const result = await new Promise<{ success: boolean; error?: string }>((resolve) => {
-      const socket = new net.Socket();
-      socket.setTimeout(5000);
-      socket.on('connect', () => {
-        socket.destroy();
-        resolve({ success: true });
+    type NetSocket = import('net').Socket;
+
+    const connectToProxy = (): Promise<NetSocket> =>
+      new Promise((resolve, reject) => {
+        const socket = new net.Socket();
+        socket.setTimeout(5000);
+        socket.on('connect', () => resolve(socket));
+        socket.on('timeout', () => { socket.destroy(); reject(new Error('Connection timeout')); });
+        socket.on('error', (err: Error) => reject(err));
+        socket.connect(port, host);
       });
-      socket.on('timeout', () => {
-        socket.destroy();
-        resolve({ success: false, error: 'Connection timeout' });
-      });
-      socket.on('error', (err: Error) => {
-        resolve({ success: false, error: err.message });
-      });
-      socket.connect(port, host);
-    });
+
+    let result: { success: boolean; error?: string };
+
+    if (type === 'socks5') {
+      // SOCKS5 protocol handshake test
+      try {
+        const socket = await connectToProxy();
+        result = await new Promise((resolve) => {
+          // Step 1: Send SOCKS5 greeting (version 5, 1 method, no-auth)
+          const greeting = username
+            ? Buffer.from([0x05, 0x02, 0x00, 0x02]) // no-auth + username/password
+            : Buffer.from([0x05, 0x01, 0x00]);        // no-auth only
+
+          socket.setTimeout(5000);
+          socket.write(greeting);
+
+          let step = 0;
+          socket.on('data', (data: Buffer) => {
+            if (step === 0) {
+              // Step 2: Server selects auth method
+              if (data[0] !== 0x05) {
+                socket.destroy();
+                resolve({ success: false, error: `Invalid SOCKS5 version: ${data[0]}` });
+                return;
+              }
+              if (data[1] === 0xFF) {
+                socket.destroy();
+                resolve({ success: false, error: 'SOCKS5 server: no acceptable auth method' });
+                return;
+              }
+              if (data[1] === 0x02 && username && password) {
+                // Username/password auth
+                step = 1;
+                const userBuf = Buffer.from(username, 'utf8');
+                const passBuf = Buffer.from(password, 'utf8');
+                const authReq = Buffer.alloc(3 + userBuf.length + passBuf.length);
+                authReq[0] = 0x01; // auth version
+                authReq[1] = userBuf.length;
+                userBuf.copy(authReq, 2);
+                authReq[2 + userBuf.length] = passBuf.length;
+                passBuf.copy(authReq, 3 + userBuf.length);
+                socket.write(authReq);
+              } else {
+                // No-auth accepted, test passed
+                socket.destroy();
+                resolve({ success: true });
+              }
+            } else if (step === 1) {
+              // Step 3: Auth response
+              socket.destroy();
+              if (data[0] === 0x01 && data[1] === 0x00) {
+                resolve({ success: true });
+              } else {
+                resolve({ success: false, error: 'SOCKS5 authentication failed' });
+              }
+            }
+          });
+
+          socket.on('timeout', () => { socket.destroy(); resolve({ success: false, error: 'SOCKS5 handshake timeout' }); });
+          socket.on('error', (err: Error) => { resolve({ success: false, error: err.message }); });
+        });
+      } catch (err) {
+        result = { success: false, error: err instanceof Error ? err.message : 'Connection failed' };
+      }
+    } else {
+      // HTTP proxy: send CONNECT request to verify it's a working proxy
+      try {
+        const socket = await connectToProxy();
+        result = await new Promise((resolve) => {
+          socket.setTimeout(5000);
+          const authHeader = username && password
+            ? `Proxy-Authorization: Basic ${Buffer.from(`${username}:${password}`).toString('base64')}\r\n`
+            : '';
+          const connectReq = `CONNECT httpbin.org:443 HTTP/1.1\r\nHost: httpbin.org:443\r\n${authHeader}\r\n`;
+          socket.write(connectReq);
+
+          let responseData = '';
+          socket.on('data', (data: Buffer) => {
+            responseData += data.toString();
+            // Wait for end of HTTP headers
+            if (responseData.includes('\r\n\r\n')) {
+              socket.destroy();
+              if (responseData.includes('200')) {
+                resolve({ success: true });
+              } else if (responseData.includes('407')) {
+                resolve({ success: false, error: 'Proxy authentication required' });
+              } else {
+                const statusLine = responseData.split('\r\n')[0] || 'Unknown';
+                resolve({ success: false, error: `Proxy rejected CONNECT: ${statusLine}` });
+              }
+            }
+          });
+
+          socket.on('timeout', () => { socket.destroy(); resolve({ success: false, error: 'HTTP proxy handshake timeout' }); });
+          socket.on('error', (err: Error) => { resolve({ success: false, error: err.message }); });
+        });
+      } catch (err) {
+        result = { success: false, error: err instanceof Error ? err.message : 'Connection failed' };
+      }
+    }
 
     res.json(result);
   } catch (err) {

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -384,9 +384,23 @@ router.put('/api/settings/proxy', (req, res) => {
     const db = getDb();
     const { enabled, type, host, port, username, password } = req.body;
 
+    // Preserve existing password if not provided in the request
+    let storedPassword: string | undefined;
+    if (!password) {
+      const existing = db.prepare('SELECT value FROM settings WHERE key = ?').get('proxy_config') as { value: string } | undefined;
+      if (existing?.value) {
+        try {
+          const parsed = JSON.parse(existing.value);
+          storedPassword = parsed.password;
+        } catch { /* ignore */ }
+      }
+    }
+
     const configToStore: Record<string, unknown> = { enabled, type, host, port, username };
     if (password) {
       configToStore.password = password;
+    } else if (storedPassword) {
+      configToStore.password = storedPassword;
     }
 
     db.prepare('INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)')

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -11,11 +11,9 @@ function getProxyConfig(): ProxyConfig | null {
     if (!row?.value) return null;
     const parsed = JSON.parse(row.value);
     if (parsed && parsed.enabled && parsed.host && parsed.port) {
-      // Decrypt password if encrypted
+      // Decrypt password if encrypted - fail closed on decrypt error
       if (parsed.password_encrypted) {
-        try {
-          parsed.password = decrypt(parsed.password_encrypted, config.encryptionKey);
-        } catch { parsed.password = ''; }
+        parsed.password = decrypt(parsed.password_encrypted, config.encryptionKey);
         delete parsed.password_encrypted;
       }
       return parsed as ProxyConfig;
@@ -391,22 +389,26 @@ router.put('/api/settings/proxy', (req, res) => {
   try {
     const db = getDb();
     const { enabled, type, host, port, username, password } = req.body;
-
-    // Preserve existing encrypted password if not provided in the request
-    let existingEncrypted: string | undefined;
-    const existing = db.prepare('SELECT value FROM settings WHERE key = ?').get('proxy_config') as { value: string } | undefined;
-    if (existing?.value) {
-      try {
-        const parsed = JSON.parse(existing.value);
-        existingEncrypted = parsed.password_encrypted;
-      } catch { /* ignore */ }
-    }
+    const passwordProvided = 'password' in req.body;
 
     const configToStore: Record<string, unknown> = { enabled, type, host, port, username };
-    if (password) {
+    if (passwordProvided && password) {
+      // New password provided - encrypt and store
       configToStore.password_encrypted = encrypt(password, config.encryptionKey);
-    } else if (existingEncrypted) {
-      configToStore.password_encrypted = existingEncrypted;
+    } else if (passwordProvided && !password) {
+      // Explicitly empty password - clear stored secret
+      // No password_encrypted field = no password
+    } else {
+      // Password field omitted - preserve existing encrypted password
+      const existing = db.prepare('SELECT value FROM settings WHERE key = ?').get('proxy_config') as { value: string } | undefined;
+      if (existing?.value) {
+        try {
+          const parsed = JSON.parse(existing.value);
+          if (parsed.password_encrypted) {
+            configToStore.password_encrypted = parsed.password_encrypted;
+          }
+        } catch { /* ignore */ }
+      }
     }
 
     db.prepare('INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)')

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -2,7 +2,22 @@ import { Router } from 'express';
 import { getDb } from '../db/connection.js';
 import { decrypt } from '../services/crypto.js';
 import { config } from '../config.js';
-import { proxyRequest } from '../services/proxyService.js';
+import { proxyRequest, ProxyConfig } from '../services/proxyService.js';
+
+function getProxyConfig(): ProxyConfig | null {
+  try {
+    const db = getDb();
+    const row = db.prepare('SELECT value FROM settings WHERE key = ?').get('proxy_config') as { value: string } | undefined;
+    if (!row?.value) return null;
+    const parsed = JSON.parse(row.value);
+    if (parsed && parsed.enabled && parsed.host && parsed.port) {
+      return parsed as ProxyConfig;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 const router = Router();
 
@@ -77,7 +92,8 @@ router.post('/api/proxy/github/*', async (req, res) => {
       'User-Agent': 'GithubStarsManager-Backend',
     };
 
-    const result = await proxyRequest({ url: targetUrl, method, headers });
+    const proxyConfig = getProxyConfig();
+    const result = await proxyRequest({ url: targetUrl, method, headers, proxyConfig });
     res.status(result.status).json(result.data);
   } catch (err) {
     console.error('GitHub proxy error:', err);
@@ -187,12 +203,14 @@ router.post('/api/proxy/ai', async (req, res) => {
 
     const timeout = apiType === 'openai-responses' || !!reasoningEffort ? 600000 : 60000;
 
+    const proxyConfig = getProxyConfig();
     const result = await proxyRequest({
       url: targetUrl,
       method: 'POST',
       headers,
       body: effectiveRequestBody,
       timeout,
+      proxyConfig,
     });
 
     res.status(result.status).json(result.data);
@@ -242,12 +260,14 @@ router.post('/api/proxy/webdav', async (req, res) => {
       headers['Content-Type'] = headers['Content-Type'] || 'application/xml';
     }
 
+    const proxyConfig = getProxyConfig();
     const result = await proxyRequest({
       url: targetUrl,
       method,
       headers,
       body: requestBody,
       timeout: 60000,
+      proxyConfig,
     });
 
     res.status(result.status).json(result.data);
@@ -288,7 +308,8 @@ router.post('/api/proxy/github/search/repositories', async (req, res) => {
       'User-Agent': 'GithubStarsManager-Backend',
     };
 
-    const result = await proxyRequest({ url: targetUrl, method: 'GET', headers });
+    const proxyConfig = getProxyConfig();
+    const result = await proxyRequest({ url: targetUrl, method: 'GET', headers, proxyConfig });
     res.status(result.status).json(result.data);
   } catch (err) {
     console.error('GitHub search repositories proxy error:', err);
@@ -327,11 +348,88 @@ router.post('/api/proxy/github/search/users', async (req, res) => {
       'User-Agent': 'GithubStarsManager-Backend',
     };
 
-    const result = await proxyRequest({ url: targetUrl, method: 'GET', headers });
+    const proxyConfig = getProxyConfig();
+    const result = await proxyRequest({ url: targetUrl, method: 'GET', headers, proxyConfig });
     res.status(result.status).json(result.data);
   } catch (err) {
     console.error('GitHub search users proxy error:', err);
     res.status(500).json({ error: 'GitHub search proxy failed', code: 'GITHUB_SEARCH_PROXY_FAILED' });
+  }
+});
+
+// GET /api/settings/proxy
+router.get('/api/settings/proxy', (_req, res) => {
+  try {
+    const db = getDb();
+    const row = db.prepare('SELECT value FROM settings WHERE key = ?').get('proxy_config') as { value: string } | undefined;
+    if (!row?.value) {
+      res.json({ enabled: false, type: 'http', host: '', port: 7890 });
+      return;
+    }
+    const parsed = JSON.parse(row.value);
+    // Mask password
+    if (parsed.password) {
+      parsed.hasPassword = true;
+      parsed.password = '';
+    }
+    res.json(parsed);
+  } catch {
+    res.json({ enabled: false, type: 'http', host: '', port: 7890 });
+  }
+});
+
+// PUT /api/settings/proxy
+router.put('/api/settings/proxy', (req, res) => {
+  try {
+    const db = getDb();
+    const { enabled, type, host, port, username, password } = req.body;
+
+    const configToStore: Record<string, unknown> = { enabled, type, host, port, username };
+    if (password) {
+      configToStore.password = password;
+    }
+
+    db.prepare('INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)')
+      .run('proxy_config', JSON.stringify(configToStore));
+
+    res.json({ success: true });
+  } catch (err) {
+    console.error('Failed to save proxy config:', err);
+    res.status(500).json({ error: 'Failed to save proxy config' });
+  }
+});
+
+// POST /api/settings/proxy/test
+router.post('/api/settings/proxy/test', async (req, res) => {
+  try {
+    const { host, port, type } = req.body;
+    if (!host || !port) {
+      res.json({ success: false, error: 'Host and port are required' });
+      return;
+    }
+
+    // Test TCP connectivity to the proxy server
+    const net = await import('net');
+    const result = await new Promise<{ success: boolean; error?: string }>((resolve) => {
+      const socket = new net.Socket();
+      socket.setTimeout(5000);
+      socket.on('connect', () => {
+        socket.destroy();
+        resolve({ success: true });
+      });
+      socket.on('timeout', () => {
+        socket.destroy();
+        resolve({ success: false, error: 'Connection timeout' });
+      });
+      socket.on('error', (err: Error) => {
+        resolve({ success: false, error: err.message });
+      });
+      socket.connect(port, host);
+    });
+
+    res.json(result);
+  } catch (err) {
+    res.json({ success: false, error: err instanceof Error ? err.message : 'Unknown error' });
   }
 });
 

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { getDb } from '../db/connection.js';
-import { decrypt } from '../services/crypto.js';
+import { encrypt, decrypt } from '../services/crypto.js';
 import { config } from '../config.js';
 import { proxyRequest, ProxyConfig } from '../services/proxyService.js';
 
@@ -11,6 +11,13 @@ function getProxyConfig(): ProxyConfig | null {
     if (!row?.value) return null;
     const parsed = JSON.parse(row.value);
     if (parsed && parsed.enabled && parsed.host && parsed.port) {
+      // Decrypt password if encrypted
+      if (parsed.password_encrypted) {
+        try {
+          parsed.password = decrypt(parsed.password_encrypted, config.encryptionKey);
+        } catch { parsed.password = ''; }
+        delete parsed.password_encrypted;
+      }
       return parsed as ProxyConfig;
     }
     return null;
@@ -367,11 +374,12 @@ router.get('/api/settings/proxy', (_req, res) => {
       return;
     }
     const parsed = JSON.parse(row.value);
-    // Mask password
-    if (parsed.password) {
+    // Mask password - don't expose encrypted value
+    if (parsed.password_encrypted) {
       parsed.hasPassword = true;
-      parsed.password = '';
     }
+    delete parsed.password_encrypted;
+    delete parsed.password;
     res.json(parsed);
   } catch {
     res.json({ enabled: false, type: 'http', host: '', port: 7890 });
@@ -384,23 +392,21 @@ router.put('/api/settings/proxy', (req, res) => {
     const db = getDb();
     const { enabled, type, host, port, username, password } = req.body;
 
-    // Preserve existing password if not provided in the request
-    let storedPassword: string | undefined;
-    if (!password) {
-      const existing = db.prepare('SELECT value FROM settings WHERE key = ?').get('proxy_config') as { value: string } | undefined;
-      if (existing?.value) {
-        try {
-          const parsed = JSON.parse(existing.value);
-          storedPassword = parsed.password;
-        } catch { /* ignore */ }
-      }
+    // Preserve existing encrypted password if not provided in the request
+    let existingEncrypted: string | undefined;
+    const existing = db.prepare('SELECT value FROM settings WHERE key = ?').get('proxy_config') as { value: string } | undefined;
+    if (existing?.value) {
+      try {
+        const parsed = JSON.parse(existing.value);
+        existingEncrypted = parsed.password_encrypted;
+      } catch { /* ignore */ }
     }
 
     const configToStore: Record<string, unknown> = { enabled, type, host, port, username };
     if (password) {
-      configToStore.password = password;
-    } else if (storedPassword) {
-      configToStore.password = storedPassword;
+      configToStore.password_encrypted = encrypt(password, config.encryptionKey);
+    } else if (existingEncrypted) {
+      configToStore.password_encrypted = existingEncrypted;
     }
 
     db.prepare('INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)')

--- a/server/src/services/proxyService.ts
+++ b/server/src/services/proxyService.ts
@@ -95,11 +95,31 @@ export async function proxyRequest(options: ProxyRequestOptions): Promise<ProxyR
 
     // 配置代理
     if (proxyConfig?.enabled && proxyConfig.host && proxyConfig.port) {
-      axiosConfig.proxy = {
-        protocol: proxyConfig.type === 'socks5' ? 'socks5' : 'http',
-        host: proxyConfig.host,
-        port: proxyConfig.port,
-      };
+      if (proxyConfig.type === 'socks5') {
+        // SOCKS5: axios 不原生支持，使用 socks-proxy-agent
+        const { SocksProxyAgent } = await import('socks-proxy-agent');
+        const socksUrl = `socks5://${proxyConfig.host}:${proxyConfig.port}`;
+        const agent = new SocksProxyAgent(socksUrl);
+        axiosConfig.httpAgent = agent;
+        axiosConfig.httpsAgent = agent;
+        axiosConfig.proxy = false; // 禁用 axios 内置代理，使用自定义 agent
+      } else {
+        // HTTP/HTTPS 代理
+        axiosConfig.proxy = {
+          protocol: 'http',
+          host: proxyConfig.host,
+          port: proxyConfig.port,
+        };
+        if (proxyConfig.username && proxyConfig.password) {
+          axiosConfig.proxy.auth = {
+            username: proxyConfig.username,
+            password: proxyConfig.password,
+          };
+        }
+      }
+    } else {
+      // 显式禁用代理，防止 axios 回退到环境变量 HTTP_PROXY/HTTPS_PROXY
+      axiosConfig.proxy = false;
     }
 
     const response = await axios(axiosConfig);

--- a/server/src/services/proxyService.ts
+++ b/server/src/services/proxyService.ts
@@ -1,9 +1,21 @@
+import axios, { AxiosRequestConfig } from 'axios';
+
+export interface ProxyConfig {
+  enabled: boolean;
+  type: 'http' | 'socks5';
+  host: string;
+  port: number;
+  username?: string;
+  password?: string;
+}
+
 export interface ProxyRequestOptions {
   url: string;
   method: string;
   headers?: Record<string, string>;
   body?: string | object;
   timeout?: number;
+  proxyConfig?: ProxyConfig | null;
 }
 
 export interface ProxyResponse {
@@ -57,60 +69,86 @@ function validateUrl(rawUrl: string): void {
 }
 
 export async function proxyRequest(options: ProxyRequestOptions): Promise<ProxyResponse> {
-  const { url, method, headers = {}, body, timeout = 30000 } = options;
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeout);
+  const { url, method, headers = {}, body, timeout = 30000, proxyConfig } = options;
 
   try {
     validateUrl(url);
     console.log(`[Proxy] ${method} ${redactUrl(url)}`);
 
-    const fetchOptions: RequestInit = {
-      method,
+    const axiosConfig: AxiosRequestConfig = {
+      url,
+      method: method.toLowerCase() as AxiosRequestConfig['method'],
       headers,
-      signal: controller.signal,
+      timeout,
+      validateStatus: () => true, // 不抛出 HTTP 错误状态码
     };
 
     if (body && method !== 'GET' && method !== 'HEAD') {
-      fetchOptions.body = typeof body === 'string' ? body : JSON.stringify(body);
+      axiosConfig.data = body;
       const hasContentType = Object.keys(headers).some(
         k => k.toLowerCase() === 'content-type'
       );
-      if (!hasContentType) {
-        (fetchOptions.headers as Record<string, string>)['Content-Type'] = 'application/json';
+      if (!hasContentType && typeof body === 'object') {
+        axiosConfig.headers = { ...axiosConfig.headers, 'Content-Type': 'application/json' };
       }
     }
 
-    const response = await fetch(url, fetchOptions);
+    // 配置代理
+    if (proxyConfig?.enabled && proxyConfig.host && proxyConfig.port) {
+      axiosConfig.proxy = {
+        protocol: proxyConfig.type === 'socks5' ? 'socks5' : 'http',
+        host: proxyConfig.host,
+        port: proxyConfig.port,
+      };
+    }
+
+    const response = await axios(axiosConfig);
 
     console.log(`[Proxy] ${method} ${redactUrl(url)} -> ${response.status}`);
 
     const responseHeaders: Record<string, string> = {};
-    response.headers.forEach((value, key) => {
-      responseHeaders[key] = value;
-    });
+    if (response.headers) {
+      for (const [key, value] of Object.entries(response.headers)) {
+        responseHeaders[key] = String(value);
+      }
+    }
 
     let data: unknown;
-    const contentType = response.headers.get('content-type') || '';
-    const text = await response.text();
-    if (contentType.includes('application/json') && text.length > 0) {
+    const contentType = String(response.headers['content-type'] || '');
+    if (contentType.includes('application/json') && typeof response.data === 'object') {
+      data = response.data;
+    } else if (typeof response.data === 'string') {
       try {
-        data = JSON.parse(text);
+        data = JSON.parse(response.data);
       } catch {
-        data = text;
+        data = response.data;
       }
     } else {
-      data = text;
+      data = response.data;
     }
 
     return { status: response.status, headers: responseHeaders, data };
   } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
-      return { status: 504, headers: {}, data: { error: 'Gateway Timeout', code: 'GATEWAY_TIMEOUT' } };
+    if (axios.isAxiosError(error)) {
+      if (error.code === 'ECONNABORTED' || error.message.includes('timeout')) {
+        return { status: 504, headers: {}, data: { error: 'Gateway Timeout', code: 'GATEWAY_TIMEOUT' } };
+      }
+      if (error.code === 'ECONNREFUSED') {
+        return { status: 502, headers: {}, data: { error: 'Proxy connection refused', code: 'PROXY_CONNECTION_REFUSED', details: error.message } };
+      }
+      if (error.code === 'ETIMEDOUT') {
+        return { status: 504, headers: {}, data: { error: 'Proxy connection timeout', code: 'PROXY_TIMEOUT', details: error.message } };
+      }
+      if (error.response) {
+        // 请求已发出，服务器返回了错误状态码
+        return {
+          status: error.response.status,
+          headers: {},
+          data: error.response.data || { error: 'Upstream error' }
+        };
+      }
     }
     console.error(`[Proxy] Error: ${error instanceof Error ? error.message : 'Unknown error'}`);
     return { status: 502, headers: {}, data: { error: 'Bad Gateway', code: 'BAD_GATEWAY', details: error instanceof Error ? error.message : 'Unknown error' } };
-  } finally {
-    clearTimeout(timeoutId);
   }
 }

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -9,8 +9,11 @@ import {
   Package,
   X,
   Trash2,
+  Wifi,
 } from 'lucide-react';
 import { useAppStore } from '../store/useAppStore';
+import { isElectron } from '../services/electronProxy';
+import { backend } from '../services/backendAdapter';
 import {
   GeneralPanel,
   AIConfigPanel,
@@ -19,9 +22,10 @@ import {
   BackendPanel,
   CategoryPanel,
   DataManagementPanel,
+  NetworkPanel,
 } from './settings';
 
-type SettingsTab = 'general' | 'ai' | 'webdav' | 'backup' | 'backend' | 'category' | 'data';
+type SettingsTab = 'general' | 'ai' | 'webdav' | 'backup' | 'backend' | 'category' | 'data' | 'network';
 
 interface SettingsTabItem {
   id: SettingsTab;
@@ -282,6 +286,11 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
       label: t('数据管理', 'Data Management'),
       icon: <Trash2 className="w-5 h-5" />,
     },
+    ...((isElectron() || backend.isAvailable) ? [{
+      id: 'network' as SettingsTab,
+      label: t('网络设置', 'Network'),
+      icon: <Wifi className="w-5 h-5" />,
+    }] : []),
   ];
 
   const renderTabContent = () => {
@@ -301,6 +310,8 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
           return <CategoryPanel t={t} />;
         case 'data':
           return <DataManagementPanel t={t} />;
+        case 'network':
+          return <NetworkPanel t={t} />;
         default:
           return null;
       }

--- a/src/components/settings/GeneralPanel.tsx
+++ b/src/components/settings/GeneralPanel.tsx
@@ -4,6 +4,7 @@ import { UpdateChecker } from '../UpdateChecker';
 import { useAppStore } from '../../store/useAppStore';
 import { version } from '../../../package.json';
 import { PROJECT_REPO_URL } from '../../constants/project';
+import { NetworkPanel } from './NetworkPanel';
 
 interface GeneralPanelProps {
   t: (zh: string, en: string) => string;
@@ -132,6 +133,8 @@ export const GeneralPanel: React.FC<GeneralPanelProps> = ({ t }) => {
           </button>
         </div>
       </div>
+
+      <NetworkPanel t={t} />
     </div>
   );
 };

--- a/src/components/settings/GeneralPanel.tsx
+++ b/src/components/settings/GeneralPanel.tsx
@@ -4,7 +4,6 @@ import { UpdateChecker } from '../UpdateChecker';
 import { useAppStore } from '../../store/useAppStore';
 import { version } from '../../../package.json';
 import { PROJECT_REPO_URL } from '../../constants/project';
-import { NetworkPanel } from './NetworkPanel';
 
 interface GeneralPanelProps {
   t: (zh: string, en: string) => string;
@@ -133,8 +132,6 @@ export const GeneralPanel: React.FC<GeneralPanelProps> = ({ t }) => {
           </button>
         </div>
       </div>
-
-      <NetworkPanel t={t} />
     </div>
   );
 };

--- a/src/components/settings/NetworkPanel.tsx
+++ b/src/components/settings/NetworkPanel.tsx
@@ -1,0 +1,289 @@
+import React, { useState, useEffect } from 'react';
+import { Wifi, Eye, EyeOff, Loader2, CheckCircle2, XCircle } from 'lucide-react';
+import { useAppStore } from '../../store/useAppStore';
+import { backend } from '../../services/backendAdapter';
+import { isElectron, electronProxy } from '../../services/electronProxy';
+import type { ProxyConfig, ProxyType } from '../../types';
+
+interface NetworkPanelProps {
+  t: (zh: string, en: string) => string;
+}
+
+export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
+  const { proxyConfig, setProxyConfig, backendApiSecret } = useAppStore();
+
+  const [form, setForm] = useState<ProxyConfig>(proxyConfig);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showAuth, setShowAuth] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<{ success: boolean; error?: string } | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  // Sync form when store changes externally
+  useEffect(() => {
+    setForm(proxyConfig);
+    if (proxyConfig.username || proxyConfig.password) {
+      setShowAuth(true);
+    }
+  }, [proxyConfig]);
+
+  const canUseProxy = isElectron() || backend.isAvailable;
+
+  if (!canUseProxy) {
+    return null;
+  }
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      // Save to store
+      setProxyConfig(form);
+
+      // If Electron, sync to Electron main process
+      if (isElectron()) {
+        await electronProxy.setProxy(form);
+      }
+
+      // If backend is available, sync to backend
+      if (backend.isAvailable) {
+        try {
+          const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
+          if (backendApiSecret) {
+            authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
+          }
+          await fetch('/api/settings/proxy', {
+            method: 'PUT',
+            headers: authHeaders,
+            body: JSON.stringify(form),
+          });
+        } catch {
+          // Backend sync is best-effort
+        }
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleTest = async () => {
+    setTesting(true);
+    setTestResult(null);
+    try {
+      if (isElectron()) {
+        const result = await electronProxy.testProxy(form);
+        setTestResult(result);
+      } else if (backend.isAvailable) {
+        try {
+          const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
+          if (backendApiSecret) {
+            authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
+          }
+          const resp = await fetch('/api/settings/proxy/test', {
+            method: 'POST',
+            headers: authHeaders,
+            body: JSON.stringify(form),
+          });
+          const data = await resp.json();
+          setTestResult(data);
+        } catch (e) {
+          setTestResult({ success: false, error: e instanceof Error ? e.message : 'Unknown error' });
+        }
+      }
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const hasChanges = JSON.stringify(form) !== JSON.stringify(proxyConfig);
+
+  return (
+    <div className="p-6 bg-white dark:bg-panel-dark rounded-xl border border-black/[0.06] dark:border-white/[0.04]">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center space-x-3">
+          <Wifi className="w-5 h-5 text-gray-700 dark:text-text-secondary" />
+          <h4 className="font-medium text-gray-900 dark:text-text-primary">
+            {t('网络代理', 'Network Proxy')}
+          </h4>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={form.enabled}
+          onClick={() => setForm({ ...form, enabled: !form.enabled })}
+          className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${form.enabled ? 'bg-brand-indigo' : 'bg-gray-300 dark:bg-gray-600'}`}
+        >
+          <span
+            className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${form.enabled ? 'translate-x-[18px]' : 'translate-x-[2px]'}`}
+          />
+        </button>
+      </div>
+
+      {form.enabled && (
+        <div className="space-y-4">
+          {/* Proxy Type */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-text-secondary mb-2">
+              {t('代理类型', 'Proxy Type')}
+            </label>
+            <div className="grid grid-cols-2 gap-3 max-w-md">
+              {(['http', 'socks5'] as ProxyType[]).map((type) => (
+                <label
+                  key={type}
+                  className={`flex items-center space-x-3 cursor-pointer p-3 rounded-lg border transition-colors ${
+                    form.type === type
+                      ? 'border-brand-indigo bg-brand-indigo/5 dark:bg-brand-indigo/10'
+                      : 'border-black/[0.06] dark:border-white/[0.04] hover:bg-light-bg dark:hover:bg-white/10'
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="proxyType"
+                    value={type}
+                    checked={form.type === type}
+                    onChange={() => setForm({ ...form, type })}
+                    className="w-4 h-4 text-brand-violet bg-light-surface border-black/[0.06] focus:ring-brand-violet dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-white/[0.04] dark:border-white/[0.04]"
+                  />
+                  <span className="text-sm font-medium text-gray-900 dark:text-text-primary uppercase">
+                    {type}
+                  </span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {/* Host and Port */}
+          <div className="grid grid-cols-3 gap-3">
+            <div className="col-span-2">
+              <label className="block text-sm font-medium text-gray-700 dark:text-text-secondary mb-1">
+                {t('主机地址', 'Host')}
+              </label>
+              <input
+                type="text"
+                value={form.host}
+                onChange={(e) => setForm({ ...form, host: e.target.value })}
+                placeholder="127.0.0.1"
+                className="w-full px-3 py-2 bg-light-surface dark:bg-white/[0.04] border border-black/[0.06] dark:border-white/[0.04] rounded-lg text-gray-900 dark:text-text-primary text-sm focus:ring-2 focus:ring-brand-violet focus:border-transparent outline-none"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-text-secondary mb-1">
+                {t('端口', 'Port')}
+              </label>
+              <input
+                type="number"
+                value={form.port || ''}
+                onChange={(e) => setForm({ ...form, port: parseInt(e.target.value) || 0 })}
+                placeholder="7890"
+                min={1}
+                max={65535}
+                className="w-full px-3 py-2 bg-light-surface dark:bg-white/[0.04] border border-black/[0.06] dark:border-white/[0.04] rounded-lg text-gray-900 dark:text-text-primary text-sm focus:ring-2 focus:ring-brand-violet focus:border-transparent outline-none"
+              />
+            </div>
+          </div>
+
+          {/* Authentication (collapsible) */}
+          <div>
+            <button
+              type="button"
+              onClick={() => setShowAuth(!showAuth)}
+              className="text-sm text-gray-500 dark:text-text-tertiary hover:text-gray-700 dark:hover:text-text-secondary transition-colors"
+            >
+              {showAuth ? t('隐藏认证', 'Hide Authentication') : t('需要认证（可选）', 'Authentication (optional)')}
+            </button>
+
+            {showAuth && (
+              <div className="mt-3 grid grid-cols-2 gap-3">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-text-secondary mb-1">
+                    {t('用户名', 'Username')}
+                  </label>
+                  <input
+                    type="text"
+                    value={form.username || ''}
+                    onChange={(e) => setForm({ ...form, username: e.target.value || undefined })}
+                    placeholder={t('可选', 'Optional')}
+                    className="w-full px-3 py-2 bg-light-surface dark:bg-white/[0.04] border border-black/[0.06] dark:border-white/[0.04] rounded-lg text-gray-900 dark:text-text-primary text-sm focus:ring-2 focus:ring-brand-violet focus:border-transparent outline-none"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-text-secondary mb-1">
+                    {t('密码', 'Password')}
+                  </label>
+                  <div className="relative">
+                    <input
+                      type={showPassword ? 'text' : 'password'}
+                      value={form.password || ''}
+                      onChange={(e) => setForm({ ...form, password: e.target.value || undefined })}
+                      placeholder={t('可选', 'Optional')}
+                      className="w-full px-3 py-2 pr-10 bg-light-surface dark:bg-white/[0.04] border border-black/[0.06] dark:border-white/[0.04] rounded-lg text-gray-900 dark:text-text-primary text-sm focus:ring-2 focus:ring-brand-violet focus:border-transparent outline-none"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword(!showPassword)}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-text-secondary"
+                    >
+                      {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Actions */}
+          <div className="flex items-center space-x-3 pt-2">
+            <button
+              onClick={handleTest}
+              disabled={testing || !form.host || !form.port}
+              className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-text-secondary bg-light-surface dark:bg-white/[0.04] border border-black/[0.06] dark:border-white/[0.04] rounded-lg hover:bg-gray-200 dark:hover:bg-white/[0.08] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {testing ? (
+                <span className="flex items-center space-x-2">
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  <span>{t('测试中...', 'Testing...')}</span>
+                </span>
+              ) : (
+                t('测试连接', 'Test Connection')
+              )}
+            </button>
+
+            <button
+              onClick={handleSave}
+              disabled={saving || !hasChanges}
+              className="px-4 py-2 text-sm font-medium text-white bg-brand-indigo hover:bg-brand-hover rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {saving ? (
+                <span className="flex items-center space-x-2">
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  <span>{t('保存中...', 'Saving...')}</span>
+                </span>
+              ) : (
+                t('保存', 'Save')
+              )}
+            </button>
+          </div>
+
+          {/* Test Result */}
+          {testResult && (
+            <div className={`flex items-start space-x-2 p-3 rounded-lg text-sm ${
+              testResult.success
+                ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400'
+                : 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400'
+            }`}>
+              {testResult.success ? (
+                <CheckCircle2 className="w-4 h-4 mt-0.5 flex-shrink-0" />
+              ) : (
+                <XCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
+              )}
+              <span>
+                {testResult.success
+                  ? t('代理连接成功', 'Proxy connection successful')
+                  : testResult.error || t('代理连接失败', 'Proxy connection failed')}
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/settings/NetworkPanel.tsx
+++ b/src/components/settings/NetworkPanel.tsx
@@ -33,33 +33,38 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
     return null;
   }
 
+  const isFormValid = !form.enabled || (form.host.trim() && form.port >= 1 && form.port <= 65535);
+
   const handleSave = async () => {
+    if (!isFormValid) return;
+
     setSaving(true);
     try {
-      // Save to store
-      setProxyConfig(form);
-
-      // If Electron, sync to Electron main process
+      // Sync to Electron first (if applicable)
       if (isElectron()) {
         await electronProxy.setProxy(form);
       }
 
-      // If backend is available, sync to backend
+      // Sync to backend (if applicable)
       if (backend.isAvailable) {
-        try {
-          const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
-          if (backendApiSecret) {
-            authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
-          }
-          await fetch('/api/settings/proxy', {
-            method: 'PUT',
-            headers: authHeaders,
-            body: JSON.stringify(form),
-          });
-        } catch {
-          // Backend sync is best-effort
+        const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
+        if (backendApiSecret) {
+          authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
+        }
+        const resp = await fetch('/api/settings/proxy', {
+          method: 'PUT',
+          headers: authHeaders,
+          body: JSON.stringify(form),
+        });
+        if (!resp.ok) {
+          throw new Error(`Backend returned ${resp.status}`);
         }
       }
+
+      // Only persist locally after remote sync succeeds
+      setProxyConfig(form);
+    } catch (e) {
+      setTestResult({ success: false, error: e instanceof Error ? e.message : t('保存失败', 'Save failed') });
     } finally {
       setSaving(false);
     }
@@ -73,22 +78,20 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
         const result = await electronProxy.testProxy(form);
         setTestResult(result);
       } else if (backend.isAvailable) {
-        try {
-          const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
-          if (backendApiSecret) {
-            authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
-          }
-          const resp = await fetch('/api/settings/proxy/test', {
-            method: 'POST',
-            headers: authHeaders,
-            body: JSON.stringify(form),
-          });
-          const data = await resp.json();
-          setTestResult(data);
-        } catch (e) {
-          setTestResult({ success: false, error: e instanceof Error ? e.message : 'Unknown error' });
+        const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
+        if (backendApiSecret) {
+          authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
         }
+        const resp = await fetch('/api/settings/proxy/test', {
+          method: 'POST',
+          headers: authHeaders,
+          body: JSON.stringify(form),
+        });
+        const data = await resp.json();
+        setTestResult(data);
       }
+    } catch (e) {
+      setTestResult({ success: false, error: e instanceof Error ? e.message : 'Unknown error' });
     } finally {
       setTesting(false);
     }
@@ -109,6 +112,7 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
           type="button"
           role="switch"
           aria-checked={form.enabled}
+          aria-label={t('启用网络代理', 'Enable network proxy')}
           onClick={() => setForm({ ...form, enabled: !form.enabled })}
           className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${form.enabled ? 'bg-brand-indigo' : 'bg-gray-300 dark:bg-gray-600'}`}
         >
@@ -219,6 +223,7 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
                     />
                     <button
                       type="button"
+                      aria-label={showPassword ? t('隐藏密码', 'Hide password') : t('显示密码', 'Show password')}
                       onClick={() => setShowPassword(!showPassword)}
                       className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-text-secondary"
                     >
@@ -249,7 +254,7 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
 
             <button
               onClick={handleSave}
-              disabled={saving || !hasChanges}
+              disabled={saving || !hasChanges || !isFormValid}
               className="px-4 py-2 text-sm font-medium text-white bg-brand-indigo hover:bg-brand-hover rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {saving ? (

--- a/src/components/settings/NetworkPanel.tsx
+++ b/src/components/settings/NetworkPanel.tsx
@@ -39,6 +39,8 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
     if (!isFormValid) return;
 
     setSaving(true);
+    setTestResult(null);
+    const previousConfig = proxyConfig;
     try {
       // Sync to Electron first (if applicable)
       if (isElectron()) {
@@ -64,6 +66,10 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
       // Only persist locally after remote sync succeeds
       setProxyConfig(form);
     } catch (e) {
+      // Rollback: restore Electron proxy to previous state
+      if (isElectron()) {
+        try { await electronProxy.setProxy(previousConfig); } catch { /* best effort */ }
+      }
       setTestResult({ success: false, error: e instanceof Error ? e.message : t('保存失败', 'Save failed') });
     } finally {
       setSaving(false);

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -5,3 +5,4 @@ export { BackendPanel } from './BackendPanel';
 export { CategoryPanel } from './CategoryPanel';
 export { GeneralPanel } from './GeneralPanel';
 export { DataManagementPanel } from './DataManagementPanel';
+export { NetworkPanel } from './NetworkPanel';

--- a/src/services/electronProxy.ts
+++ b/src/services/electronProxy.ts
@@ -1,0 +1,36 @@
+import type { ProxyConfig } from '../types';
+
+interface ElectronAPI {
+  setProxy: (config: ProxyConfig) => Promise<{ success: boolean }>;
+  getProxy: () => Promise<ProxyConfig>;
+  testProxy: (config: ProxyConfig) => Promise<{ success: boolean; error?: string }>;
+}
+
+declare global {
+  interface Window {
+    electronAPI?: ElectronAPI;
+  }
+}
+
+export const isElectron = (): boolean => {
+  return typeof window !== 'undefined' && !!window.electronAPI;
+};
+
+export const electronProxy = {
+  async setProxy(config: ProxyConfig): Promise<void> {
+    if (window.electronAPI) {
+      await window.electronAPI.setProxy(config);
+    }
+  },
+
+  async getProxy(): Promise<ProxyConfig | null> {
+    return window.electronAPI?.getProxy() ?? null;
+  },
+
+  async testProxy(config: ProxyConfig): Promise<{ success: boolean; error?: string }> {
+    if (!window.electronAPI) {
+      return { success: false, error: 'Not running in Electron' };
+    }
+    return window.electronAPI.testProxy(config);
+  },
+};

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -540,6 +540,8 @@ const normalizePersistedState = (
           type: validType as import('../types').ProxyType,
           host: validHost,
           port: validPort,
+          username: typeof obj.username === 'string' ? obj.username : undefined,
+          // password 不从持久化恢复，仅在内存中
         };
       }
       return { enabled: false, type: 'http' as const, host: '', port: 7890 };
@@ -1499,7 +1501,15 @@ export const useAppStore = create<AppState & AppActions>()(
       discoverySortBy: state.discoverySortBy,
       discoverySortOrder: state.discoverySortOrder,
       discoverySelectedTopic: state.discoverySelectedTopic,
-      proxyConfig: state.proxyConfig,
+      // 持久化代理配置，但排除密码（安全考虑）
+      proxyConfig: {
+        enabled: state.proxyConfig.enabled,
+        type: state.proxyConfig.type,
+        host: state.proxyConfig.host,
+        port: state.proxyConfig.port,
+        username: state.proxyConfig.username,
+        // password 不持久化，仅保留在内存中
+      },
       }),
       migrate: (persistedState) => {
         // 版本升级适配处理

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -5,16 +5,17 @@ import {
   Repository,
   Release,
   ForkRepo,
-  AIConfig, 
-  WebDAVConfig, 
-  SearchFilters, 
-  GitHubUser, 
-  Category, 
-  AssetFilter, 
-  UpdateNotification, 
-  AnalysisProgress, 
-  DiscoveryChannel, 
-  DiscoveryChannelId, 
+  AIConfig,
+  WebDAVConfig,
+  ProxyConfig,
+  SearchFilters,
+  GitHubUser,
+  Category,
+  AssetFilter,
+  UpdateNotification,
+  AnalysisProgress,
+  DiscoveryChannel,
+  DiscoveryChannelId,
   DiscoveryRepo,
   DiscoveryPlatform,
   ProgrammingLanguage,
@@ -167,6 +168,9 @@ interface AppActions {
   // Backend actions
   setBackendApiSecret: (secret: string | null) => void;
 
+  // Proxy actions
+  setProxyConfig: (updates: Partial<ProxyConfig>) => void;
+
   // Release Timeline View actions
   setReleaseViewMode: (mode: 'timeline' | 'repository') => void;
   setReleaseSelectedFilters: (filters: string[]) => void;
@@ -271,6 +275,7 @@ type PersistedAppState = Partial<
     | 'discoveryLanguage'
     | 'discoverySortBy'
     | 'discoverySortOrder'
+    | 'proxyConfig'
     | 'subscriptionRepos'
     | 'subscriptionLastRefresh'
     | 'subscriptionIsLoading'
@@ -523,6 +528,13 @@ const normalizePersistedState = (
         defaultSubscriptionChannels.filter(dch => !persisted.some((ch: unknown) => (ch as Record<string, unknown>).id === dch.id))
       );
     })(),
+    proxyConfig: (() => {
+      const p = (safePersisted as Record<string, unknown>).proxyConfig;
+      if (p && typeof p === 'object' && typeof (p as Record<string, unknown>).enabled === 'boolean') {
+        return p as import('../types').ProxyConfig;
+      }
+      return { enabled: false, type: 'http' as const, host: '', port: 7890 };
+    })(),
   };
 };
 
@@ -710,6 +722,7 @@ export const useAppStore = create<AppState & AppActions>()(
       updateNotification: null,
       analysisProgress: { current: 0, total: 0 },
       backendApiSecret: readSessionBackendSecret(),
+      proxyConfig: { enabled: false, type: 'http', host: '', port: 7890 },
       isSidebarCollapsed: false,
       readmeModalOpen: false,
       releaseViewMode: 'timeline',
@@ -1234,6 +1247,9 @@ export const useAppStore = create<AppState & AppActions>()(
         writeSessionBackendSecret(backendApiSecret);
         set({ backendApiSecret });
       },
+      setProxyConfig: (updates) => set((state) => ({
+        proxyConfig: { ...state.proxyConfig, ...updates }
+      })),
 
       // Release Timeline View actions
       setReleaseViewMode: (releaseViewMode) => set({ releaseViewMode }),
@@ -1389,7 +1405,7 @@ export const useAppStore = create<AppState & AppActions>()(
     }),
     {
       name: 'github-stars-manager',
-      version: 5,
+      version: 6,
       storage: debouncedPersistStorage,
       partialize: (state) => ({
         // 持久化用户信息和认证状态
@@ -1474,6 +1490,7 @@ export const useAppStore = create<AppState & AppActions>()(
       discoverySortBy: state.discoverySortBy,
       discoverySortOrder: state.discoverySortOrder,
       discoverySelectedTopic: state.discoverySelectedTopic,
+      proxyConfig: state.proxyConfig,
       }),
       migrate: (persistedState) => {
         // 版本升级适配处理
@@ -1593,6 +1610,11 @@ export const useAppStore = create<AppState & AppActions>()(
     (state as Record<string, unknown>).discoveryScrollPositions = {
       'trending': 0, 'hot-release': 0, 'most-popular': 0, 'topic': 0, 'search': 0,
     };
+  }
+
+  // v5→v6: 初始化 proxyConfig
+  if (state && !(state as Record<string, unknown>).proxyConfig) {
+    (state as Record<string, unknown>).proxyConfig = { enabled: false, type: 'http', host: '', port: 7890 };
   }
 
         return state as PersistedAppState;

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -530,8 +530,17 @@ const normalizePersistedState = (
     })(),
     proxyConfig: (() => {
       const p = (safePersisted as Record<string, unknown>).proxyConfig;
-      if (p && typeof p === 'object' && typeof (p as Record<string, unknown>).enabled === 'boolean') {
-        return p as import('../types').ProxyConfig;
+      if (p && typeof p === 'object') {
+        const obj = p as Record<string, unknown>;
+        const validType = obj.type === 'http' || obj.type === 'socks5' ? obj.type : 'http';
+        const validHost = typeof obj.host === 'string' ? obj.host : '';
+        const validPort = typeof obj.port === 'number' && Number.isFinite(obj.port) ? obj.port : 7890;
+        return {
+          enabled: typeof obj.enabled === 'boolean' ? obj.enabled : false,
+          type: validType as import('../types').ProxyType,
+          host: validHost,
+          port: validPort,
+        };
       }
       return { enabled: false, type: 'http' as const, host: '', port: 7890 };
     })(),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -158,6 +158,17 @@ export interface WebDAVConfig {
   passwordStatus?: SecretStatus;
 }
 
+export type ProxyType = 'http' | 'socks5';
+
+export interface ProxyConfig {
+  enabled: boolean;
+  type: ProxyType;
+  host: string;
+  port: number;
+  username?: string;
+  password?: string;
+}
+
 export interface SearchFilters {
   query: string;
   tags: string[];
@@ -247,6 +258,9 @@ export interface AppState {
 
   // Backend
   backendApiSecret: string | null;
+
+  // Network Proxy
+  proxyConfig: ProxyConfig;
 
   // Fork Timeline View
   forks: ForkRepo[];


### PR DESCRIPTION
## Summary
- Add network proxy configuration in settings UI for Electron client and backend-connected browser modes
- Support HTTP and SOCKS5 proxy protocols with optional username/password authentication
- Proxy applies to all external requests (GitHub API, AI providers, WebDAV) but NOT to backend communication
- Add Electron IPC bridge for session-level proxy via `session.setProxy` with bypass rules for localhost
- Replace `fetch` with `axios` in backend proxyService for native proxy support
- Add proxy config API endpoints (GET/PUT/test) in backend

## Changes
- **Types**: Add `ProxyConfig` interface and `ProxyType` to `src/types/index.ts`
- **Store**: Add proxyConfig state, `setProxyConfig` action, persistence, and migration v5→v6 in `useAppStore.ts`
- **UI**: New `NetworkPanel.tsx` with toggle, type radio, host/port inputs, collapsible auth, test button, save button
- **Electron**: CI workflow generates `preload.js` with IPC bridge; main process handles `set-proxy`/`get-proxy`/`test-proxy` IPC calls; applies `session.setProxy` with `proxyBypassRules: '<local>;localhost;127.0.0.1'`
- **Backend**: `proxyService.ts` uses `axios` with `proxy` config option; `proxy.ts` routes pass `proxyConfig` to all `proxyRequest` calls; new `/api/settings/proxy` endpoints
- **Visibility**: Network settings section only renders when `isElectron() || backend.isAvailable` (hidden in pure browser mode)

## Backward Compatibility
- Default `enabled: false` — existing users unaffected
- Zustand migration adds `proxyConfig` field with safe defaults
- Electron: no proxy-config.json → no `session.setProxy` call
- Backend: `proxyConfig` parameter is optional, defaults to no proxy
- New `axios` dependency only used in proxy path, existing behavior unchanged

## Test plan
- [ ] Electron client: configure local HTTP proxy (e.g. Clash 127.0.0.1:7890), verify external requests go through proxy
- [ ] Electron SOCKS5: configure SOCKS5 proxy, verify it works
- [ ] Electron + backend: verify proxy applies to external requests, NOT to backend communication
- [ ] Browser + backend: verify proxy settings visible and syncable to backend
- [ ] Browser only: verify proxy settings section is hidden
- [ ] Save flow: change settings without saving → refresh → confirm unchanged; save → refresh → confirm persisted
- [ ] Test connection button: verify success/failure feedback
- [ ] Proxy unreachable: configure wrong proxy, verify no crash, error displayed
- [ ] TypeScript compilation: `npx tsc --noEmit` passes for both frontend and server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure HTTP or SOCKS5 proxy in Settings (enable/disable, host, port, optional auth).
  * Test proxy connectivity from the UI (desktop or server) before saving; Save disabled when invalid or unchanged.
  * Proxy settings persisted and automatically reapplied on app launch; applied to outgoing requests (including integrations).

* **Bug Fixes / Improvements**
  * Stored passwords are masked when reading settings; backend preserves existing encrypted password when omitted.
* **Desktop**
  * Desktop build exposes proxy controls to the renderer and supports runtime proxy apply/test.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmintaCCCP/GithubStarsManager/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->