### PR TITLE
fix: optimize default AI prompt to reduce thinking process output

### DIFF
--- a/src/components/settings/AIConfigPanel.tsx
+++ b/src/components/settings/AIConfigPanel.tsx
@@ -243,7 +243,8 @@ export const AIConfigPanel: React.FC<AIConfigPanelProps> = ({ t }) => {
 
 要求：
 - summary：中文概述，说明仓库的主要功能和用途，不超过50字。
-- tags：3-5个中文应用类型标签，类似应用商店的分类，如：开发工具、Web应用、移动应用、数据库、AI工具等。
+- tags：3-5个中文应用类型标签，请优先从提供的分类中选择。
+{CATEGORIES_INFO}
 - platforms：只能从 ["mac","windows","linux","ios","android","docker","web","cli"] 中选择；无法判断则为 []。
 
 输出格式：
@@ -263,7 +264,8 @@ Dockerfile/docker-compose=docker；CLI/命令行/终端=cli；浏览器/前端/A
 
 Requirements:
 - summary: A concise English overview explaining the main functionality and purpose, no more than 50 words.
-- tags: 3-5 English application type tags, similar to app store categories such as: development tools, web apps, mobile apps, database, AI tools, etc.
+- tags: 3-5 English application type tags, please prioritize from the provided categories.
+{CATEGORIES_INFO}
 - platforms: Must only choose from ["mac","windows","linux","ios","android","docker","web","cli"]; use [] if unable to determine.
 
 Output format:

--- a/src/components/settings/AIConfigPanel.tsx
+++ b/src/components/settings/AIConfigPanel.tsx
@@ -239,45 +239,45 @@ export const AIConfigPanel: React.FC<AIConfigPanelProps> = ({ t }) => {
 
   const defaultPrompt = useMemo(() => {
     if (language === 'zh') {
-      return `请分析这个GitHub仓库并提供：
+      return `请分析以下GitHub仓库信息，并只输出合法JSON对象。不要输出思考过程、Markdown、代码块标记、解释或任何额外文本。
 
-1. 一个简洁的中文概述（不超过50字），说明这个仓库的主要功能和用途
-2. 3-5个相关的应用类型标签（用中文，类似应用商店的分类，如：开发工具、Web应用、移动应用、数据库、AI工具等）
-3. 支持的平台类型（从以下选择：mac、windows、linux、ios、android、docker、web、cli）
+要求：
+- summary：中文概述，说明仓库的主要功能和用途，不超过50字。
+- tags：3-5个中文应用类型标签，类似应用商店的分类，如：开发工具、Web应用、移动应用、数据库、AI工具等。
+- platforms：只能从 ["mac","windows","linux","ios","android","docker","web","cli"] 中选择；无法判断则为 []。
 
-重要：请严格使用中文进行分析和回复，无论原始README是什么语言。
-
-请以JSON格式回复：
+输出格式：
 {
-  "summary": "你的中文概述",
-  "tags": ["标签1", "标签2", "标签3", "标签4", "标签5"],
-  "platforms": ["platform1", "platform2", "platform3"]
+  "summary": "中文概述",
+  "tags": ["标签1", "标签2", "标签3"],
+  "platforms": ["web", "cli"]
 }
+
+平台线索：
+Dockerfile/docker-compose=docker；CLI/命令行/终端=cli；浏览器/前端/API=web；iOS/Swift/Xcode=ios；Android/Kotlin/Gradle=android；macOS/Homebrew=mac；Windows/.exe/MSI=windows；Linux/systemd/apt=linux。
 
 仓库信息：
-{REPO_INFO}
-
-重点关注实用性和准确的分类，帮助用户快速理解仓库的用途和支持的平台。`;
+{REPO_INFO}`;
     } else {
-      return `Please analyze this GitHub repository and provide:
+      return `Please analyze the following GitHub repository information and only output a valid JSON object. Do not output thinking process, Markdown, code block markers, explanations, or any extra text.
 
-1. A concise English overview (no more than 50 words) explaining the main functionality and purpose of this repository
-2. 3-5 relevant application type tags (in English, similar to app store categories, such as: development tools, web apps, mobile apps, database, AI tools, etc.)
-3. Supported platform types (choose from: mac, windows, linux, ios, android, docker, web, cli)
+Requirements:
+- summary: A concise English overview explaining the main functionality and purpose, no more than 50 words.
+- tags: 3-5 English application type tags, similar to app store categories such as: development tools, web apps, mobile apps, database, AI tools, etc.
+- platforms: Must only choose from ["mac","windows","linux","ios","android","docker","web","cli"]; use [] if unable to determine.
 
-Important: Please strictly use English for analysis and response, regardless of the original README language.
-
-Please reply in JSON format:
+Output format:
 {
-  "summary": "Your English overview",
-  "tags": ["tag1", "tag2", "tag3", "tag4", "tag5"],
-  "platforms": ["platform1", "platform2", "platform3"]
+  "summary": "English overview",
+  "tags": ["tag1", "tag2", "tag3"],
+  "platforms": ["web", "cli"]
 }
 
-Repository information:
-{REPO_INFO}
+Platform hints:
+Dockerfile/docker-compose=docker; CLI/command-line/terminal=cli; browser/frontend/API=web; iOS/Swift/Xcode=ios; Android/Kotlin/Gradle=android; macOS/Homebrew=mac; Windows/.exe/MSI=windows; Linux/systemd/apt=linux.
 
-Focus on practicality and accurate categorization to help users quickly understand the repository's purpose and supported platforms.`;
+Repository information:
+{REPO_INFO}`;
     }
   }, [language]);
 

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -448,7 +448,14 @@ ${repoInfo}
             : (this.language === 'zh' ? '无法生成概述' : 'Unable to generate summary'),
           tags: Array.isArray(parsed.tags) ? parsed.tags.filter((v) => typeof v === 'string').slice(0, 5) : [],
           platforms: Array.isArray(parsed.platforms)
-            ? parsed.platforms.filter((v) => typeof v === 'string' && AIService.VALID_PLATFORMS.includes(v.toLowerCase())).slice(0, 8)
+            ? Array.from(
+                new Set(
+                  parsed.platforms
+                    .filter((v): v is string => typeof v === 'string')
+                    .map((v) => v.trim().toLowerCase())
+                    .filter((v) => AIService.VALID_PLATFORMS.includes(v))
+                )
+              ).slice(0, 8)
             : [],
         };
       }

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -377,17 +377,16 @@ ${this.language === 'zh' ? 'README内容 (前2000字符)' : 'README Content (fir
 ${this.sanitizeForPrompt(readmeContent.substring(0, 2000))}
     `.trim();
 
-    const categoriesInfo = customCategories && customCategories.length > 0 
-      ? `\n\n${this.language === 'zh' ? '可用的应用分类' : 'Available Application Categories'}: ${customCategories.join(', ')}`
-      : '';
-
     if (this.language === 'zh') {
+      const categoriesLine = customCategories && customCategories.length > 0
+        ? `\n可用分类（tags 请优先从中选择）：${customCategories.join(', ')}`
+        : '';
       return `
 请分析以下GitHub仓库信息，并只输出合法JSON对象。不要输出思考过程、Markdown、代码块标记、解释或任何额外文本。
 
 要求：
 - summary：中文概述，说明仓库的主要功能和用途，不超过50字。
-- tags：3-5个中文应用类型标签${customCategories ? '，请优先从提供的分类中选择' : '，类似应用商店的分类，如：开发工具、Web应用、移动应用、数据库、AI工具等'}。
+- tags：3-5个中文应用类型标签${customCategories && customCategories.length > 0 ? '，请优先从上方的可用分类中选择' : '，类似应用商店的分类，如：开发工具、Web应用、移动应用、数据库、AI工具等'}。${categoriesLine}
 - platforms：只能从 ["mac","windows","linux","ios","android","docker","web","cli"] 中选择；无法判断则为 []。
 
 输出格式：
@@ -401,15 +400,18 @@ ${this.sanitizeForPrompt(readmeContent.substring(0, 2000))}
 Dockerfile/docker-compose=docker；CLI/命令行/终端=cli；浏览器/前端/API=web；iOS/Swift/Xcode=ios；Android/Kotlin/Gradle=android；macOS/Homebrew=mac；Windows/.exe/MSI=windows；Linux/systemd/apt=linux。
 
 仓库信息：
-${repoInfo}${categoriesInfo}
+${repoInfo}
       `.trim();
     } else {
+      const categoriesLine = customCategories && customCategories.length > 0
+        ? `\nAvailable categories (tags should prioritize these): ${customCategories.join(', ')}`
+        : '';
       return `
 Please analyze the following GitHub repository information and only output a valid JSON object. Do not output thinking process, Markdown, code block markers, explanations, or any extra text.
 
 Requirements:
 - summary: A concise English overview explaining the main functionality and purpose, no more than 50 words.
-- tags: 3-5 English application type tags${customCategories ? ', please prioritize from the provided categories' : ', similar to app store categories such as: development tools, web apps, mobile apps, database, AI tools, etc.'}.
+- tags: 3-5 English application type tags${customCategories && customCategories.length > 0 ? ', please prioritize from the available categories above' : ', similar to app store categories such as: development tools, web apps, mobile apps, database, AI tools, etc.'}.${categoriesLine}
 - platforms: Must only choose from ["mac","windows","linux","ios","android","docker","web","cli"]; use [] if unable to determine.
 
 Output format:
@@ -423,7 +425,7 @@ Platform hints:
 Dockerfile/docker-compose=docker; CLI/command-line/terminal=cli; browser/frontend/API=web; iOS/Swift/Xcode=ios; Android/Kotlin/Gradle=android; macOS/Homebrew=mac; Windows/.exe/MSI=windows; Linux/systemd/apt=linux.
 
 Repository information:
-${repoInfo}${categoriesInfo}
+${repoInfo}
       `.trim();
     }
   }

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -430,6 +430,8 @@ ${repoInfo}
     }
   }
 
+  private static readonly VALID_PLATFORMS = ['mac', 'windows', 'linux', 'ios', 'android', 'docker', 'web', 'cli'];
+
   private parseAIResponse(content: string): { summary: string; tags: string[]; platforms: string[] } {
     try {
       const cleaned = content
@@ -445,7 +447,9 @@ ${repoInfo}
             ? parsed.summary.trim()
             : (this.language === 'zh' ? '无法生成概述' : 'Unable to generate summary'),
           tags: Array.isArray(parsed.tags) ? parsed.tags.filter((v) => typeof v === 'string').slice(0, 5) : [],
-          platforms: Array.isArray(parsed.platforms) ? parsed.platforms.filter((v) => typeof v === 'string').slice(0, 8) : [],
+          platforms: Array.isArray(parsed.platforms)
+            ? parsed.platforms.filter((v) => typeof v === 'string' && AIService.VALID_PLATFORMS.includes(v.toLowerCase())).slice(0, 8)
+            : [],
         };
       }
 

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -321,8 +321,8 @@ ${options.user}` : options.user;
     
     try {
       const system = this.language === 'zh'
-        ? '你是一个专业的GitHub仓库分析助手。请严格按照用户指定的语言进行分析，无论原始内容是什么语言。请用中文简洁地分析仓库，提供实用的概述、分类标签和支持的平台类型。'
-        : 'You are a professional GitHub repository analysis assistant. Please strictly analyze in the language specified by the user, regardless of the original content language. Please analyze repositories concisely in English, providing practical overviews, category tags, and supported platform types.';
+        ? '你是一个专业的GitHub仓库分析助手。请严格按照用户指定的语言进行分析，无论原始内容是什么语言。请用中文简洁地分析仓库，提供实用的概述、分类标签和支持的平台类型。只输出合法JSON，不要输出思考过程、Markdown、代码块标记或任何额外文本。'
+        : 'You are a professional GitHub repository analysis assistant. Please strictly analyze in the language specified by the user, regardless of the original content language. Please analyze repositories concisely in English, providing practical overviews, category tags, and supported platform types. Only output valid JSON. Do not output thinking process, Markdown, code block markers, or any extra text.';
 
       const content = await this.requestText({
         system,
@@ -383,47 +383,47 @@ ${this.sanitizeForPrompt(readmeContent.substring(0, 2000))}
 
     if (this.language === 'zh') {
       return `
-请分析这个GitHub仓库并提供：
+请分析以下GitHub仓库信息，并只输出合法JSON对象。不要输出思考过程、Markdown、代码块标记、解释或任何额外文本。
 
-1. 一个简洁的中文概述（不超过50字），说明这个仓库的主要功能和用途
-2. 3-5个相关的应用类型标签（用中文，类似应用商店的分类，如：开发工具、Web应用、移动应用、数据库、AI工具等${customCategories ? '，请优先从提供的分类中选择' : ''}）
-3. 支持的平台类型（从以下选择：mac、windows、linux、ios、android、docker、web、cli）
+要求：
+- summary：中文概述，说明仓库的主要功能和用途，不超过50字。
+- tags：3-5个中文应用类型标签${customCategories ? '，请优先从提供的分类中选择' : '，类似应用商店的分类，如：开发工具、Web应用、移动应用、数据库、AI工具等'}。
+- platforms：只能从 ["mac","windows","linux","ios","android","docker","web","cli"] 中选择；无法判断则为 []。
 
-重要：请严格使用中文进行分析和回复，无论原始README是什么语言。
-
-请以JSON格式回复：
+输出格式：
 {
-  "summary": "你的中文概述",
-  "tags": ["标签1", "标签2", "标签3", "标签4", "标签5"],
-  "platforms": ["platform1", "platform2", "platform3"]
+  "summary": "中文概述",
+  "tags": ["标签1", "标签2", "标签3"],
+  "platforms": ["web", "cli"]
 }
+
+平台线索：
+Dockerfile/docker-compose=docker；CLI/命令行/终端=cli；浏览器/前端/API=web；iOS/Swift/Xcode=ios；Android/Kotlin/Gradle=android；macOS/Homebrew=mac；Windows/.exe/MSI=windows；Linux/systemd/apt=linux。
 
 仓库信息：
 ${repoInfo}${categoriesInfo}
-
-重点关注实用性和准确的分类，帮助用户快速理解仓库的用途和支持的平台。
       `.trim();
     } else {
       return `
-Please analyze this GitHub repository and provide:
+Please analyze the following GitHub repository information and only output a valid JSON object. Do not output thinking process, Markdown, code block markers, explanations, or any extra text.
 
-1. A concise English overview (no more than 50 words) explaining the main functionality and purpose of this repository
-2. 3-5 relevant application type tags (in English, similar to app store categories, such as: development tools, web apps, mobile apps, database, AI tools, etc.${customCategories ? ', please prioritize from the provided categories' : ''})
-3. Supported platform types (choose from: mac, windows, linux, ios, android, docker, web, cli)
+Requirements:
+- summary: A concise English overview explaining the main functionality and purpose, no more than 50 words.
+- tags: 3-5 English application type tags${customCategories ? ', please prioritize from the provided categories' : ', similar to app store categories such as: development tools, web apps, mobile apps, database, AI tools, etc.'}.
+- platforms: Must only choose from ["mac","windows","linux","ios","android","docker","web","cli"]; use [] if unable to determine.
 
-Important: Please strictly use English for analysis and response, regardless of the original README language.
-
-Please reply in JSON format:
+Output format:
 {
-  "summary": "Your English overview",
-  "tags": ["tag1", "tag2", "tag3", "tag4", "tag5"],
-  "platforms": ["platform1", "platform2", "platform3"]
+  "summary": "English overview",
+  "tags": ["tag1", "tag2", "tag3"],
+  "platforms": ["web", "cli"]
 }
+
+Platform hints:
+Dockerfile/docker-compose=docker; CLI/command-line/terminal=cli; browser/frontend/API=web; iOS/Swift/Xcode=ios; Android/Kotlin/Gradle=android; macOS/Homebrew=mac; Windows/.exe/MSI=windows; Linux/systemd/apt=linux.
 
 Repository information:
 ${repoInfo}${categoriesInfo}
-
-Focus on practicality and accurate categorization to help users quickly understand the repository's purpose and supported platforms.
       `.trim();
     }
   }


### PR DESCRIPTION
## Summary

- 基于 #174 的反馈，优化默认 AI 分析提示词，减少模型返回思考过程/推理内容的现象
- 在 system prompt 和 user prompt 中明确要求"只输出合法JSON"，禁止输出思考过程、Markdown、代码块等额外文本
- 重构提示词为清晰的 Requirements/输出格式 结构
- 新增平台检测线索（Dockerfile→docker, CLI→cli 等），提升平台识别准确性
- 约束 platforms 字段为显式枚举值，无法判断时使用 `[]`
- 提供具体的 JSON 输出示例替代泛化的占位值

Closes #174

## Test plan

- [ ] 使用默认提示词分析若干仓库，验证 AI 仅返回 JSON 而不包含思考过程
- [ ] 验证设置面板中默认提示词显示与新格式一致
- [ ] 验证自定义提示词仍能正常替换 `{REPO_INFO}`、`{CATEGORIES_INFO}` 占位符
- [ ] 验证平台检测线索对常见仓库类型的识别效果

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced strict JSON-only AI output with a fixed schema (summary, tags, platforms) to remove stray text or formatting.
  * Ensured invalid or unknown platforms are dropped (yielding an empty platforms list when none remain).

* **Enhancements**
  * Standardized and validated platform classification (allowed list, normalization, dedupe, max 8).
  * Improved tag selection and category prioritization, including better handling of custom categories and platform hints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmintaCCCP/GithubStarsManager/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->