### PR TITLE
fix: 代理开关状态切换页面后不保存 (#183)

### DIFF
--- a/src/components/settings/NetworkPanel.tsx
+++ b/src/components/settings/NetworkPanel.tsx
@@ -119,7 +119,31 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
           role="switch"
           aria-checked={form.enabled}
           aria-label={t('启用网络代理', 'Enable network proxy')}
-          onClick={() => setForm({ ...form, enabled: !form.enabled })}
+          onClick={async () => {
+            const newEnabled = !form.enabled;
+            const newForm = { ...form, enabled: newEnabled };
+            setForm(newForm);
+            // 立即持久化 enabled 状态，无需用户手动点击保存
+            setProxyConfig({ enabled: newEnabled });
+            // 同步到后端
+            if (backend.isAvailable) {
+              try {
+                const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
+                if (backendApiSecret) {
+                  authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
+                }
+                await fetch('/api/settings/proxy', {
+                  method: 'PUT',
+                  headers: authHeaders,
+                  body: JSON.stringify({ ...proxyConfig, enabled: newEnabled }),
+                });
+              } catch { /* best effort */ }
+            }
+            // 同步到 Electron
+            if (isElectron()) {
+              try { await electronProxy.setProxy(newForm); } catch { /* best effort */ }
+            }
+          }}
           className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${form.enabled ? 'bg-brand-indigo' : 'bg-gray-300 dark:bg-gray-600'}`}
         >
           <span

--- a/src/components/settings/NetworkPanel.tsx
+++ b/src/components/settings/NetworkPanel.tsx
@@ -120,11 +120,10 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
           aria-checked={form.enabled}
           aria-label={t('启用网络代理', 'Enable network proxy')}
           onClick={async () => {
-            const newEnabled = !form.enabled;
-            const newForm = { ...form, enabled: newEnabled };
+            const newForm = { ...form, enabled: !form.enabled };
             setForm(newForm);
-            // 立即持久化 enabled 状态，无需用户手动点击保存
-            setProxyConfig({ enabled: newEnabled });
+            // 立即持久化，无需用户手动点击保存
+            setProxyConfig(newForm);
             // 同步到后端
             if (backend.isAvailable) {
               try {
@@ -135,7 +134,7 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
                 await fetch('/api/settings/proxy', {
                   method: 'PUT',
                   headers: authHeaders,
-                  body: JSON.stringify({ ...proxyConfig, enabled: newEnabled }),
+                  body: JSON.stringify(newForm),
                 });
               } catch { /* best effort */ }
             }


### PR DESCRIPTION
## 问题

设置 → 网络设置 → 代理开关一旦开启后无法关闭。关闭开关后切到别的页面再切回来，开关仍然显示打开状态。

## 根因

代理开关的  只更新了本地 React state（），没有将  状态持久化到 Zustand store。用户需要手动点击「保存」按钮才会生效，但 toggle 开关的 UX 语义是即时生效的。

## 修复

修改 toggle 的  处理器，在切换时立即同步  状态到：

- **本地 form state**（）— 即时视觉反馈
- **Zustand store**（）— 页面切换后状态不丢失
- **后端**（）— 保持服务端代理配置一致
- **Electron 主进程**（）— 保持 Electron 代理配置一致

所有远程同步均为 best-effort，不会因网络问题阻塞 UI。

Fixes #183

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Network panel toggles now persist immediately when changed, removing the need for a separate save action.
  * Changes are now propagated automatically with best-effort synchronization to remote and system configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->