### PR TITLE
fix: use inline config for AI proxy to avoid configId lookup failure (#166)

### DIFF
--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -154,11 +154,7 @@ export class AIService {
 
       let data: Record<string, unknown>;
       if (backend.isAvailable) {
-        if (this.config.id) {
-          data = await backend.proxyAIRequest(this.config.id, requestBody, options.signal) as Record<string, unknown>;
-        } else {
-          data = await backend.proxyAIRequestWithConfig(this.config, requestBody, options.signal) as Record<string, unknown>;
-        }
+        data = await backend.proxyAIRequestWithConfig(this.config, requestBody, options.signal) as Record<string, unknown>;
       } else {
         const url = buildFinalApiUrl(this.config.baseUrl, apiType);
         const response = await fetch(url, {
@@ -216,11 +212,7 @@ export class AIService {
 
       let data: unknown;
       if (backend.isAvailable) {
-        if (this.config.id) {
-          data = await backend.proxyAIRequest(this.config.id, requestBody, options.signal);
-        } else {
-          data = await backend.proxyAIRequestWithConfig(this.config, requestBody, options.signal);
-        }
+        data = await backend.proxyAIRequestWithConfig(this.config, requestBody, options.signal);
       } else {
         const url = buildApiUrl(this.config.baseUrl, 'v1/messages');
         const response = await fetch(url, {
@@ -276,11 +268,7 @@ ${options.user}` : options.user;
 
     let data: unknown;
     if (backend.isAvailable) {
-      if (this.config.id) {
-        data = await backend.proxyAIRequest(this.config.id, requestBody, options.signal);
-      } else {
-        data = await backend.proxyAIRequestWithConfig(this.config, requestBody, options.signal);
-      }
+      data = await backend.proxyAIRequestWithConfig(this.config, requestBody, options.signal);
     } else {
       const path = `v1beta/models/${encodeURIComponent(model)}:generateContent`;
       const urlObj = new URL(buildApiUrl(this.config.baseUrl, path));

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -154,7 +154,7 @@ export class AIService {
 
       let data: Record<string, unknown>;
       if (backend.isAvailable) {
-        data = await backend.proxyAIRequestWithConfig(this.config, requestBody, options.signal) as Record<string, unknown>;
+        data = await backend.proxyAIRequestWithFallback(this.config.id, this.config, requestBody, options.signal) as Record<string, unknown>;
       } else {
         const url = buildFinalApiUrl(this.config.baseUrl, apiType);
         const response = await fetch(url, {
@@ -212,7 +212,7 @@ export class AIService {
 
       let data: unknown;
       if (backend.isAvailable) {
-        data = await backend.proxyAIRequestWithConfig(this.config, requestBody, options.signal);
+        data = await backend.proxyAIRequestWithFallback(this.config.id, this.config, requestBody, options.signal);
       } else {
         const url = buildApiUrl(this.config.baseUrl, 'v1/messages');
         const response = await fetch(url, {
@@ -268,7 +268,7 @@ ${options.user}` : options.user;
 
     let data: unknown;
     if (backend.isAvailable) {
-      data = await backend.proxyAIRequestWithConfig(this.config, requestBody, options.signal);
+      data = await backend.proxyAIRequestWithFallback(this.config.id, this.config, requestBody, options.signal);
     } else {
       const path = `v1beta/models/${encodeURIComponent(model)}:generateContent`;
       const urlObj = new URL(buildApiUrl(this.config.baseUrl, path));

--- a/src/services/backendAdapter.ts
+++ b/src/services/backendAdapter.ts
@@ -252,6 +252,32 @@ class BackendAdapter {
     return res.json();
   }
 
+  async proxyAIRequestWithFallback(configId: string, aiConfig: { apiType?: string; baseUrl: string; apiKey: string; model: string; reasoningEffort?: string }, body: object, signal?: AbortSignal): Promise<unknown> {
+    if (!this._backendUrl) throw new Error('Backend not available');
+
+    // Try configId lookup first to avoid sending API key inline
+    if (configId) {
+      try {
+        const res = await this.fetchWithTimeout(`${this._backendUrl}/proxy/ai`, {
+          method: 'POST',
+          headers: this.getAuthHeaders(),
+          body: JSON.stringify({ configId, body }),
+          signal,
+        }, 120000);
+        if (res.ok) return res.json();
+        // Fall through to inline config on 404 (config not synced yet)
+        if (res.status !== 404) await this.throwTranslatedError(res, 'AI proxy error');
+      } catch (err) {
+        // If it's a non-404 error, rethrow; otherwise fall through
+        const msg = err instanceof Error ? err.message : '';
+        if (!msg.includes('AI config not found') && !msg.includes('AI_CONFIG_NOT_FOUND')) throw err;
+      }
+    }
+
+    // Fallback: send full config inline
+    return this.proxyAIRequestWithConfig(aiConfig, body, signal);
+  }
+
   // === WebDAV Proxy ===
 
   async proxyWebDAV(configId: string, method: string, path: string, body?: string, headers?: Record<string, string>): Promise<Response> {

--- a/src/services/backendAdapter.ts
+++ b/src/services/backendAdapter.ts
@@ -136,7 +136,10 @@ class BackendAdapter {
       }
     } catch { /* body not JSON */ }
     const translated = translateBackendError(code, `${fallbackPrefix}: ${res.status}`);
-    throw new Error(detail ? `${translated} - ${detail}` : translated);
+    const error = new Error(detail ? `${translated} - ${detail}` : translated) as Error & { statusCode?: number; code?: string };
+    error.statusCode = res.status;
+    if (code) error.code = code;
+    throw error;
   }
 
   // === GitHub Proxy ===
@@ -268,9 +271,9 @@ class BackendAdapter {
         // Fall through to inline config on 404 (config not synced yet)
         if (res.status !== 404) await this.throwTranslatedError(res, 'AI proxy error');
       } catch (err) {
-        // If it's a non-404 error, rethrow; otherwise fall through
-        const msg = err instanceof Error ? err.message : '';
-        if (!msg.includes('AI config not found') && !msg.includes('AI_CONFIG_NOT_FOUND')) throw err;
+        // Rethrow non-404 errors; fall through to inline config on config-not-found
+        const e = err as Error & { statusCode?: number; code?: string };
+        if (e.statusCode !== 404 && e.code !== 'AI_CONFIG_NOT_FOUND') throw err;
       }
     }
 


### PR DESCRIPTION
## Summary

- Fix "AI config not found" error when testing AI connection from the service list page or using AI to analyze repos in backend mode
- Root cause: `AIService.requestText()` used `configId` lookup path when `config.id` was set, but the config might not yet be synced to the backend DB (auto-sync has a 2s debounce)
- Fix: always use `proxyAIRequestWithConfig` (inline config path) to send the full config data directly to the backend, matching what the form test connection already does

## Problem

In backend mode, there were two code paths for AI proxy requests:

| Path | Trigger | How it works |
|------|---------|-------------|
| `proxyAIRequest(configId)` | Saved config (has `id`) | Backend looks up config by ID in SQLite DB |
| `proxyAIRequestWithConfig(config)` | Form test (no `id`) | Backend uses config data directly from request |

The `configId` path failed when auto-sync hadn't pushed the config yet (2s debounce window after saving), causing:
- List page "Test Connection" → "AI config not found" 404
- AI repo analysis → "AI config not found" 404

## Test plan

- [ ] Backend mode: create/edit AI config → test from list page → should succeed
- [ ] Backend mode: use AI to analyze a repo → should succeed
- [ ] Backend mode: test connection from edit form → should continue working
- [ ] Desktop client (no backend): all AI features → should continue working
- [ ] Pure web frontend (no backend): all AI features → should continue working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated AI request routing to prefer a proxy lookup with an automatic fallback to an inline-config proxy to improve reliability of AI integrations (OpenAI-family, Claude, Gemini).
  * Enhanced backend error handling for more informative failures.
  * No visible user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmintaCCCP/GithubStarsManager/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->