### PR TITLE
fix: 悬停始终弹出描述tooltip，趋势页新增tooltip

### DIFF
--- a/src/components/FloatingTooltip.tsx
+++ b/src/components/FloatingTooltip.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useCallback } from 'react';
+import React, { useLayoutEffect, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 
 interface FloatingTooltipProps {
@@ -6,6 +6,7 @@ interface FloatingTooltipProps {
   visible: boolean;
   triggerRef: React.RefObject<HTMLElement | null>;
   onMouseLeave: () => void;
+  onMouseEnter?: () => void;
 }
 
 export const FloatingTooltip: React.FC<FloatingTooltipProps> = ({
@@ -13,8 +14,10 @@ export const FloatingTooltip: React.FC<FloatingTooltipProps> = ({
   visible,
   triggerRef,
   onMouseLeave,
+  onMouseEnter,
 }) => {
   const tooltipRef = useRef<HTMLDivElement>(null);
+  const rafRef = useRef<number>(0);
 
   const updatePosition = useCallback(() => {
     if (!triggerRef.current || !tooltipRef.current || !visible) return;
@@ -22,38 +25,36 @@ export const FloatingTooltip: React.FC<FloatingTooltipProps> = ({
     const triggerRect = triggerRef.current.getBoundingClientRect();
     const tooltipEl = tooltipRef.current;
 
-    // Reset height to get natural measurement
     tooltipEl.style.maxHeight = '280px';
     const tooltipHeight = tooltipEl.offsetHeight;
     const tooltipWidth = triggerRect.width;
 
-    // Position above the trigger
     const top = triggerRect.top - tooltipHeight - 8;
     const left = triggerRect.left;
 
-    // If tooltip would go above viewport, flip it below
     if (top < 8) {
       tooltipEl.style.top = `${triggerRect.bottom + 8}px`;
       tooltipEl.style.bottom = 'auto';
-      // Flip arrow direction
-      tooltipEl.dataset.flipped = 'true';
     } else {
       tooltipEl.style.top = `${top}px`;
       tooltipEl.style.bottom = 'auto';
-      tooltipEl.dataset.flipped = 'false';
     }
 
     tooltipEl.style.left = `${left}px`;
     tooltipEl.style.width = `${tooltipWidth}px`;
   }, [triggerRef, visible]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (visible) {
       updatePosition();
-      const handleResize = () => updatePosition();
+      const handleResize = () => {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = requestAnimationFrame(updatePosition);
+      };
       window.addEventListener('resize', handleResize);
       window.addEventListener('scroll', handleResize, true);
       return () => {
+        cancelAnimationFrame(rafRef.current);
         window.removeEventListener('resize', handleResize);
         window.removeEventListener('scroll', handleResize, true);
       };
@@ -65,6 +66,7 @@ export const FloatingTooltip: React.FC<FloatingTooltipProps> = ({
   return createPortal(
     <div
       ref={tooltipRef}
+      onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       className="fixed z-[9999] p-4 bg-white dark:bg-surface-3 text-gray-900 dark:text-text-primary text-[13px] leading-[1.625] rounded-xl shadow-dialog border border-gray-200/80 dark:border-white/[0.04] animate-fade-in max-h-[280px] overflow-y-auto scrollbar-auto"
       style={{ pointerEvents: 'auto' }}

--- a/src/components/FloatingTooltip.tsx
+++ b/src/components/FloatingTooltip.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+
+interface FloatingTooltipProps {
+  content: React.ReactNode;
+  visible: boolean;
+  triggerRef: React.RefObject<HTMLElement | null>;
+  onMouseLeave: () => void;
+}
+
+export const FloatingTooltip: React.FC<FloatingTooltipProps> = ({
+  content,
+  visible,
+  triggerRef,
+  onMouseLeave,
+}) => {
+  const tooltipRef = useRef<HTMLDivElement>(null);
+
+  const updatePosition = useCallback(() => {
+    if (!triggerRef.current || !tooltipRef.current || !visible) return;
+
+    const triggerRect = triggerRef.current.getBoundingClientRect();
+    const tooltipEl = tooltipRef.current;
+
+    // Reset height to get natural measurement
+    tooltipEl.style.maxHeight = '280px';
+    const tooltipHeight = tooltipEl.offsetHeight;
+    const tooltipWidth = triggerRect.width;
+
+    // Position above the trigger
+    const top = triggerRect.top - tooltipHeight - 8;
+    const left = triggerRect.left;
+
+    // If tooltip would go above viewport, flip it below
+    if (top < 8) {
+      tooltipEl.style.top = `${triggerRect.bottom + 8}px`;
+      tooltipEl.style.bottom = 'auto';
+      // Flip arrow direction
+      tooltipEl.dataset.flipped = 'true';
+    } else {
+      tooltipEl.style.top = `${top}px`;
+      tooltipEl.style.bottom = 'auto';
+      tooltipEl.dataset.flipped = 'false';
+    }
+
+    tooltipEl.style.left = `${left}px`;
+    tooltipEl.style.width = `${tooltipWidth}px`;
+  }, [triggerRef, visible]);
+
+  useEffect(() => {
+    if (visible) {
+      updatePosition();
+      const handleResize = () => updatePosition();
+      window.addEventListener('resize', handleResize);
+      window.addEventListener('scroll', handleResize, true);
+      return () => {
+        window.removeEventListener('resize', handleResize);
+        window.removeEventListener('scroll', handleResize, true);
+      };
+    }
+  }, [visible, updatePosition]);
+
+  if (!visible) return null;
+
+  return createPortal(
+    <div
+      ref={tooltipRef}
+      onMouseLeave={onMouseLeave}
+      className="fixed z-[9999] p-4 bg-white dark:bg-surface-3 text-gray-900 dark:text-text-primary text-[13px] leading-[1.625] rounded-xl shadow-dialog border border-gray-200/80 dark:border-white/[0.04] animate-fade-in max-h-[280px] overflow-y-auto scrollbar-auto"
+      style={{ pointerEvents: 'auto' }}
+    >
+      <div className="whitespace-pre-wrap break-words pr-2">
+        {content}
+      </div>
+    </div>,
+    document.body
+  );
+};

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -135,12 +135,9 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [readmeModalOpen, setReadmeModalOpen] = useState(false);
   const [showTooltip, setShowTooltip] = useState(false);
-  const [isTextTruncated, setIsTextTruncated] = useState(false);
   const [unstarring, setUnstarring] = useState(false);
   const [showDragHint, setShowDragHint] = useState(false);
   const dragHintTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const descriptionRef = useRef<HTMLParagraphElement>(null);
 
   // 高亮搜索关键词的工具函数 - 使用缓存优化
   const highlightSearchTerm = useCallback((text: string, searchTerm: string): React.ReactNode => {
@@ -176,28 +173,14 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
     return result;
   }, []);
 
-  // Check if text is actually truncated by comparing scroll height with client height
+  // Cleanup drag hint timeout on unmount
   useEffect(() => {
-    const checkTruncation = () => {
-      if (descriptionRef.current) {
-        const element = descriptionRef.current;
-        const isTruncated = element.scrollHeight > element.clientHeight;
-        setIsTextTruncated(isTruncated);
-      }
-    };
-
-    // Check truncation after component mounts and when content changes
-    checkTruncation();
-
-    // Also check on window resize
-    window.addEventListener('resize', checkTruncation);
     return () => {
-      window.removeEventListener('resize', checkTruncation);
       if (dragHintTimeoutRef.current) {
         clearTimeout(dragHintTimeoutRef.current);
       }
     };
-  }, [repository, showAISummary]);
+  }, []);
 
   const formatNumber = (num: number) => {
     if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`;
@@ -882,18 +865,17 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
       <div className="mb-4 flex-1">
         <div
           className="relative group"
-          onMouseEnter={() => isTextTruncated && setShowTooltip(true)}
+          onMouseEnter={() => setShowTooltip(true)}
           onMouseLeave={() => setShowTooltip(false)}
         >
           <p
-            ref={descriptionRef}
             className="text-gray-800 dark:text-text-secondary text-[13px] leading-[1.625] line-clamp-3 mb-2 transition-colors duration-200 hover:text-gray-900 dark:hover:text-text-primary rounded px-1 -mx-1 hover:bg-gray-50/50 dark:hover:bg-white/[0.02]"
           >
             {highlightSearchTerm(displayContent.content, searchQuery)}
           </p>
 
           {/* Enhanced Tooltip - Optimized for Light Mode Readability */}
-          {isTextTruncated && showTooltip && (
+          {showTooltip && (
             <div className="absolute z-50 bottom-full left-0 right-0 mb-2 p-4 bg-white dark:bg-surface-3 text-gray-900 dark:text-text-primary text-[13px] leading-[1.625] rounded-xl shadow-dialog border border-gray-200/80 dark:border-white/[0.04] animate-fade-in max-h-[280px] overflow-y-auto scrollbar-auto">
               <div className="whitespace-pre-wrap break-words pr-2">
                 {highlightSearchTerm(displayContent.content, searchQuery)}

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -867,6 +867,10 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
           className="relative group"
           onMouseEnter={() => setShowTooltip(true)}
           onMouseLeave={() => setShowTooltip(false)}
+          onFocus={() => setShowTooltip(true)}
+          onBlur={() => setShowTooltip(false)}
+          onTouchStart={() => setShowTooltip((v) => !v)}
+          tabIndex={0}
         >
           <p
             className="text-gray-800 dark:text-text-secondary text-[13px] leading-[1.625] line-clamp-3 mb-2 transition-colors duration-200 hover:text-gray-900 dark:hover:text-text-primary rounded px-1 -mx-1 hover:bg-gray-50/50 dark:hover:bg-white/[0.02]"

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -137,6 +137,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
   const [readmeModalOpen, setReadmeModalOpen] = useState(false);
   const [showTooltip, setShowTooltip] = useState(false);
   const descTriggerRef = useRef<HTMLDivElement>(null);
+  const tooltipHideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [unstarring, setUnstarring] = useState(false);
   const [showDragHint, setShowDragHint] = useState(false);
   const dragHintTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -175,11 +176,14 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
     return result;
   }, []);
 
-  // Cleanup drag hint timeout on unmount
+  // Cleanup timeouts on unmount
   useEffect(() => {
     return () => {
       if (dragHintTimeoutRef.current) {
         clearTimeout(dragHintTimeoutRef.current);
+      }
+      if (tooltipHideTimerRef.current) {
+        clearTimeout(tooltipHideTimerRef.current);
       }
     };
   }, []);
@@ -868,10 +872,10 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
         <div
           ref={descTriggerRef}
           className="relative group"
-          onMouseEnter={() => setShowTooltip(true)}
-          onMouseLeave={() => setShowTooltip(false)}
-          onFocus={() => setShowTooltip(true)}
-          onBlur={() => setShowTooltip(false)}
+          onMouseEnter={() => { clearTimeout(tooltipHideTimerRef.current); setShowTooltip(true); }}
+          onMouseLeave={() => { tooltipHideTimerRef.current = setTimeout(() => setShowTooltip(false), 150); }}
+          onFocus={() => { clearTimeout(tooltipHideTimerRef.current); setShowTooltip(true); }}
+          onBlur={() => { tooltipHideTimerRef.current = setTimeout(() => setShowTooltip(false), 150); }}
           onTouchStart={() => setShowTooltip((v) => !v)}
           tabIndex={0}
         >
@@ -884,7 +888,8 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
             content={highlightSearchTerm(displayContent.content, searchQuery)}
             visible={showTooltip}
             triggerRef={descTriggerRef}
-            onMouseLeave={() => setShowTooltip(false)}
+            onMouseEnter={() => clearTimeout(tooltipHideTimerRef.current)}
+            onMouseLeave={() => { tooltipHideTimerRef.current = setTimeout(() => setShowTooltip(false), 150); }}
           />
         </div>
 

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -10,6 +10,7 @@ import { GitHubApiService } from '../services/githubApi';
 import { formatDistanceToNow } from 'date-fns';
 import { RepositoryEditModal } from './RepositoryEditModal';
 import { ReadmeModal } from './ReadmeModal';
+import { FloatingTooltip } from './FloatingTooltip';
 import { shallow } from 'zustand/shallow';
 import { useDialog } from '../hooks/useDialog';
 
@@ -135,6 +136,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [readmeModalOpen, setReadmeModalOpen] = useState(false);
   const [showTooltip, setShowTooltip] = useState(false);
+  const descTriggerRef = useRef<HTMLDivElement>(null);
   const [unstarring, setUnstarring] = useState(false);
   const [showDragHint, setShowDragHint] = useState(false);
   const dragHintTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -861,9 +863,10 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
         </div>
       </div>
 
-      {/* Description with Tooltip - Enhanced for Light Mode */}
+      {/* Description with Tooltip */}
       <div className="mb-4 flex-1">
         <div
+          ref={descTriggerRef}
           className="relative group"
           onMouseEnter={() => setShowTooltip(true)}
           onMouseLeave={() => setShowTooltip(false)}
@@ -877,17 +880,12 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
           >
             {highlightSearchTerm(displayContent.content, searchQuery)}
           </p>
-
-          {/* Enhanced Tooltip - Optimized for Light Mode Readability */}
-          {showTooltip && (
-            <div className="absolute z-50 bottom-full left-0 right-0 mb-2 p-4 bg-white dark:bg-surface-3 text-gray-900 dark:text-text-primary text-[13px] leading-[1.625] rounded-xl shadow-dialog border border-gray-200/80 dark:border-white/[0.04] animate-fade-in max-h-[280px] overflow-y-auto scrollbar-auto">
-              <div className="whitespace-pre-wrap break-words pr-2">
-                {highlightSearchTerm(displayContent.content, searchQuery)}
-              </div>
-              {/* Arrow with Light Mode Optimization */}
-              <div className="absolute top-full left-4 w-0 h-0 border-l-[6px] border-l-transparent border-r-[6px] border-r-transparent border-t-[6px] border-t-white dark:border-t-surface-3 drop-shadow-sm"></div>
-            </div>
-          )}
+          <FloatingTooltip
+            content={highlightSearchTerm(displayContent.content, searchQuery)}
+            visible={showTooltip}
+            triggerRef={descTriggerRef}
+            onMouseLeave={() => setShowTooltip(false)}
+          />
         </div>
 
         {/* 方案一：同时显示多个状态标签 */}

--- a/src/components/SubscriptionRepoCard.tsx
+++ b/src/components/SubscriptionRepoCard.tsx
@@ -7,6 +7,7 @@ import { forceSyncToBackend } from '../services/autoSync';
 import { GitHubApiService } from '../services/githubApi';
 import { ReadmeModal } from './ReadmeModal';
 import { Modal } from './Modal';
+import { FloatingTooltip } from './FloatingTooltip';
 import { useDialog } from '../hooks/useDialog';
 
 interface SubscriptionRepoCardProps {
@@ -41,6 +42,8 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
   const [pendingUnstarAction, setPendingUnstarAction] = useState<(() => void) | null>(null);
   const [descTooltip, setDescTooltip] = useState(false);
   const [aiTooltip, setAiTooltip] = useState(false);
+  const descTriggerRef = useRef<HTMLDivElement>(null);
+  const aiTriggerRef = useRef<HTMLDivElement>(null);
 
   const abortControllerRef = useRef<AbortController | null>(null);
 
@@ -406,6 +409,7 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
           {/* Description */}
           {repo.description && (
             <div
+              ref={descTriggerRef}
               className="relative mb-3"
               onMouseEnter={() => setDescTooltip(true)}
               onMouseLeave={() => setDescTooltip(false)}
@@ -417,20 +421,19 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
               <p className="text-sm text-gray-700 dark:text-text-tertiary line-clamp-2 rounded px-1 -mx-1 hover:bg-gray-50/50 dark:hover:bg-white/[0.02] transition-colors duration-200">
                 {repo.description}
               </p>
-              {descTooltip && (
-                <div className="absolute z-50 bottom-full left-0 right-0 mb-2 p-4 bg-white dark:bg-surface-3 text-gray-900 dark:text-text-primary text-sm leading-[1.625] rounded-xl shadow-dialog border border-gray-200/80 dark:border-white/[0.04] animate-fade-in max-h-[280px] overflow-y-auto scrollbar-auto">
-                  <div className="whitespace-pre-wrap break-words pr-2">
-                    {repo.description}
-                  </div>
-                  <div className="absolute top-full left-4 w-0 h-0 border-l-[6px] border-l-transparent border-r-[6px] border-r-transparent border-t-[6px] border-t-white dark:border-t-surface-3 drop-shadow-sm"></div>
-                </div>
-              )}
+              <FloatingTooltip
+                content={repo.description}
+                visible={descTooltip}
+                triggerRef={descTriggerRef}
+                onMouseLeave={() => setDescTooltip(false)}
+              />
             </div>
           )}
 
           {/* AI Summary */}
           {repo.ai_summary && (
             <div
+              ref={aiTriggerRef}
               className="relative flex items-start gap-1.5 mb-3"
               onMouseEnter={() => setAiTooltip(true)}
               onMouseLeave={() => setAiTooltip(false)}
@@ -443,14 +446,12 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
               <p className="text-sm text-gray-700 dark:text-text-secondary line-clamp-2 rounded px-1 -mx-1 hover:bg-gray-50/50 dark:hover:bg-white/[0.02] transition-colors duration-200">
                 {repo.ai_summary}
               </p>
-              {aiTooltip && (
-                <div className="absolute z-50 bottom-full left-0 right-0 mb-2 p-4 bg-white dark:bg-surface-3 text-gray-900 dark:text-text-primary text-sm leading-[1.625] rounded-xl shadow-dialog border border-gray-200/80 dark:border-white/[0.04] animate-fade-in max-h-[280px] overflow-y-auto scrollbar-auto">
-                  <div className="whitespace-pre-wrap break-words pr-2">
-                    {repo.ai_summary}
-                  </div>
-                  <div className="absolute top-full left-4 w-0 h-0 border-l-[6px] border-l-transparent border-r-[6px] border-r-transparent border-t-[6px] border-t-white dark:border-t-surface-3 drop-shadow-sm"></div>
-                </div>
-              )}
+              <FloatingTooltip
+                content={repo.ai_summary}
+                visible={aiTooltip}
+                triggerRef={aiTriggerRef}
+                onMouseLeave={() => setAiTooltip(false)}
+              />
             </div>
           )}
 

--- a/src/components/SubscriptionRepoCard.tsx
+++ b/src/components/SubscriptionRepoCard.tsx
@@ -44,6 +44,16 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
   const [aiTooltip, setAiTooltip] = useState(false);
   const descTriggerRef = useRef<HTMLDivElement>(null);
   const aiTriggerRef = useRef<HTMLDivElement>(null);
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const scheduleHide = useCallback((setter: (v: boolean) => void) => {
+    if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+    hideTimerRef.current = setTimeout(() => setter(false), 150);
+  }, []);
+
+  const cancelHide = useCallback(() => {
+    if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+  }, []);
 
   const abortControllerRef = useRef<AbortController | null>(null);
 
@@ -411,10 +421,10 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
             <div
               ref={descTriggerRef}
               className="relative mb-3"
-              onMouseEnter={() => setDescTooltip(true)}
-              onMouseLeave={() => setDescTooltip(false)}
-              onFocus={() => setDescTooltip(true)}
-              onBlur={() => setDescTooltip(false)}
+              onMouseEnter={() => { cancelHide(); setDescTooltip(true); }}
+              onMouseLeave={() => scheduleHide(setDescTooltip)}
+              onFocus={() => { cancelHide(); setDescTooltip(true); }}
+              onBlur={() => scheduleHide(setDescTooltip)}
               onTouchStart={() => setDescTooltip((v) => !v)}
               tabIndex={0}
             >
@@ -425,7 +435,8 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
                 content={repo.description}
                 visible={descTooltip}
                 triggerRef={descTriggerRef}
-                onMouseLeave={() => setDescTooltip(false)}
+                onMouseEnter={() => { cancelHide(); }}
+                onMouseLeave={() => scheduleHide(setDescTooltip)}
               />
             </div>
           )}
@@ -435,10 +446,10 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
             <div
               ref={aiTriggerRef}
               className="relative flex items-start gap-1.5 mb-3"
-              onMouseEnter={() => setAiTooltip(true)}
-              onMouseLeave={() => setAiTooltip(false)}
-              onFocus={() => setAiTooltip(true)}
-              onBlur={() => setAiTooltip(false)}
+              onMouseEnter={() => { cancelHide(); setAiTooltip(true); }}
+              onMouseLeave={() => scheduleHide(setAiTooltip)}
+              onFocus={() => { cancelHide(); setAiTooltip(true); }}
+              onBlur={() => scheduleHide(setAiTooltip)}
               onTouchStart={() => setAiTooltip((v) => !v)}
               tabIndex={0}
             >
@@ -450,7 +461,8 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
                 content={repo.ai_summary}
                 visible={aiTooltip}
                 triggerRef={aiTriggerRef}
-                onMouseLeave={() => setAiTooltip(false)}
+                onMouseEnter={() => { cancelHide(); }}
+                onMouseLeave={() => scheduleHide(setAiTooltip)}
               />
             </div>
           )}

--- a/src/components/SubscriptionRepoCard.tsx
+++ b/src/components/SubscriptionRepoCard.tsx
@@ -39,6 +39,8 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
   // 取消Star确认对话框状态
   const [unstarConfirmOpen, setUnstarConfirmOpen] = useState(false);
   const [pendingUnstarAction, setPendingUnstarAction] = useState<(() => void) | null>(null);
+  const [descTooltip, setDescTooltip] = useState(false);
+  const [aiTooltip, setAiTooltip] = useState(false);
 
   const abortControllerRef = useRef<AbortController | null>(null);
 
@@ -403,18 +405,44 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
 
           {/* Description */}
           {repo.description && (
-            <p className="text-sm text-gray-700 dark:text-text-tertiary mb-3 line-clamp-2">
-              {repo.description}
-            </p>
+            <div
+              className="relative mb-3"
+              onMouseEnter={() => setDescTooltip(true)}
+              onMouseLeave={() => setDescTooltip(false)}
+            >
+              <p className="text-sm text-gray-700 dark:text-text-tertiary line-clamp-2 rounded px-1 -mx-1 hover:bg-gray-50/50 dark:hover:bg-white/[0.02] transition-colors duration-200">
+                {repo.description}
+              </p>
+              {descTooltip && (
+                <div className="absolute z-50 bottom-full left-0 right-0 mb-2 p-4 bg-white dark:bg-surface-3 text-gray-900 dark:text-text-primary text-sm leading-[1.625] rounded-xl shadow-dialog border border-gray-200/80 dark:border-white/[0.04] animate-fade-in max-h-[280px] overflow-y-auto scrollbar-auto">
+                  <div className="whitespace-pre-wrap break-words pr-2">
+                    {repo.description}
+                  </div>
+                  <div className="absolute top-full left-4 w-0 h-0 border-l-[6px] border-l-transparent border-r-[6px] border-r-transparent border-t-[6px] border-t-white dark:border-t-surface-3 drop-shadow-sm"></div>
+                </div>
+              )}
+            </div>
           )}
 
           {/* AI Summary */}
           {repo.ai_summary && (
-            <div className="flex items-start gap-1.5 mb-3">
+            <div
+              className="relative flex items-start gap-1.5 mb-3"
+              onMouseEnter={() => setAiTooltip(true)}
+              onMouseLeave={() => setAiTooltip(false)}
+            >
               <Bot className="w-4 h-4 text-gray-700 dark:text-text-secondary flex-shrink-0 mt-0.5" />
-              <p className="text-sm text-gray-700 dark:text-text-secondary line-clamp-2">
+              <p className="text-sm text-gray-700 dark:text-text-secondary line-clamp-2 rounded px-1 -mx-1 hover:bg-gray-50/50 dark:hover:bg-white/[0.02] transition-colors duration-200">
                 {repo.ai_summary}
               </p>
+              {aiTooltip && (
+                <div className="absolute z-50 bottom-full left-0 right-0 mb-2 p-4 bg-white dark:bg-surface-3 text-gray-900 dark:text-text-primary text-sm leading-[1.625] rounded-xl shadow-dialog border border-gray-200/80 dark:border-white/[0.04] animate-fade-in max-h-[280px] overflow-y-auto scrollbar-auto">
+                  <div className="whitespace-pre-wrap break-words pr-2">
+                    {repo.ai_summary}
+                  </div>
+                  <div className="absolute top-full left-4 w-0 h-0 border-l-[6px] border-l-transparent border-r-[6px] border-r-transparent border-t-[6px] border-t-white dark:border-t-surface-3 drop-shadow-sm"></div>
+                </div>
+              )}
             </div>
           )}
 

--- a/src/components/SubscriptionRepoCard.tsx
+++ b/src/components/SubscriptionRepoCard.tsx
@@ -409,6 +409,10 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
               className="relative mb-3"
               onMouseEnter={() => setDescTooltip(true)}
               onMouseLeave={() => setDescTooltip(false)}
+              onFocus={() => setDescTooltip(true)}
+              onBlur={() => setDescTooltip(false)}
+              onTouchStart={() => setDescTooltip((v) => !v)}
+              tabIndex={0}
             >
               <p className="text-sm text-gray-700 dark:text-text-tertiary line-clamp-2 rounded px-1 -mx-1 hover:bg-gray-50/50 dark:hover:bg-white/[0.02] transition-colors duration-200">
                 {repo.description}
@@ -430,6 +434,10 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
               className="relative flex items-start gap-1.5 mb-3"
               onMouseEnter={() => setAiTooltip(true)}
               onMouseLeave={() => setAiTooltip(false)}
+              onFocus={() => setAiTooltip(true)}
+              onBlur={() => setAiTooltip(false)}
+              onTouchStart={() => setAiTooltip((v) => !v)}
+              tabIndex={0}
             >
               <Bot className="w-4 h-4 text-gray-700 dark:text-text-secondary flex-shrink-0 mt-0.5" />
               <p className="text-sm text-gray-700 dark:text-text-secondary line-clamp-2 rounded px-1 -mx-1 hover:bg-gray-50/50 dark:hover:bg-white/[0.02] transition-colors duration-200">


### PR DESCRIPTION
## Summary
- 移除 RepositoryCard 的截断检测门槛（`scrollHeight > clientHeight`），悬停时始终弹出 tooltip，解决因字体渲染差异导致检测不准的问题
- 为 SubscriptionRepoCard（趋势页）新增描述和 AI 总结的悬停 tooltip，之前趋势页完全没有查看完整文本的方式

Closes #165

## Test plan
- [ ] 仓库列表页悬停任意描述（包括短文本），tooltip 始终弹出
- [ ] 趋势页悬停描述和 AI 总结，tooltip 弹出显示完整内容
- [ ] tooltip 在 light/dark mode 下样式正常
- [ ] 长文本 tooltip 内可滚动
- [ ] 离开悬停区域 tooltip 消失

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable floating tooltip with smarter positioning and automatic flip when space is limited.
  * Tooltips now have independent controls for description and AI summary, and support touch interactions.

* **Bug Fixes**
  * Tooltips reliably show full text via hover, focus, and touch, with mouse-leave hide delay.
  * Simplified timeout cleanup to avoid lingering timers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmintaCCCP/GithubStarsManager/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->