### PR TITLE
fix: tooltip stuck on hover and dual-tooltip overlap on trends page

### DIFF
--- a/src/components/FloatingTooltip.tsx
+++ b/src/components/FloatingTooltip.tsx
@@ -29,6 +29,7 @@ export const FloatingTooltip: React.FC<FloatingTooltipProps> = ({
 }) => {
   const tooltipRef = useRef<HTMLDivElement>(null);
   const rafRef = useRef<number>(0);
+  const lastPointerRef = useRef<{ x: number; y: number } | null>(null);
 
   const updatePosition = useCallback(() => {
     if (!triggerRef.current || !tooltipRef.current || !visible) return;
@@ -77,32 +78,49 @@ export const FloatingTooltip: React.FC<FloatingTooltipProps> = ({
   // (e.g., portal gap, fast mouse movement, scroll repositioning).
   // Uses a debounce so the pointer can travel through the gap between
   // trigger and tooltip without premature dismissal.
+  // Also re-checks on scroll/resize using the last known pointer coordinates,
+  // so a stationary pointer that scrolls out of range still triggers dismissal.
   useEffect(() => {
     if (!visible) return;
 
     let rafId = 0;
     let awayTimer = 0;
-    const handlePointerMove = (e: PointerEvent) => {
-      cancelAnimationFrame(rafId);
-      rafId = requestAnimationFrame(() => {
-        const nearTrigger = isPointerNear(triggerRef.current, e.clientX, e.clientY, 10);
-        const nearTooltip = isPointerNear(tooltipRef.current, e.clientX, e.clientY, 10);
-        if (!nearTrigger && !nearTooltip) {
-          if (!awayTimer) {
-            awayTimer = window.setTimeout(() => onMouseLeave(), 100);
-          }
-        } else {
-          clearTimeout(awayTimer);
-          awayTimer = 0;
+
+    const checkPointer = (x: number, y: number) => {
+      const nearTrigger = isPointerNear(triggerRef.current, x, y, 10);
+      const nearTooltip = isPointerNear(tooltipRef.current, x, y, 10);
+      if (!nearTrigger && !nearTooltip) {
+        if (!awayTimer) {
+          awayTimer = window.setTimeout(() => onMouseLeave(), 100);
         }
-      });
+      } else {
+        clearTimeout(awayTimer);
+        awayTimer = 0;
+      }
+    };
+
+    const handlePointerMove = (e: PointerEvent) => {
+      lastPointerRef.current = { x: e.clientX, y: e.clientY };
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(() => checkPointer(e.clientX, e.clientY));
+    };
+
+    const handleViewportChange = () => {
+      const point = lastPointerRef.current;
+      if (!point) return;
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(() => checkPointer(point.x, point.y));
     };
 
     document.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('scroll', handleViewportChange, true);
+    window.addEventListener('resize', handleViewportChange);
     return () => {
       cancelAnimationFrame(rafId);
       clearTimeout(awayTimer);
       document.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('scroll', handleViewportChange, true);
+      window.removeEventListener('resize', handleViewportChange);
     };
   }, [visible, onMouseLeave, triggerRef]);
 

--- a/src/components/FloatingTooltip.tsx
+++ b/src/components/FloatingTooltip.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect, useRef, useCallback } from 'react';
+import React, { useLayoutEffect, useRef, useCallback, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 
 interface FloatingTooltipProps {
@@ -7,6 +7,17 @@ interface FloatingTooltipProps {
   triggerRef: React.RefObject<HTMLElement | null>;
   onMouseLeave: () => void;
   onMouseEnter?: () => void;
+}
+
+function isPointerNear(el: HTMLElement | null, x: number, y: number, padding: number): boolean {
+  if (!el) return false;
+  const rect = el.getBoundingClientRect();
+  return (
+    x >= rect.left - padding &&
+    x <= rect.right + padding &&
+    y >= rect.top - padding &&
+    y <= rect.bottom + padding
+  );
 }
 
 export const FloatingTooltip: React.FC<FloatingTooltipProps> = ({
@@ -60,6 +71,40 @@ export const FloatingTooltip: React.FC<FloatingTooltipProps> = ({
       };
     }
   }, [visible, updatePosition]);
+
+  // Safety net: detect when pointer is far from both trigger and tooltip,
+  // covering edge cases where mouseenter/mouseleave events don't fire correctly
+  // (e.g., portal gap, fast mouse movement, scroll repositioning).
+  // Uses a debounce so the pointer can travel through the gap between
+  // trigger and tooltip without premature dismissal.
+  useEffect(() => {
+    if (!visible) return;
+
+    let rafId = 0;
+    let awayTimer = 0;
+    const handlePointerMove = (e: PointerEvent) => {
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(() => {
+        const nearTrigger = isPointerNear(triggerRef.current, e.clientX, e.clientY, 10);
+        const nearTooltip = isPointerNear(tooltipRef.current, e.clientX, e.clientY, 10);
+        if (!nearTrigger && !nearTooltip) {
+          if (!awayTimer) {
+            awayTimer = window.setTimeout(() => onMouseLeave(), 100);
+          }
+        } else {
+          clearTimeout(awayTimer);
+          awayTimer = 0;
+        }
+      });
+    };
+
+    document.addEventListener('pointermove', handlePointerMove);
+    return () => {
+      cancelAnimationFrame(rafId);
+      clearTimeout(awayTimer);
+      document.removeEventListener('pointermove', handlePointerMove);
+    };
+  }, [visible, onMouseLeave, triggerRef]);
 
   if (!visible) return null;
 

--- a/src/components/SubscriptionRepoCard.tsx
+++ b/src/components/SubscriptionRepoCard.tsx
@@ -44,15 +44,25 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
   const [aiTooltip, setAiTooltip] = useState(false);
   const descTriggerRef = useRef<HTMLDivElement>(null);
   const aiTriggerRef = useRef<HTMLDivElement>(null);
-  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const descHideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const aiHideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const scheduleHide = useCallback((setter: (v: boolean) => void) => {
-    if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
-    hideTimerRef.current = setTimeout(() => setter(false), 150);
+  const scheduleHideDesc = useCallback(() => {
+    if (descHideTimerRef.current) clearTimeout(descHideTimerRef.current);
+    descHideTimerRef.current = setTimeout(() => setDescTooltip(false), 150);
   }, []);
 
-  const cancelHide = useCallback(() => {
-    if (hideTimerRef.current) clearTimeout(hideTimerRef.current);
+  const cancelHideDesc = useCallback(() => {
+    if (descHideTimerRef.current) clearTimeout(descHideTimerRef.current);
+  }, []);
+
+  const scheduleHideAi = useCallback(() => {
+    if (aiHideTimerRef.current) clearTimeout(aiHideTimerRef.current);
+    aiHideTimerRef.current = setTimeout(() => setAiTooltip(false), 150);
+  }, []);
+
+  const cancelHideAi = useCallback(() => {
+    if (aiHideTimerRef.current) clearTimeout(aiHideTimerRef.current);
   }, []);
 
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -60,6 +70,8 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
   useEffect(() => {
     return () => {
       abortControllerRef.current?.abort();
+      if (descHideTimerRef.current) clearTimeout(descHideTimerRef.current);
+      if (aiHideTimerRef.current) clearTimeout(aiHideTimerRef.current);
     };
   }, []);
   
@@ -421,10 +433,10 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
             <div
               ref={descTriggerRef}
               className="relative mb-3"
-              onMouseEnter={() => { cancelHide(); setDescTooltip(true); }}
-              onMouseLeave={() => scheduleHide(setDescTooltip)}
-              onFocus={() => { cancelHide(); setDescTooltip(true); }}
-              onBlur={() => scheduleHide(setDescTooltip)}
+              onMouseEnter={() => { cancelHideDesc(); setDescTooltip(true); }}
+              onMouseLeave={scheduleHideDesc}
+              onFocus={() => { cancelHideDesc(); setDescTooltip(true); }}
+              onBlur={scheduleHideDesc}
               onTouchStart={() => setDescTooltip((v) => !v)}
               tabIndex={0}
             >
@@ -435,8 +447,8 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
                 content={repo.description}
                 visible={descTooltip}
                 triggerRef={descTriggerRef}
-                onMouseEnter={() => { cancelHide(); }}
-                onMouseLeave={() => scheduleHide(setDescTooltip)}
+                onMouseEnter={cancelHideDesc}
+                onMouseLeave={scheduleHideDesc}
               />
             </div>
           )}
@@ -446,10 +458,10 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
             <div
               ref={aiTriggerRef}
               className="relative flex items-start gap-1.5 mb-3"
-              onMouseEnter={() => { cancelHide(); setAiTooltip(true); }}
-              onMouseLeave={() => scheduleHide(setAiTooltip)}
-              onFocus={() => { cancelHide(); setAiTooltip(true); }}
-              onBlur={() => scheduleHide(setAiTooltip)}
+              onMouseEnter={() => { cancelHideAi(); setAiTooltip(true); }}
+              onMouseLeave={scheduleHideAi}
+              onFocus={() => { cancelHideAi(); setAiTooltip(true); }}
+              onBlur={scheduleHideAi}
               onTouchStart={() => setAiTooltip((v) => !v)}
               tabIndex={0}
             >
@@ -461,8 +473,8 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
                 content={repo.ai_summary}
                 visible={aiTooltip}
                 triggerRef={aiTriggerRef}
-                onMouseEnter={() => { cancelHide(); }}
-                onMouseLeave={() => scheduleHide(setAiTooltip)}
+                onMouseEnter={cancelHideAi}
+                onMouseLeave={scheduleHideAi}
               />
             </div>
           )}


### PR DESCRIPTION
## 问题

仓库描述和趋势描述（原始描述与 AI 分析）的 tooltip 存在两个问题：

1. **Tooltip 悬停后不消失** — FloatingTooltip 基于 portal 渲染，与 trigger 之间有 8px 间隙。鼠标快速移动或页面滚动时，mouseenter/mouseleave 事件可能未正确触发，导致 tooltip 卡住不消失。
2. **趋势页两个 tooltip 同时显示** — SubscriptionRepoCard 中描述 tooltip 和 AI 摘要 tooltip 共用同一个 hideTimerRef，当 cancelHide() 被其中一个 tooltip 调用时，会清除另一个 tooltip 的隐藏定时器，导致两者同时显示。

## 修复

### FloatingTooltip.tsx — 指针距离安全网
- 新增 pointermove 监听器，通过 requestAnimationFrame 节流检测指针是否同时远离 trigger 和 tooltip
- 使用 100ms 防抖：指针离开两个区域后等待 100ms 才触发 onMouseLeave，避免鼠标在间隙中穿行时误触发
- 10px 容差匹配 tooltip 自身 8px 偏移量，适配高 DPI 屏幕

### SubscriptionRepoCard.tsx — 独立隐藏定时器
- 将共享的 hideTimerRef 拆分为 descHideTimerRef 和 aiHideTimerRef
- 每个 tooltip 拥有独立的 scheduleHide/cancelHide 函数，互不干扰
- 组件卸载时清理待执行的定时器


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip dismissal so tooltips no longer disappear when moving the pointer between a trigger and its tooltip.
  * Tooltips now re-check proximity on scroll/resize to avoid unexpected closes.

* **Refactor**
  * Repository cards now manage description and AI summary tooltips independently, giving more consistent hover/focus behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmintaCCCP/GithubStarsManager/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->