### PR TITLE
fix: Release 页面空状态图标居中 & 未读筛选标记已读后不立即消失

### DIFF
--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -57,16 +57,6 @@ export const ReleaseTimeline: React.FC = () => {
   const [isShowModeDropdownOpen, setIsShowModeDropdownOpen] = useState(false);
   const [isMarkingAllRead, setIsMarkingAllRead] = useState(false);
 
-  // 未读模式下，快照当前未读 release ID，避免标记已读后立即消失
-  const unreadSnapshotRef = useRef<Set<number>>(new Set());
-  const updateUnreadSnapshot = useCallback(() => {
-    const ids = new Set<number>();
-    subscribedReleases.forEach(r => {
-      if (!readReleases.has(r.id)) ids.add(r.id);
-    });
-    unreadSnapshotRef.current = ids;
-  }, [subscribedReleases, readReleases]);
-
   // 使用全局状态的别名，保持代码一致性
   const viewMode = releaseViewMode;
   const selectedFilters = releaseSelectedFilters;
@@ -203,6 +193,17 @@ export const ReleaseTimeline: React.FC = () => {
     ),
     [releases, releaseSubscriptions, includePreRelease]
   );
+
+  // 未读模式下，快照当前未读 release ID，避免标记已读后立即消失
+  const unreadSnapshotRef = useRef<Set<number>>(new Set());
+  const updateUnreadSnapshot = useCallback(() => {
+    const state = useAppStore.getState();
+    const ids = new Set<number>();
+    subscribedReleases.forEach(r => {
+      if (!state.readReleases.has(r.id)) ids.add(r.id);
+    });
+    unreadSnapshotRef.current = ids;
+  }, [subscribedReleases]);
 
   // 预计算每个 release 的下载链接和过滤后的链接
   const releasesWithLinks = useMemo(() => {
@@ -388,14 +389,7 @@ export const ReleaseTimeline: React.FC = () => {
 
       // 刷新后更新未读快照，以便"仅未读"模式显示最新状态
       if (releaseShowMode === 'unread') {
-        const state = useAppStore.getState();
-        const snapshot = new Set<number>();
-        state.releases.forEach(r => {
-          if (releaseSubscriptions.has(r.repository?.id) && !state.readReleases.has(r.id)) {
-            snapshot.add(r.id);
-          }
-        });
-        unreadSnapshotRef.current = snapshot;
+        updateUnreadSnapshot();
       }
     } catch (error) {
       console.error('Refresh failed:', error);

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import { Package, Bell, Search, X, RefreshCw, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, LayoutGrid, CalendarDays, ChevronDown, CheckCircle, Filter } from 'lucide-react';
 import { Release } from '../types';
 import { useAppStore } from '../store/useAppStore';
@@ -56,6 +56,16 @@ export const ReleaseTimeline: React.FC = () => {
   const [releaseShowMode, setReleaseShowMode] = useState<'all' | 'unread'>('all');
   const [isShowModeDropdownOpen, setIsShowModeDropdownOpen] = useState(false);
   const [isMarkingAllRead, setIsMarkingAllRead] = useState(false);
+
+  // 未读模式下，快照当前未读 release ID，避免标记已读后立即消失
+  const unreadSnapshotRef = useRef<Set<number>>(new Set());
+  const updateUnreadSnapshot = useCallback(() => {
+    const ids = new Set<number>();
+    subscribedReleases.forEach(r => {
+      if (!readReleases.has(r.id)) ids.add(r.id);
+    });
+    unreadSnapshotRef.current = ids;
+  }, [subscribedReleases, readReleases]);
 
   // 使用全局状态的别名，保持代码一致性
   const viewMode = releaseViewMode;
@@ -241,13 +251,13 @@ export const ReleaseTimeline: React.FC = () => {
       }));
   }, [releasesWithLinks, searchQuery, selectedFilters]);
 
-  // 未读模式过滤
+  // 未读模式过滤（使用快照，标记已读后不会立即消失，刷新页面后才更新）
   const filteredReleases = useMemo(() => {
     if (releaseShowMode === 'unread') {
-      return preUnreadFilteredReleases.filter(({ release }) => !readReleases.has(release.id));
+      return preUnreadFilteredReleases.filter(({ release }) => unreadSnapshotRef.current.has(release.id));
     }
     return preUnreadFilteredReleases;
-  }, [preUnreadFilteredReleases, releaseShowMode, readReleases]);
+  }, [preUnreadFilteredReleases, releaseShowMode]);
 
   const unreadCount = useMemo(() => {
     return subscribedReleases.filter(r => !readReleases.has(r.id)).length;
@@ -375,6 +385,18 @@ export const ReleaseTimeline: React.FC = () => {
       }
 
       toast(message, actuallyNewCount > 0 ? 'success' : 'info');
+
+      // 刷新后更新未读快照，以便"仅未读"模式显示最新状态
+      if (releaseShowMode === 'unread') {
+        const state = useAppStore.getState();
+        const snapshot = new Set<number>();
+        state.releases.forEach(r => {
+          if (releaseSubscriptions.has(r.repository?.id) && !state.readReleases.has(r.id)) {
+            snapshot.add(r.id);
+          }
+        });
+        unreadSnapshotRef.current = snapshot;
+      }
     } catch (error) {
       console.error('Refresh failed:', error);
       const errorMessage = language === 'zh'
@@ -387,6 +409,9 @@ export const ReleaseTimeline: React.FC = () => {
   };
 
   const handleShowModeChange = (mode: 'all' | 'unread') => {
+    if (mode === 'unread') {
+      updateUnreadSnapshot();
+    }
     setReleaseShowMode(mode);
     setCurrentPage(1);
     setIsShowModeDropdownOpen(false);
@@ -920,7 +945,7 @@ export const ReleaseTimeline: React.FC = () => {
        <div className="space-y-2">
          {paginatedReleases.length === 0 ? (
            <div className="text-center py-12 bg-light-bg dark:bg-panel-dark/50 rounded-xl border-2 border-dashed border-black/[0.06]-alt dark:border-white/[0.04]">
-            <Package className="w-12 h-12 text-gray-400 dark:text-text-secondarymx-auto mb-3" />
+            <Package className="w-12 h-12 text-gray-400 dark:text-text-secondary mx-auto mb-3" />
             <h3 className="text-lg font-medium text-gray-900 dark:text-text-secondary mb-1">
               {releaseShowMode === 'unread'
                 ? t('没有未读的 Release', 'No unread releases')

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -40,6 +40,8 @@ export const ReleaseTimeline: React.FC = () => {
     setReleaseIsRefreshing,
     includePreRelease,
     setIncludePreRelease,
+    releaseShowMode,
+    setReleaseShowMode,
   } = useAppStore();
 
   const { toast, confirm } = useDialog();
@@ -53,7 +55,6 @@ export const ReleaseTimeline: React.FC = () => {
   const [fullContentReleases, setFullContentReleases] = useState<Set<number>>(new Set());
   // 视图切换下拉菜单状态（本地UI状态）
   const [isViewDropdownOpen, setIsViewDropdownOpen] = useState(false);
-  const [releaseShowMode, setReleaseShowMode] = useState<'all' | 'unread'>('all');
   const [isShowModeDropdownOpen, setIsShowModeDropdownOpen] = useState(false);
   const [isMarkingAllRead, setIsMarkingAllRead] = useState(false);
 

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -209,7 +209,7 @@ export const ReleaseTimeline: React.FC = () => {
       }
     });
     unreadSnapshotRef.current = ids;
-  }, [releases, releaseSubscriptions, includePreRelease, readReleases]);
+  }, [releases, releaseSubscriptions, includePreRelease, releaseShowMode]);
 
   // 预计算每个 release 的下载链接和过滤后的链接
   const releasesWithLinks = useMemo(() => {

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -195,15 +195,20 @@ export const ReleaseTimeline: React.FC = () => {
   );
 
   // 未读模式下，快照当前未读 release ID，避免标记已读后立即消失
+  // 依赖项变化时自动重建快照（releases 刷新、标记已读等）
   const unreadSnapshotRef = useRef<Set<number>>(new Set());
-  const updateUnreadSnapshot = useCallback(() => {
+  useEffect(() => {
     const state = useAppStore.getState();
     const ids = new Set<number>();
-    subscribedReleases.forEach(r => {
-      if (!state.readReleases.has(r.id)) ids.add(r.id);
+    releases.forEach(r => {
+      if (releaseSubscriptions.has(r.repository.id) &&
+          (includePreRelease || !r.prerelease) &&
+          !state.readReleases.has(r.id)) {
+        ids.add(r.id);
+      }
     });
     unreadSnapshotRef.current = ids;
-  }, [subscribedReleases]);
+  }, [releases, releaseSubscriptions, includePreRelease, readReleases]);
 
   // 预计算每个 release 的下载链接和过滤后的链接
   const releasesWithLinks = useMemo(() => {
@@ -386,11 +391,6 @@ export const ReleaseTimeline: React.FC = () => {
       }
 
       toast(message, actuallyNewCount > 0 ? 'success' : 'info');
-
-      // 刷新后更新未读快照，以便"仅未读"模式显示最新状态
-      if (releaseShowMode === 'unread') {
-        updateUnreadSnapshot();
-      }
     } catch (error) {
       console.error('Refresh failed:', error);
       const errorMessage = language === 'zh'
@@ -403,9 +403,6 @@ export const ReleaseTimeline: React.FC = () => {
   };
 
   const handleShowModeChange = (mode: 'all' | 'unread') => {
-    if (mode === 'unread') {
-      updateUnreadSnapshot();
-    }
     setReleaseShowMode(mode);
     setCurrentPage(1);
     setIsShowModeDropdownOpen(false);

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -196,8 +196,9 @@ export const ReleaseTimeline: React.FC = () => {
   );
 
   // 未读模式下，快照当前未读 release ID，避免标记已读后立即消失
-  // 依赖项变化时自动重建快照（releases 刷新、标记已读等）
+  // 不依赖 readReleases，避免标记已读时重建快照导致列表项立即消失
   const unreadSnapshotRef = useRef<Set<number>>(new Set());
+  const [snapshotVersion, setSnapshotVersion] = useState(0);
   useEffect(() => {
     const state = useAppStore.getState();
     const ids = new Set<number>();
@@ -209,6 +210,7 @@ export const ReleaseTimeline: React.FC = () => {
       }
     });
     unreadSnapshotRef.current = ids;
+    setSnapshotVersion(v => v + 1);
   }, [releases, releaseSubscriptions, includePreRelease, releaseShowMode]);
 
   // 预计算每个 release 的下载链接和过滤后的链接
@@ -264,7 +266,9 @@ export const ReleaseTimeline: React.FC = () => {
       return preUnreadFilteredReleases.filter(({ release }) => unreadSnapshotRef.current.has(release.id));
     }
     return preUnreadFilteredReleases;
-  }, [preUnreadFilteredReleases, releaseShowMode]);
+    // snapshotVersion 触发快照更新后重算；readReleases 不在此处以避免标记已读立即消失
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [preUnreadFilteredReleases, releaseShowMode, snapshotVersion]);
 
   const unreadCount = useMemo(() => {
     return subscribedReleases.filter(r => !readReleases.has(r.id)).length;

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -174,6 +174,7 @@ interface AppActions {
 
   // Release Timeline View actions
   setReleaseViewMode: (mode: 'timeline' | 'repository') => void;
+  setReleaseShowMode: (mode: 'all' | 'unread') => void;
   setReleaseSelectedFilters: (filters: string[]) => void;
   toggleReleaseSelectedFilter: (filterId: string) => void;
   clearReleaseSelectedFilters: () => void;

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -262,6 +262,7 @@ type PersistedAppState = Partial<
     | 'forkSearchQuery'
     | 'forkExpandedRepositories'
     | 'releaseViewMode'
+    | 'releaseShowMode'
     | 'releaseSelectedFilters'
     | 'releaseSearchQuery'
     | 'includePreRelease'
@@ -381,6 +382,7 @@ const normalizePersistedState = (
     language: safePersisted.language || 'zh',
     isAuthenticated: !!(safePersisted.user && safePersisted.githubToken),
     releaseViewMode: safePersisted.releaseViewMode || 'timeline',
+    releaseShowMode: safePersisted.releaseShowMode === 'unread' ? 'unread' : 'all',
     releaseSelectedFilters: Array.isArray(safePersisted.releaseSelectedFilters) ? safePersisted.releaseSelectedFilters : [],
     releaseSearchQuery: typeof safePersisted.releaseSearchQuery === 'string' ? safePersisted.releaseSearchQuery : '',
     discoveryChannels: (() => {
@@ -738,6 +740,7 @@ export const useAppStore = create<AppState & AppActions>()(
       isSidebarCollapsed: false,
       readmeModalOpen: false,
       releaseViewMode: 'timeline',
+      releaseShowMode: 'all',
       releaseSelectedFilters: [],
       releaseSearchQuery: '',
       releaseExpandedRepositories: new Set<number>(),
@@ -1265,6 +1268,7 @@ export const useAppStore = create<AppState & AppActions>()(
 
       // Release Timeline View actions
       setReleaseViewMode: (releaseViewMode) => set({ releaseViewMode }),
+      setReleaseShowMode: (releaseShowMode) => set({ releaseShowMode }),
       setReleaseSelectedFilters: (releaseSelectedFilters) => set({ releaseSelectedFilters }),
       toggleReleaseSelectedFilter: (filterId) => set((state) => ({
         releaseSelectedFilters: state.releaseSelectedFilters.includes(filterId)
@@ -1474,6 +1478,7 @@ export const useAppStore = create<AppState & AppActions>()(
 
         // 持久化Release页面视图设置
         releaseViewMode: state.releaseViewMode,
+        releaseShowMode: state.releaseShowMode,
         releaseSelectedFilters: state.releaseSelectedFilters,
         releaseSearchQuery: state.releaseSearchQuery,
         releaseExpandedRepositories: Array.from(state.releaseExpandedRepositories),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -275,6 +275,7 @@ export interface AppState {
 
   // Release Timeline View
   releaseViewMode: 'timeline' | 'repository';
+  releaseShowMode: 'all' | 'unread';
   releaseSelectedFilters: string[];
   releaseSearchQuery: string;
   releaseExpandedRepositories: Set<number>;


### PR DESCRIPTION
## 修复内容

### 1. 空状态图标未居中
 图标的 className 中  缺少空格，导致  无法生效，图标贴到了容器左侧。

**修复**: 补上空格 → 

### 2. 仅未读模式标记已读后列表项立即消失
在未读筛选模式下，点击列表项标记已读后，该项会瞬间从列表中消失，用户无法继续操作。

**修复**: 引入  快照机制：
- 切换到仅未读模式时，快照当前未读 release ID
-  基于快照过滤，而非实时 
- 标记已读后项保持显示，直到刷新页面或重新切换模式时才更新
-  完成后自动更新快照

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent release view toggle to switch between "All" and "Unread" releases, restored across sessions.

* **Bug Fixes**
  * Stabilized unread filtering so the unread view remains consistent after reads and data refreshes.
  * Fixed empty-state placeholder spacing so the icon displays correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmintaCCCP/GithubStarsManager/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->