### PR TITLE
fix: tooltip 文字显示不全

### DIFF
--- a/src/components/FloatingTooltip.tsx
+++ b/src/components/FloatingTooltip.tsx
@@ -38,10 +38,8 @@ export const FloatingTooltip: React.FC<FloatingTooltipProps> = ({
     const tooltipEl = tooltipRef.current;
 
     const tooltipHeight = tooltipEl.offsetHeight;
-    const tooltipWidth = triggerRect.width;
 
     const top = triggerRect.top - tooltipHeight - 8;
-    const left = triggerRect.left;
 
     if (top < 8) {
       tooltipEl.style.top = `${triggerRect.bottom + 8}px`;
@@ -51,8 +49,7 @@ export const FloatingTooltip: React.FC<FloatingTooltipProps> = ({
       tooltipEl.style.bottom = 'auto';
     }
 
-    tooltipEl.style.left = `${left}px`;
-    tooltipEl.style.width = `${tooltipWidth}px`;
+    tooltipEl.style.left = `${triggerRect.left}px`;
   }, [triggerRef, visible]);
 
   useLayoutEffect(() => {
@@ -130,7 +127,7 @@ export const FloatingTooltip: React.FC<FloatingTooltipProps> = ({
       ref={tooltipRef}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
-      className="fixed z-[9999] p-4 bg-white dark:bg-surface-3 text-gray-900 dark:text-text-primary text-[13px] leading-[1.625] rounded-xl shadow-dialog border border-gray-200/80 dark:border-white/[0.04] animate-fade-in max-h-[300px] overflow-y-auto scrollbar-auto"
+      className="fixed z-[9999] p-4 bg-white dark:bg-surface-3 text-gray-900 dark:text-text-primary text-[13px] leading-[1.625] rounded-xl shadow-dialog border border-gray-200/80 dark:border-white/[0.04] animate-fade-in max-w-[480px]"
       style={{ pointerEvents: 'auto' }}
     >
       <div className="whitespace-pre-wrap break-words pr-2">

--- a/src/components/FloatingTooltip.tsx
+++ b/src/components/FloatingTooltip.tsx
@@ -130,7 +130,7 @@ export const FloatingTooltip: React.FC<FloatingTooltipProps> = ({
       ref={tooltipRef}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
-      className="fixed z-[9999] p-4 bg-white dark:bg-surface-3 text-gray-900 dark:text-text-primary text-[13px] leading-[1.625] rounded-xl shadow-dialog border border-gray-200/80 dark:border-white/[0.04] animate-fade-in"
+      className="fixed z-[9999] p-4 bg-white dark:bg-surface-3 text-gray-900 dark:text-text-primary text-[13px] leading-[1.625] rounded-xl shadow-dialog border border-gray-200/80 dark:border-white/[0.04] animate-fade-in max-h-[300px] overflow-y-auto scrollbar-auto"
       style={{ pointerEvents: 'auto' }}
     >
       <div className="whitespace-pre-wrap break-words pr-2">

--- a/src/components/FloatingTooltip.tsx
+++ b/src/components/FloatingTooltip.tsx
@@ -37,7 +37,6 @@ export const FloatingTooltip: React.FC<FloatingTooltipProps> = ({
     const triggerRect = triggerRef.current.getBoundingClientRect();
     const tooltipEl = tooltipRef.current;
 
-    tooltipEl.style.maxHeight = '280px';
     const tooltipHeight = tooltipEl.offsetHeight;
     const tooltipWidth = triggerRect.width;
 
@@ -131,7 +130,7 @@ export const FloatingTooltip: React.FC<FloatingTooltipProps> = ({
       ref={tooltipRef}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
-      className="fixed z-[9999] p-4 bg-white dark:bg-surface-3 text-gray-900 dark:text-text-primary text-[13px] leading-[1.625] rounded-xl shadow-dialog border border-gray-200/80 dark:border-white/[0.04] animate-fade-in max-h-[280px] overflow-y-auto scrollbar-auto"
+      className="fixed z-[9999] p-4 bg-white dark:bg-surface-3 text-gray-900 dark:text-text-primary text-[13px] leading-[1.625] rounded-xl shadow-dialog border border-gray-200/80 dark:border-white/[0.04] animate-fade-in"
       style={{ pointerEvents: 'auto' }}
     >
       <div className="whitespace-pre-wrap break-words pr-2">

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -538,7 +538,7 @@ ${this.sanitizeForPrompt(readmeContent.substring(0, 2000))}
 请分析以下GitHub仓库信息，并只输出合法JSON对象。不要输出思考过程、Markdown、代码块标记、解释或任何额外文本。
 
 要求：
-- summary：中文概述，说明仓库的主要功能和用途，不超过50字。
+- summary：中文概述，说明仓库的主要功能和用途，不超过200字。
 - tags：3-5个中文应用类型标签${customCategories && customCategories.length > 0 ? '，请优先从上方的可用分类中选择' : '，类似应用商店的分类，如：开发工具、Web应用、移动应用、数据库、AI工具等'}。${categoriesLine}
 - platforms：只能从 ["mac","windows","linux","ios","android","docker","web","cli"] 中选择；无法判断则为 []。
 
@@ -563,7 +563,7 @@ ${repoInfo}
 Please analyze the following GitHub repository information and only output a valid JSON object. Do not output thinking process, Markdown, code block markers, explanations, or any extra text.
 
 Requirements:
-- summary: A concise English overview explaining the main functionality and purpose, no more than 50 words.
+- summary: A concise English overview explaining the main functionality and purpose, no more than 200 words.
 - tags: 3-5 English application type tags${customCategories && customCategories.length > 0 ? ', please prioritize from the available categories above' : ', similar to app store categories such as: development tools, web apps, mobile apps, database, AI tools, etc.'}.${categoriesLine}
 - platforms: Must only choose from ["mac","windows","linux","ios","android","docker","web","cli"]; use [] if unable to determine.
 
@@ -614,7 +614,7 @@ ${repoInfo}
       }
 
       return {
-        summary: cleaned.substring(0, 50) + (cleaned.length > 50 ? '...' : ''),
+        summary: cleaned.substring(0, 500) + (cleaned.length > 500 ? '...' : ''),
         tags: [],
         platforms: [],
       };


### PR DESCRIPTION
## 问题
Tooltip 的 `max-h-[280px]` 硬编码高度限制导致长文本（如 AI 分析描述）被截断，用户无法查看完整内容。(#165)

## 修复
移除 `FloatingTooltip` 中 JS 和 CSS 两处 maxHeight 约束，让 tooltip 按内容实际行数自动撑开高度。

### 改动
- `src/components/FloatingTooltip.tsx`
  - 移除 `tooltipEl.style.maxHeight = '280px'`（JS 层）
  - 移除 `max-h-[280px] overflow-y-auto scrollbar-auto`（CSS 层）

### 效果
- 短文本：tooltip 一行/两行高度，紧凑显示
- 长文本：tooltip 完整展开，不再截断

Fixes #165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tooltips now size and position using their natural rendered height; removed forced inline height and internal vertical scrolling so taller content displays correctly while width is capped.
* **New Features / Improvements**
  * AI-generated analysis now returns longer summaries (Chinese and English), with a longer fallback snippet when parsing fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->