### PR TITLE
fix: AI分析摘要截断问题

### DIFF
--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -538,7 +538,7 @@ ${this.sanitizeForPrompt(readmeContent.substring(0, 2000))}
 请分析以下GitHub仓库信息，并只输出合法JSON对象。不要输出思考过程、Markdown、代码块标记、解释或任何额外文本。
 
 要求：
-- summary：中文概述，说明仓库的主要功能和用途，不超过50字。
+- summary：中文概述，说明仓库的主要功能和用途，不超过200字。
 - tags：3-5个中文应用类型标签${customCategories && customCategories.length > 0 ? '，请优先从上方的可用分类中选择' : '，类似应用商店的分类，如：开发工具、Web应用、移动应用、数据库、AI工具等'}。${categoriesLine}
 - platforms：只能从 ["mac","windows","linux","ios","android","docker","web","cli"] 中选择；无法判断则为 []。
 
@@ -563,7 +563,7 @@ ${repoInfo}
 Please analyze the following GitHub repository information and only output a valid JSON object. Do not output thinking process, Markdown, code block markers, explanations, or any extra text.
 
 Requirements:
-- summary: A concise English overview explaining the main functionality and purpose, no more than 50 words.
+- summary: A concise English overview explaining the main functionality and purpose, no more than 200 words.
 - tags: 3-5 English application type tags${customCategories && customCategories.length > 0 ? ', please prioritize from the available categories above' : ', similar to app store categories such as: development tools, web apps, mobile apps, database, AI tools, etc.'}.${categoriesLine}
 - platforms: Must only choose from ["mac","windows","linux","ios","android","docker","web","cli"]; use [] if unable to determine.
 
@@ -614,7 +614,7 @@ ${repoInfo}
       }
 
       return {
-        summary: cleaned.substring(0, 50) + (cleaned.length > 50 ? '...' : ''),
+        summary: cleaned.substring(0, 500) + (cleaned.length > 500 ? '...' : ''),
         tags: [],
         platforms: [],
       };


### PR DESCRIPTION
## 问题
AI分析完成后，tooltip只显示几个字就截断了，例如"我们分析仓库信息：仓库名称Prsedion-fan/linux-0.11-rs,描述我是Linux 0..."，后面大量空白。(#165)

## 根因
问题不在tooltip组件，而在**AI分析逻辑**：

1. **Prompt限制**（aiService.ts 第541/566行）：`不超过50字` — AI被告知只写50字
2. **兜底截断**（aiService.ts 第617行）：`cleaned.substring(0, 50) + '...'` — JSON解析失败时原始回复被截到50字符

用户看到的 `"我们分析仓库信息：..."` 就是第二种情况——AI没返回标准JSON，整个回复被50字符截断。

## 修复
| 改动 | 原值 | 新值 |
|---|---|---|
| Prompt限制（中/英文） | 50字 | 200字 |
| 兜底截断 | 50字符 | 500字符 |
| Tooltip maxHeight | 280px | 移除 |
| Tooltip width | = trigger宽度 | max-w-[480px]自适应 |

Fixes #165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Increased maximum length constraints for AI-generated summaries, allowing for more detailed content.
  * Enhanced fallback summary generation to provide longer summaries when AI processing is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->