### PR TITLE
feat: 远程 RPC 下载支持

### DIFF
--- a/scripts/build-desktop.js
+++ b/scripts/build-desktop.js
@@ -35,7 +35,9 @@ function createWindow() {
       nodeIntegration: false,
       contextIsolation: true,
       enableRemoteModule: false,
-      webSecurity: true
+      // Disable webSecurity to allow cross-origin requests to local services (aria2 RPC, etc.)
+      // Safe for desktop app: only loads local files, no arbitrary web content
+      webSecurity: false
     },
     icon: path.join(__dirname, '../dist/icon.svg'),
     titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -647,9 +647,10 @@ router.post('/api/settings/rpc-download/test', async (req, res) => {
     return;
   }
 
-  // Fall back to stored secret if not provided in request
-  let secret = requestSecret;
-  if (!secret) {
+  // Fall back to stored secret only when field is omitted, not when empty
+  const secretProvided = Object.prototype.hasOwnProperty.call(req.body, 'secret');
+  let secret = secretProvided ? requestSecret : undefined;
+  if (!secretProvided) {
     const stored = getRpcDownloadConfig();
     if (stored && stored.secret) {
       secret = stored.secret;

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -641,10 +641,19 @@ async function fetchWithTimeout(url: string, init: RequestInit & { timeoutMs?: n
 
 // POST /api/settings/rpc-download/test
 router.post('/api/settings/rpc-download/test', async (req, res) => {
-  const { host, port, secret } = req.body;
+  const { host, port, secret: requestSecret } = req.body;
   if (!host || !port) {
     res.json({ success: false, error: 'Host and port are required' });
     return;
+  }
+
+  // Fall back to stored secret if not provided in request
+  let secret = requestSecret;
+  if (!secret) {
+    const stored = getRpcDownloadConfig();
+    if (stored && stored.secret) {
+      secret = stored.secret;
+    }
   }
 
   try {

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { getDb } from '../db/connection.js';
 import { encrypt, decrypt } from '../services/crypto.js';
 import { config } from '../config.js';
-import { proxyRequest, ProxyConfig } from '../services/proxyService.js';
+import { proxyRequest, ProxyConfig, validateUrl } from '../services/proxyService.js';
 import { logger } from '../services/logger.js';
 
 function getProxyConfig(): ProxyConfig | null {
@@ -547,6 +547,188 @@ router.post('/api/settings/proxy/test', async (req, res) => {
     res.json(result);
   } catch (err) {
     res.json({ success: false, error: err instanceof Error ? err.message : 'Unknown error' });
+  }
+});
+
+// --- RPC Download endpoints ---
+
+function getRpcDownloadConfig(): { host: string; port: number; secret: string } | null {
+  try {
+    const db = getDb();
+    const row = db.prepare('SELECT value FROM settings WHERE key = ?').get('rpc_download_config') as { value: string } | undefined;
+    if (!row?.value) return null;
+    const parsed = JSON.parse(row.value);
+    if (parsed && parsed.enabled && parsed.host && parsed.port) {
+      let secret = '';
+      if (parsed.secret_encrypted) {
+        secret = decrypt(parsed.secret_encrypted, config.encryptionKey);
+      }
+      return { host: parsed.host, port: parsed.port, secret };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// GET /api/settings/rpc-download
+router.get('/api/settings/rpc-download', (_req, res) => {
+  try {
+    const db = getDb();
+    const row = db.prepare('SELECT value FROM settings WHERE key = ?').get('rpc_download_config') as { value: string } | undefined;
+    if (!row?.value) {
+      res.json({ enabled: false, host: '', port: 6800 });
+      return;
+    }
+    const parsed = JSON.parse(row.value);
+    if (parsed.secret_encrypted) {
+      parsed.hasSecret = true;
+    }
+    delete parsed.secret_encrypted;
+    delete parsed.secret;
+    res.json(parsed);
+  } catch {
+    res.json({ enabled: false, host: '', port: 6800 });
+  }
+});
+
+// PUT /api/settings/rpc-download
+router.put('/api/settings/rpc-download', (req, res) => {
+  try {
+    const db = getDb();
+    const { enabled, host, port, secret } = req.body;
+    const secretProvided = 'secret' in req.body;
+
+    const configToStore: Record<string, unknown> = { enabled, host, port };
+    if (secretProvided && secret) {
+      configToStore.secret_encrypted = encrypt(secret, config.encryptionKey);
+    } else if (secretProvided && !secret) {
+      // Explicitly empty secret - clear stored secret
+    } else {
+      // Secret field omitted - preserve existing encrypted secret
+      const existing = db.prepare('SELECT value FROM settings WHERE key = ?').get('rpc_download_config') as { value: string } | undefined;
+      if (existing?.value) {
+        try {
+          const parsed = JSON.parse(existing.value);
+          if (parsed.secret_encrypted) {
+            configToStore.secret_encrypted = parsed.secret_encrypted;
+          }
+        } catch { /* ignore */ }
+      }
+    }
+
+    db.prepare('INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)')
+      .run('rpc_download_config', JSON.stringify(configToStore));
+
+    res.json({ success: true });
+  } catch (err) {
+    logger.errorFromError('rpc.settings', 'Failed to save RPC download config', err);
+    res.status(500).json({ error: 'Failed to save RPC download config' });
+  }
+});
+
+// POST /api/settings/rpc-download/test
+router.post('/api/settings/rpc-download/test', async (req, res) => {
+  try {
+    const { host, port, secret } = req.body;
+    if (!host || !port) {
+      res.json({ success: false, error: 'Host and port are required' });
+      return;
+    }
+
+    const rpcUrl = `http://${host}:${port}/jsonrpc`;
+    const params = secret ? [`token:${secret}`] : [];
+
+    const response = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'test',
+        method: 'aria2.getVersion',
+        params,
+      }),
+      signal: AbortSignal.timeout(5000),
+    });
+
+    const data = await response.json() as Record<string, unknown>;
+    if (data.error) {
+      const error = data.error as { message?: string };
+      res.json({ success: false, error: error.message || 'RPC error' });
+      return;
+    }
+    const result = data.result as Record<string, unknown> | undefined;
+    res.json({
+      success: true,
+      version: result?.version || 'unknown',
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Connection failed';
+    const isConnRefused = message.includes('ECONNREFUSED') || message.includes('fetch failed');
+    res.json({
+      success: false,
+      error: isConnRefused ? 'RPC service not running' : message,
+    });
+  }
+});
+
+// POST /api/download/rpc
+router.post('/api/download/rpc', async (req, res) => {
+  try {
+    const rpcConfig = getRpcDownloadConfig();
+    if (!rpcConfig) {
+      res.status(400).json({ success: false, error: 'RPC download not configured or disabled' });
+      return;
+    }
+
+    const { url, filename } = req.body;
+    if (!url) {
+      res.status(400).json({ success: false, error: 'URL is required' });
+      return;
+    }
+
+    // SSRF protection: validate the download URL
+    try {
+      validateUrl(url);
+    } catch (e) {
+      res.status(400).json({ success: false, error: e instanceof Error ? e.message : 'Invalid URL' });
+      return;
+    }
+
+    const rpcUrl = `http://${rpcConfig.host}:${rpcConfig.port}/jsonrpc`;
+    const params: unknown[] = rpcConfig.secret
+      ? [`token:${rpcConfig.secret}`, [url]]
+      : [[url]];
+    if (filename) {
+      params.push({ out: filename });
+    }
+
+    const response = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'download',
+        method: 'aria2.addUri',
+        params,
+      }),
+      signal: AbortSignal.timeout(10000),
+    });
+
+    const data = await response.json() as Record<string, unknown>;
+    if (data.error) {
+      const error = data.error as { message?: string };
+      res.json({ success: false, error: error.message || 'RPC error' });
+      return;
+    }
+    res.json({ success: true, gid: data.result });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Connection failed';
+    const isConnRefused = message.includes('ECONNREFUSED') || message.includes('fetch failed');
+    res.json({
+      success: false,
+      error: isConnRefused ? 'RPC service not running' : message,
+    });
   }
 });
 

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -627,19 +627,33 @@ router.put('/api/settings/rpc-download', (req, res) => {
   }
 });
 
+// Helper: fetch with timeout using AbortController (compatible with older Node)
+async function fetchWithTimeout(url: string, init: RequestInit & { timeoutMs?: number } = {}): Promise<Response> {
+  const { timeoutMs = 5000, ...fetchInit } = init;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...fetchInit, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 // POST /api/settings/rpc-download/test
 router.post('/api/settings/rpc-download/test', async (req, res) => {
-  try {
-    const { host, port, secret } = req.body;
-    if (!host || !port) {
-      res.json({ success: false, error: 'Host and port are required' });
-      return;
-    }
+  const { host, port, secret } = req.body;
+  if (!host || !port) {
+    res.json({ success: false, error: 'Host and port are required' });
+    return;
+  }
 
+  try {
     const rpcUrl = `http://${host}:${port}/jsonrpc`;
     const params = secret ? [`token:${secret}`] : [];
 
-    const response = await fetch(rpcUrl, {
+    logger.info('rpc.test', `Testing connection to ${host}:${port}`);
+
+    const response = await fetchWithTimeout(rpcUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -648,39 +662,51 @@ router.post('/api/settings/rpc-download/test', async (req, res) => {
         method: 'aria2.getVersion',
         params,
       }),
-      signal: AbortSignal.timeout(5000),
+      timeoutMs: 5000,
     });
+
+    if (!response.ok) {
+      logger.warn('rpc.test', `aria2 returned HTTP ${response.status}`);
+      res.json({ success: false, error: `aria2 returned HTTP ${response.status}` });
+      return;
+    }
 
     const data = await response.json() as Record<string, unknown>;
     if (data.error) {
       const error = data.error as { message?: string };
+      logger.warn('rpc.test', 'aria2 RPC error', error);
       res.json({ success: false, error: error.message || 'RPC error' });
       return;
     }
     const result = data.result as Record<string, unknown> | undefined;
+    logger.info('rpc.test', `Connected to aria2 v${result?.version || 'unknown'}`);
     res.json({
       success: true,
       version: result?.version || 'unknown',
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Connection failed';
+    const isAbort = err instanceof Error && err.name === 'AbortError';
     const isConnRefused = message.includes('ECONNREFUSED') || message.includes('fetch failed');
-    res.json({
-      success: false,
-      error: isConnRefused ? 'RPC service not running' : message,
-    });
+    const errorMsg = isAbort
+      ? `Connection timeout (${host}:${port})`
+      : isConnRefused
+        ? 'RPC service not running'
+        : message;
+    logger.errorFromError('rpc.test', `Test connection failed: ${errorMsg}`, err, { host, port });
+    res.json({ success: false, error: errorMsg });
   }
 });
 
 // POST /api/download/rpc
 router.post('/api/download/rpc', async (req, res) => {
-  try {
-    const rpcConfig = getRpcDownloadConfig();
-    if (!rpcConfig) {
-      res.status(400).json({ success: false, error: 'RPC download not configured or disabled' });
-      return;
-    }
+  const rpcConfig = getRpcDownloadConfig();
+  if (!rpcConfig) {
+    res.status(400).json({ success: false, error: 'RPC download not configured or disabled' });
+    return;
+  }
 
+  try {
     const { url, filename } = req.body;
     if (!url) {
       res.status(400).json({ success: false, error: 'URL is required' });
@@ -703,7 +729,9 @@ router.post('/api/download/rpc', async (req, res) => {
       params.push({ out: filename });
     }
 
-    const response = await fetch(rpcUrl, {
+    logger.info('rpc.download', `Sending to aria2: ${filename || url}`);
+
+    const response = await fetchWithTimeout(rpcUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -712,23 +740,35 @@ router.post('/api/download/rpc', async (req, res) => {
         method: 'aria2.addUri',
         params,
       }),
-      signal: AbortSignal.timeout(10000),
+      timeoutMs: 10000,
     });
+
+    if (!response.ok) {
+      logger.warn('rpc.download', `aria2 returned HTTP ${response.status}`);
+      res.json({ success: false, error: `aria2 returned HTTP ${response.status}` });
+      return;
+    }
 
     const data = await response.json() as Record<string, unknown>;
     if (data.error) {
       const error = data.error as { message?: string };
+      logger.warn('rpc.download', 'aria2 RPC error', error);
       res.json({ success: false, error: error.message || 'RPC error' });
       return;
     }
+    logger.info('rpc.download', `Download queued, GID: ${data.result}`);
     res.json({ success: true, gid: data.result });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Connection failed';
+    const isAbort = err instanceof Error && err.name === 'AbortError';
     const isConnRefused = message.includes('ECONNREFUSED') || message.includes('fetch failed');
-    res.json({
-      success: false,
-      error: isConnRefused ? 'RPC service not running' : message,
-    });
+    const errorMsg = isAbort
+      ? `Connection timeout (${rpcConfig?.host}:${rpcConfig?.port})`
+      : isConnRefused
+        ? 'RPC service not running'
+        : message;
+    logger.errorFromError('rpc.download', `Download failed: ${errorMsg}`, err);
+    res.json({ success: false, error: errorMsg });
   }
 });
 

--- a/server/src/services/proxyService.ts
+++ b/server/src/services/proxyService.ts
@@ -29,7 +29,7 @@ export interface ProxyResponse {
 const BLOCKED_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', '169.254.169.254']);
 const PRIVATE_IP_PATTERNS = [/^10\./, /^172\.(1[6-9]|2\d|3[01])\./, /^192\.168\./];
 
-function validateUrl(rawUrl: string): void {
+export function validateUrl(rawUrl: string): void {
   const parsed = new URL(rawUrl);
   if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
     throw new Error(`Blocked proxy request: unsupported protocol '${parsed.protocol}'`);

--- a/src/components/ReleaseCard.tsx
+++ b/src/components/ReleaseCard.tsx
@@ -1,8 +1,11 @@
-import React, { memo, useCallback } from 'react';
-import { ExternalLink, GitBranch, Calendar, Download, ChevronDown, ChevronUp, BookOpen, ArrowUpRight, FolderOpen, Folder, BellOff, FileArchive, Code2 } from 'lucide-react';
+import React, { memo, useCallback, useRef, useState } from 'react';
+import { ExternalLink, GitBranch, Calendar, Download, ChevronDown, ChevronUp, BookOpen, ArrowUpRight, FolderOpen, Folder, BellOff, FileArchive, Code2, Loader2, CheckCircle2 } from 'lucide-react';
 import { Release } from '../types';
 import { formatDistanceToNow } from 'date-fns';
 import MarkdownRenderer from './MarkdownRenderer';
+import { useAppStore } from '../store/useAppStore';
+import { useDialog } from '../hooks/useDialog';
+import { sendToRpcDownload } from '../services/rpcDownloadService';
 
 interface DownloadLink {
   name: string;
@@ -50,6 +53,40 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
   formatFileSize,
 }) => {
   const t = useCallback((zh: string, en: string) => language === 'zh' ? zh : en, [language]);
+
+  // RPC download support — use refs to avoid stale closure in async handler
+  const { rpcDownloadConfig, backendApiSecret } = useAppStore();
+  const { toast } = useDialog();
+  const downloadingRef = useRef<Record<string, boolean>>({});
+  const downloadedRef = useRef<Record<string, boolean>>({});
+  const [, forceUpdate] = useState(0);
+
+  const handleRpcDownload = useCallback(async (link: DownloadLink) => {
+    const key = link.url;
+    if (downloadingRef.current[key] || downloadedRef.current[key]) return;
+
+    downloadingRef.current = { ...downloadingRef.current, [key]: true };
+    forceUpdate(n => n + 1);
+    try {
+      const result = await sendToRpcDownload(link.url, link.name, backendApiSecret || undefined);
+      if (result.success) {
+        downloadedRef.current = { ...downloadedRef.current, [key]: true };
+        toast(t('已发送到远程下载器', 'Sent to remote downloader'), 'success');
+      } else {
+        toast(
+          result.error === 'RPC service not running'
+            ? t('远程下载服务未运行，请检查配置', 'Remote download service not running, please check config')
+            : result.error || t('发送失败', 'Send failed'),
+          'error'
+        );
+      }
+    } catch {
+      toast(t('远程下载服务未运行，请检查配置', 'Remote download service not running, please check config'), 'error');
+    } finally {
+      downloadingRef.current = { ...downloadingRef.current, [key]: false };
+      forceUpdate(n => n + 1);
+    }
+  }, [backendApiSecret, toast, t]);
 
   // 判断是否有任何内容展开
   const isAnyExpanded = isAssetsExpanded || isReleaseNotesExpanded;
@@ -203,37 +240,82 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
               </div>
 
               <div className="bg-gray-50 dark:bg-[#121314] rounded border border-black/[0.06] dark:border-white/[0.04] max-h-72 overflow-y-auto">
-                {downloadLinks.map((link, index) => (
-                  <a
-                    key={index}
-                    href={link.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={`flex items-center justify-between px-4 py-3 hover:bg-light-surface dark:hover:bg-white/[0.06] transition-colors border-b border-black/[0.04] dark:border-white/[0.04] last:border-b-0 ${
-                      link.isSourceCode ? 'bg-gray-100 dark:bg-white/[0.04]' : ''
-                    }`}
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <div className="flex items-center space-x-1.5 min-w-0 flex-1">
-                      {link.isSourceCode ? (
-                        <Code2 className="w-3.5 h-3.5 text-gray-700 dark:text-text-secondary flex-shrink-0" />
-                      ) : (
-                        <Download className="w-3.5 h-3.5 text-gray-400 dark:text-text-quaternary flex-shrink-0" />
-                      )}
-                      <span className={`text-sm truncate ${link.isSourceCode ? 'text-gray-700 dark:text-text-secondary font-medium' : 'text-gray-900 dark:text-text-secondary'}`}>
-                        {link.name}
-                      </span>
-                    </div>
-                    <div className="flex items-center space-x-2 text-xs text-gray-500 dark:text-text-tertiary flex-shrink-0">
-                      {link.size > 0 && (
-                        <span>{formatFileSize(link.size)}</span>
-                      )}
-                      {link.downloadCount > 0 && (
-                        <span>{link.downloadCount.toLocaleString()} {t('下载', 'downloads')}</span>
-                      )}
-                    </div>
-                  </a>
-                ))}
+                {downloadLinks.map((link, index) => {
+                  const isRpcEnabled = rpcDownloadConfig.enabled;
+                  const isDownloading = downloadingRef.current[link.url];
+                  const isDownloaded = downloadedRef.current[link.url];
+
+                  if (isRpcEnabled) {
+                    return (
+                      <button
+                        key={index}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleRpcDownload(link);
+                        }}
+                        disabled={isDownloading || isDownloaded}
+                        className={`flex items-center justify-between px-4 py-3 w-full text-left hover:bg-light-surface dark:hover:bg-white/[0.06] transition-colors border-b border-black/[0.04] dark:border-white/[0.04] last:border-b-0 disabled:opacity-60 ${
+                          link.isSourceCode ? 'bg-gray-100 dark:bg-white/[0.04]' : ''
+                        }`}
+                      >
+                        <div className="flex items-center space-x-1.5 min-w-0 flex-1">
+                          {isDownloaded ? (
+                            <CheckCircle2 className="w-3.5 h-3.5 text-green-500 flex-shrink-0" />
+                          ) : isDownloading ? (
+                            <Loader2 className="w-3.5 h-3.5 text-gray-400 animate-spin flex-shrink-0" />
+                          ) : link.isSourceCode ? (
+                            <Code2 className="w-3.5 h-3.5 text-gray-700 dark:text-text-secondary flex-shrink-0" />
+                          ) : (
+                            <Download className="w-3.5 h-3.5 text-gray-400 dark:text-text-quaternary flex-shrink-0" />
+                          )}
+                          <span className={`text-sm truncate ${link.isSourceCode ? 'text-gray-700 dark:text-text-secondary font-medium' : 'text-gray-900 dark:text-text-secondary'}`}>
+                            {link.name}
+                          </span>
+                        </div>
+                        <div className="flex items-center space-x-2 text-xs text-gray-500 dark:text-text-tertiary flex-shrink-0">
+                          {link.size > 0 && (
+                            <span>{formatFileSize(link.size)}</span>
+                          )}
+                          {link.downloadCount > 0 && (
+                            <span>{link.downloadCount.toLocaleString()} {t('下载', 'downloads')}</span>
+                          )}
+                        </div>
+                      </button>
+                    );
+                  }
+
+                  return (
+                    <a
+                      key={index}
+                      href={link.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={`flex items-center justify-between px-4 py-3 hover:bg-light-surface dark:hover:bg-white/[0.06] transition-colors border-b border-black/[0.04] dark:border-white/[0.04] last:border-b-0 ${
+                        link.isSourceCode ? 'bg-gray-100 dark:bg-white/[0.04]' : ''
+                      }`}
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <div className="flex items-center space-x-1.5 min-w-0 flex-1">
+                        {link.isSourceCode ? (
+                          <Code2 className="w-3.5 h-3.5 text-gray-700 dark:text-text-secondary flex-shrink-0" />
+                        ) : (
+                          <Download className="w-3.5 h-3.5 text-gray-400 dark:text-text-quaternary flex-shrink-0" />
+                        )}
+                        <span className={`text-sm truncate ${link.isSourceCode ? 'text-gray-700 dark:text-text-secondary font-medium' : 'text-gray-900 dark:text-text-secondary'}`}>
+                          {link.name}
+                        </span>
+                      </div>
+                      <div className="flex items-center space-x-2 text-xs text-gray-500 dark:text-text-tertiary flex-shrink-0">
+                        {link.size > 0 && (
+                          <span>{formatFileSize(link.size)}</span>
+                        )}
+                        {link.downloadCount > 0 && (
+                          <span>{link.downloadCount.toLocaleString()} {t('下载', 'downloads')}</span>
+                        )}
+                      </div>
+                    </a>
+                  );
+                })}
               </div>
             </div>
           )}

--- a/src/components/settings/NetworkPanel.tsx
+++ b/src/components/settings/NetworkPanel.tsx
@@ -29,6 +29,17 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
   const [rpcTestResult, setRpcTestResult] = useState<{ success: boolean; error?: string; version?: string } | null>(null);
   const [rpcSaving, setRpcSaving] = useState(false);
 
+  // Ensure backend is initialized, then return base URL
+  const getRpcBaseUrl = async (): Promise<string> => {
+    if (!backend.isAvailable) {
+      await backend.init();
+    }
+    if (!backend.backendUrl) {
+      throw new Error('Backend not available');
+    }
+    return backend.backendUrl;
+  };
+
   // Sync proxy form when store changes externally
   useEffect(() => {
     setForm(proxyConfig);
@@ -44,14 +55,14 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
 
   // Load RPC config from backend on mount (to get hasSecret flag)
   useEffect(() => {
-    if (!backend.isAvailable) return;
     const loadRpcConfig = async () => {
       try {
+        const base = await getRpcBaseUrl();
         const authHeaders: Record<string, string> = {};
         if (backendApiSecret) {
           authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
         }
-        const resp = await fetch('/api/settings/rpc-download', { headers: authHeaders });
+        const resp = await fetch(`${base}/settings/rpc-download`, { headers: authHeaders });
         if (resp.ok) {
           const data = await resp.json();
           if (data.hasSecret) {
@@ -69,7 +80,7 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
       } catch { /* best effort */ }
     };
     loadRpcConfig();
-  }, [backend.isAvailable]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const canUseProxy = isElectron() || backend.isAvailable;
 
@@ -161,35 +172,32 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
     setRpcSaving(true);
     setRpcTestResult(null);
     try {
-      if (backend.isAvailable) {
-        const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
-        if (backendApiSecret) {
-          authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
-        }
-        // Don't send empty secret — let backend preserve the stored one
-        const body: Record<string, unknown> = {
-          enabled: rpcForm.enabled,
-          host: rpcForm.host,
-          port: rpcForm.port,
-        };
-        if (rpcForm.secret) {
-          body.secret = rpcForm.secret;
-        } else {
-          body.secret = ''; // explicitly empty = clear
-        }
+      const base = await getRpcBaseUrl();
+      const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (backendApiSecret) {
+        authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
+      }
+      // Only send secret when user explicitly typed one
+      const body: Record<string, unknown> = {
+        enabled: rpcForm.enabled,
+        host: rpcForm.host,
+        port: rpcForm.port,
+      };
+      if (rpcForm.secret) {
+        body.secret = rpcForm.secret;
+      }
 
-        const resp = await fetch('/api/settings/rpc-download', {
-          method: 'PUT',
-          headers: authHeaders,
-          body: JSON.stringify(body),
-        });
-        if (!resp.ok) {
-          throw new Error(`Backend returned ${resp.status}`);
-        }
+      const resp = await fetch(`${base}/settings/rpc-download`, {
+        method: 'PUT',
+        headers: authHeaders,
+        body: JSON.stringify(body),
+      });
+      if (!resp.ok) {
+        throw new Error(`Backend returned ${resp.status}`);
+      }
 
-        if (rpcForm.secret) {
-          setHasStoredSecret(true);
-        }
+      if (rpcForm.secret) {
+        setHasStoredSecret(true);
       }
 
       setRpcDownloadConfig(rpcForm);
@@ -219,19 +227,18 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
     const newForm = { ...rpcForm, enabled: !rpcForm.enabled };
     setRpcForm(newForm);
     setRpcDownloadConfig(newForm);
-    if (backend.isAvailable) {
-      try {
-        const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
-        if (backendApiSecret) {
-          authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
-        }
-        await fetch('/api/settings/rpc-download', {
-          method: 'PUT',
-          headers: authHeaders,
-          body: JSON.stringify(newForm),
-        });
-      } catch { /* best effort */ }
-    }
+    try {
+      const base = await getRpcBaseUrl();
+      const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (backendApiSecret) {
+        authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
+      }
+      await fetch(`${base}/settings/rpc-download`, {
+        method: 'PUT',
+        headers: authHeaders,
+        body: JSON.stringify(newForm),
+      });
+    } catch { /* best effort */ }
   };
 
   return (

--- a/src/components/settings/NetworkPanel.tsx
+++ b/src/components/settings/NetworkPanel.tsx
@@ -24,6 +24,7 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
   // --- RPC Download state ---
   const [rpcForm, setRpcForm] = useState<RpcDownloadConfig>(rpcDownloadConfig);
   const [showSecret, setShowSecret] = useState(false);
+  const [hasStoredSecret, setHasStoredSecret] = useState(false);
   const [rpcTesting, setRpcTesting] = useState(false);
   const [rpcTestResult, setRpcTestResult] = useState<{ success: boolean; error?: string; version?: string } | null>(null);
   const [rpcSaving, setRpcSaving] = useState(false);
@@ -40,6 +41,35 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
   useEffect(() => {
     setRpcForm(rpcDownloadConfig);
   }, [rpcDownloadConfig]);
+
+  // Load RPC config from backend on mount (to get hasSecret flag)
+  useEffect(() => {
+    if (!backend.isAvailable) return;
+    const loadRpcConfig = async () => {
+      try {
+        const authHeaders: Record<string, string> = {};
+        if (backendApiSecret) {
+          authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
+        }
+        const resp = await fetch('/api/settings/rpc-download', { headers: authHeaders });
+        if (resp.ok) {
+          const data = await resp.json();
+          if (data.hasSecret) {
+            setHasStoredSecret(true);
+          }
+          // Merge backend state into store (enabled/host/port)
+          if (data.enabled !== undefined || data.host || data.port) {
+            setRpcDownloadConfig({
+              enabled: data.enabled ?? rpcDownloadConfig.enabled,
+              host: data.host || rpcDownloadConfig.host,
+              port: data.port || rpcDownloadConfig.port,
+            });
+          }
+        }
+      } catch { /* best effort */ }
+    };
+    loadRpcConfig();
+  }, [backend.isAvailable]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const canUseProxy = isElectron() || backend.isAvailable;
 
@@ -131,18 +161,34 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
     setRpcSaving(true);
     setRpcTestResult(null);
     try {
-      if (backend.isAvailable && backend.backendUrl) {
+      if (backend.isAvailable) {
         const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
         if (backendApiSecret) {
           authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
         }
-        const resp = await fetch(`${backend.backendUrl}/settings/rpc-download`, {
+        // Don't send empty secret — let backend preserve the stored one
+        const body: Record<string, unknown> = {
+          enabled: rpcForm.enabled,
+          host: rpcForm.host,
+          port: rpcForm.port,
+        };
+        if (rpcForm.secret) {
+          body.secret = rpcForm.secret;
+        } else {
+          body.secret = ''; // explicitly empty = clear
+        }
+
+        const resp = await fetch('/api/settings/rpc-download', {
           method: 'PUT',
           headers: authHeaders,
-          body: JSON.stringify(rpcForm),
+          body: JSON.stringify(body),
         });
         if (!resp.ok) {
           throw new Error(`Backend returned ${resp.status}`);
+        }
+
+        if (rpcForm.secret) {
+          setHasStoredSecret(true);
         }
       }
 
@@ -173,13 +219,13 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
     const newForm = { ...rpcForm, enabled: !rpcForm.enabled };
     setRpcForm(newForm);
     setRpcDownloadConfig(newForm);
-    if (backend.isAvailable && backend.backendUrl) {
+    if (backend.isAvailable) {
       try {
         const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
         if (backendApiSecret) {
           authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
         }
-        await fetch(`${backend.backendUrl}/settings/rpc-download`, {
+        await fetch('/api/settings/rpc-download', {
           method: 'PUT',
           headers: authHeaders,
           body: JSON.stringify(newForm),
@@ -466,8 +512,13 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
                 <input
                   type={showSecret ? 'text' : 'password'}
                   value={rpcForm.secret || ''}
-                  onChange={(e) => setRpcForm({ ...rpcForm, secret: e.target.value || undefined })}
-                  placeholder={t('可选，对应 aria2 的 --rpc-secret', 'Optional, aria2 --rpc-secret')}
+                  onChange={(e) => {
+                    setRpcForm({ ...rpcForm, secret: e.target.value || undefined });
+                    if (e.target.value) setHasStoredSecret(false);
+                  }}
+                  placeholder={hasStoredSecret
+                    ? t('已保存密钥，留空则保留', 'Secret saved, leave blank to keep')
+                    : t('可选，对应 aria2 的 --rpc-secret', 'Optional, aria2 --rpc-secret')}
                   className="w-full px-3 py-2 pr-10 bg-light-surface dark:bg-white/[0.04] border border-black/[0.06] dark:border-white/[0.04] rounded-lg text-gray-900 dark:text-text-primary text-sm focus:ring-2 focus:ring-brand-violet focus:border-transparent outline-none"
                 />
                 <button

--- a/src/components/settings/NetworkPanel.tsx
+++ b/src/components/settings/NetworkPanel.tsx
@@ -84,10 +84,6 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
 
   const canUseProxy = isElectron() || backend.isAvailable;
 
-  if (!canUseProxy) {
-    return null;
-  }
-
   // --- Proxy handlers ---
 
   const isFormValid = !form.enabled || (form.host.trim() && form.port >= 1 && form.port <= 65535);
@@ -172,35 +168,37 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
     setRpcSaving(true);
     setRpcTestResult(null);
     try {
-      const base = await getRpcBaseUrl();
-      const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
-      if (backendApiSecret) {
-        authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
-      }
-      // Only send secret when user explicitly typed one
-      const body: Record<string, unknown> = {
-        enabled: rpcForm.enabled,
-        host: rpcForm.host,
-        port: rpcForm.port,
-      };
-      if (rpcForm.secret) {
-        body.secret = rpcForm.secret;
+      // Sync to backend if available
+      if (backend.isAvailable) {
+        const base = await getRpcBaseUrl();
+        const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
+        if (backendApiSecret) {
+          authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
+        }
+        const body: Record<string, unknown> = {
+          enabled: rpcForm.enabled,
+          host: rpcForm.host,
+          port: rpcForm.port,
+        };
+        if (rpcForm.secret) {
+          body.secret = rpcForm.secret;
+        }
+
+        const resp = await fetch(`${base}/settings/rpc-download`, {
+          method: 'PUT',
+          headers: authHeaders,
+          body: JSON.stringify(body),
+        });
+        if (!resp.ok) {
+          throw new Error(`Backend returned ${resp.status}`);
+        }
       }
 
-      const resp = await fetch(`${base}/settings/rpc-download`, {
-        method: 'PUT',
-        headers: authHeaders,
-        body: JSON.stringify(body),
-      });
-      if (!resp.ok) {
-        throw new Error(`Backend returned ${resp.status}`);
-      }
-
+      // Always persist to local store
+      setRpcDownloadConfig(rpcForm);
       if (rpcForm.secret) {
         setHasStoredSecret(true);
       }
-
-      setRpcDownloadConfig(rpcForm);
     } catch (e) {
       setRpcTestResult({ success: false, error: e instanceof Error ? e.message : t('保存失败', 'Save failed') });
     } finally {
@@ -227,23 +225,26 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
     const newForm = { ...rpcForm, enabled: !rpcForm.enabled };
     setRpcForm(newForm);
     setRpcDownloadConfig(newForm);
-    try {
-      const base = await getRpcBaseUrl();
-      const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
-      if (backendApiSecret) {
-        authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
-      }
-      await fetch(`${base}/settings/rpc-download`, {
-        method: 'PUT',
-        headers: authHeaders,
-        body: JSON.stringify(newForm),
-      });
-    } catch { /* best effort */ }
+    if (backend.isAvailable) {
+      try {
+        const base = await getRpcBaseUrl();
+        const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
+        if (backendApiSecret) {
+          authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
+        }
+        await fetch(`${base}/settings/rpc-download`, {
+          method: 'PUT',
+          headers: authHeaders,
+          body: JSON.stringify(newForm),
+        });
+      } catch { /* best effort */ }
+    }
   };
 
   return (
     <div className="space-y-4">
-      {/* Network Proxy Card */}
+      {/* Network Proxy Card — only available with backend or Electron */}
+      {canUseProxy && (
       <div className="p-6 bg-white dark:bg-panel-dark rounded-xl border border-black/[0.06] dark:border-white/[0.04]">
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center space-x-3">
@@ -454,6 +455,7 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
           </div>
         )}
       </div>
+      )}
 
       {/* RPC Download Card */}
       <div className="p-6 bg-white dark:bg-panel-dark rounded-xl border border-black/[0.06] dark:border-white/[0.04]">

--- a/src/components/settings/NetworkPanel.tsx
+++ b/src/components/settings/NetworkPanel.tsx
@@ -131,12 +131,12 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
     setRpcSaving(true);
     setRpcTestResult(null);
     try {
-      if (backend.isAvailable) {
+      if (backend.isAvailable && backend.backendUrl) {
         const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
         if (backendApiSecret) {
           authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
         }
-        const resp = await fetch('/api/settings/rpc-download', {
+        const resp = await fetch(`${backend.backendUrl}/settings/rpc-download`, {
           method: 'PUT',
           headers: authHeaders,
           body: JSON.stringify(rpcForm),
@@ -173,13 +173,13 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
     const newForm = { ...rpcForm, enabled: !rpcForm.enabled };
     setRpcForm(newForm);
     setRpcDownloadConfig(newForm);
-    if (backend.isAvailable) {
+    if (backend.isAvailable && backend.backendUrl) {
       try {
         const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
         if (backendApiSecret) {
           authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
         }
-        await fetch('/api/settings/rpc-download', {
+        await fetch(`${backend.backendUrl}/settings/rpc-download`, {
           method: 'PUT',
           headers: authHeaders,
           body: JSON.stringify(newForm),

--- a/src/components/settings/NetworkPanel.tsx
+++ b/src/components/settings/NetworkPanel.tsx
@@ -465,8 +465,8 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
               <div className="relative">
                 <input
                   type={showSecret ? 'text' : 'password'}
-                  value={rpcForm.secret}
-                  onChange={(e) => setRpcForm({ ...rpcForm, secret: e.target.value })}
+                  value={rpcForm.secret || ''}
+                  onChange={(e) => setRpcForm({ ...rpcForm, secret: e.target.value || undefined })}
                   placeholder={t('可选，对应 aria2 的 --rpc-secret', 'Optional, aria2 --rpc-secret')}
                   className="w-full px-3 py-2 pr-10 bg-light-surface dark:bg-white/[0.04] border border-black/[0.06] dark:border-white/[0.04] rounded-lg text-gray-900 dark:text-text-primary text-sm focus:ring-2 focus:ring-brand-violet focus:border-transparent outline-none"
                 />

--- a/src/components/settings/NetworkPanel.tsx
+++ b/src/components/settings/NetworkPanel.tsx
@@ -1,17 +1,19 @@
 import React, { useState, useEffect } from 'react';
-import { Wifi, Eye, EyeOff, Loader2, CheckCircle2, XCircle } from 'lucide-react';
+import { Wifi, Download, Eye, EyeOff, Loader2, CheckCircle2, XCircle } from 'lucide-react';
 import { useAppStore } from '../../store/useAppStore';
 import { backend } from '../../services/backendAdapter';
 import { isElectron, electronProxy } from '../../services/electronProxy';
-import type { ProxyConfig, ProxyType } from '../../types';
+import { testRpcDownload } from '../../services/rpcDownloadService';
+import type { ProxyConfig, ProxyType, RpcDownloadConfig } from '../../types';
 
 interface NetworkPanelProps {
   t: (zh: string, en: string) => string;
 }
 
 export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
-  const { proxyConfig, setProxyConfig, backendApiSecret } = useAppStore();
+  const { proxyConfig, setProxyConfig, rpcDownloadConfig, setRpcDownloadConfig, backendApiSecret } = useAppStore();
 
+  // --- Proxy state ---
   const [form, setForm] = useState<ProxyConfig>(proxyConfig);
   const [showPassword, setShowPassword] = useState(false);
   const [showAuth, setShowAuth] = useState(false);
@@ -19,7 +21,14 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
   const [testResult, setTestResult] = useState<{ success: boolean; error?: string } | null>(null);
   const [saving, setSaving] = useState(false);
 
-  // Sync form when store changes externally
+  // --- RPC Download state ---
+  const [rpcForm, setRpcForm] = useState<RpcDownloadConfig>(rpcDownloadConfig);
+  const [showSecret, setShowSecret] = useState(false);
+  const [rpcTesting, setRpcTesting] = useState(false);
+  const [rpcTestResult, setRpcTestResult] = useState<{ success: boolean; error?: string; version?: string } | null>(null);
+  const [rpcSaving, setRpcSaving] = useState(false);
+
+  // Sync proxy form when store changes externally
   useEffect(() => {
     setForm(proxyConfig);
     if (proxyConfig.username || proxyConfig.password) {
@@ -27,11 +36,18 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
     }
   }, [proxyConfig]);
 
+  // Sync RPC form when store changes externally
+  useEffect(() => {
+    setRpcForm(rpcDownloadConfig);
+  }, [rpcDownloadConfig]);
+
   const canUseProxy = isElectron() || backend.isAvailable;
 
   if (!canUseProxy) {
     return null;
   }
+
+  // --- Proxy handlers ---
 
   const isFormValid = !form.enabled || (form.host.trim() && form.port >= 1 && form.port <= 65535);
 
@@ -105,219 +121,429 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
 
   const hasChanges = JSON.stringify(form) !== JSON.stringify(proxyConfig);
 
+  // --- RPC Download handlers ---
+
+  const isRpcFormValid = !rpcForm.enabled || (rpcForm.host.trim() && rpcForm.port >= 1 && rpcForm.port <= 65535);
+
+  const handleRpcSave = async () => {
+    if (!isRpcFormValid) return;
+
+    setRpcSaving(true);
+    setRpcTestResult(null);
+    try {
+      if (backend.isAvailable) {
+        const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
+        if (backendApiSecret) {
+          authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
+        }
+        const resp = await fetch('/api/settings/rpc-download', {
+          method: 'PUT',
+          headers: authHeaders,
+          body: JSON.stringify(rpcForm),
+        });
+        if (!resp.ok) {
+          throw new Error(`Backend returned ${resp.status}`);
+        }
+      }
+
+      setRpcDownloadConfig(rpcForm);
+    } catch (e) {
+      setRpcTestResult({ success: false, error: e instanceof Error ? e.message : t('保存失败', 'Save failed') });
+    } finally {
+      setRpcSaving(false);
+    }
+  };
+
+  const handleRpcTest = async () => {
+    setRpcTesting(true);
+    setRpcTestResult(null);
+    try {
+      const result = await testRpcDownload(rpcForm, backendApiSecret || undefined);
+      setRpcTestResult(result);
+    } catch (e) {
+      setRpcTestResult({ success: false, error: e instanceof Error ? e.message : 'Unknown error' });
+    } finally {
+      setRpcTesting(false);
+    }
+  };
+
+  const rpcHasChanges = JSON.stringify(rpcForm) !== JSON.stringify(rpcDownloadConfig);
+
+  const handleRpcToggle = async () => {
+    const newForm = { ...rpcForm, enabled: !rpcForm.enabled };
+    setRpcForm(newForm);
+    setRpcDownloadConfig(newForm);
+    if (backend.isAvailable) {
+      try {
+        const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
+        if (backendApiSecret) {
+          authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
+        }
+        await fetch('/api/settings/rpc-download', {
+          method: 'PUT',
+          headers: authHeaders,
+          body: JSON.stringify(newForm),
+        });
+      } catch { /* best effort */ }
+    }
+  };
+
   return (
-    <div className="p-6 bg-white dark:bg-panel-dark rounded-xl border border-black/[0.06] dark:border-white/[0.04]">
-      <div className="flex items-center justify-between mb-4">
-        <div className="flex items-center space-x-3">
-          <Wifi className="w-5 h-5 text-gray-700 dark:text-text-secondary" />
-          <h4 className="font-medium text-gray-900 dark:text-text-primary">
-            {t('网络代理', 'Network Proxy')}
-          </h4>
+    <div className="space-y-4">
+      {/* Network Proxy Card */}
+      <div className="p-6 bg-white dark:bg-panel-dark rounded-xl border border-black/[0.06] dark:border-white/[0.04]">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center space-x-3">
+            <Wifi className="w-5 h-5 text-gray-700 dark:text-text-secondary" />
+            <h4 className="font-medium text-gray-900 dark:text-text-primary">
+              {t('网络代理', 'Network Proxy')}
+            </h4>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={form.enabled}
+            aria-label={t('启用网络代理', 'Enable network proxy')}
+            onClick={async () => {
+              const newForm = { ...form, enabled: !form.enabled };
+              setForm(newForm);
+              setProxyConfig(newForm);
+              if (backend.isAvailable) {
+                try {
+                  const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
+                  if (backendApiSecret) {
+                    authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
+                  }
+                  await fetch('/api/settings/proxy', {
+                    method: 'PUT',
+                    headers: authHeaders,
+                    body: JSON.stringify(newForm),
+                  });
+                } catch { /* best effort */ }
+              }
+              if (isElectron()) {
+                try { await electronProxy.setProxy(newForm); } catch { /* best effort */ }
+              }
+            }}
+            className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${form.enabled ? 'bg-brand-indigo' : 'bg-gray-300 dark:bg-gray-600'}`}
+          >
+            <span
+              className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${form.enabled ? 'translate-x-[18px]' : 'translate-x-[2px]'}`}
+            />
+          </button>
         </div>
-        <button
-          type="button"
-          role="switch"
-          aria-checked={form.enabled}
-          aria-label={t('启用网络代理', 'Enable network proxy')}
-          onClick={async () => {
-            const newForm = { ...form, enabled: !form.enabled };
-            setForm(newForm);
-            // 立即持久化，无需用户手动点击保存
-            setProxyConfig(newForm);
-            // 同步到后端
-            if (backend.isAvailable) {
-              try {
-                const authHeaders: Record<string, string> = { 'Content-Type': 'application/json' };
-                if (backendApiSecret) {
-                  authHeaders['Authorization'] = `Bearer ${backendApiSecret}`;
-                }
-                await fetch('/api/settings/proxy', {
-                  method: 'PUT',
-                  headers: authHeaders,
-                  body: JSON.stringify(newForm),
-                });
-              } catch { /* best effort */ }
-            }
-            // 同步到 Electron
-            if (isElectron()) {
-              try { await electronProxy.setProxy(newForm); } catch { /* best effort */ }
-            }
-          }}
-          className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${form.enabled ? 'bg-brand-indigo' : 'bg-gray-300 dark:bg-gray-600'}`}
-        >
-          <span
-            className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${form.enabled ? 'translate-x-[18px]' : 'translate-x-[2px]'}`}
-          />
-        </button>
-      </div>
 
-      {form.enabled && (
-        <div className="space-y-4">
-          {/* Proxy Type */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-text-secondary mb-2">
-              {t('代理类型', 'Proxy Type')}
-            </label>
-            <div className="grid grid-cols-2 gap-3 max-w-md">
-              {(['http', 'socks5'] as ProxyType[]).map((type) => (
-                <label
-                  key={type}
-                  className={`flex items-center space-x-3 cursor-pointer p-3 rounded-lg border transition-colors ${
-                    form.type === type
-                      ? 'border-brand-indigo bg-brand-indigo/5 dark:bg-brand-indigo/10'
-                      : 'border-black/[0.06] dark:border-white/[0.04] hover:bg-light-bg dark:hover:bg-white/10'
-                  }`}
-                >
-                  <input
-                    type="radio"
-                    name="proxyType"
-                    value={type}
-                    checked={form.type === type}
-                    onChange={() => setForm({ ...form, type })}
-                    className="w-4 h-4 text-brand-violet bg-light-surface border-black/[0.06] focus:ring-brand-violet dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-white/[0.04] dark:border-white/[0.04]"
-                  />
-                  <span className="text-sm font-medium text-gray-900 dark:text-text-primary uppercase">
-                    {type}
-                  </span>
-                </label>
-              ))}
-            </div>
-          </div>
-
-          {/* Host and Port */}
-          <div className="grid grid-cols-3 gap-3">
-            <div className="col-span-2">
-              <label className="block text-sm font-medium text-gray-700 dark:text-text-secondary mb-1">
-                {t('主机地址', 'Host')}
-              </label>
-              <input
-                type="text"
-                value={form.host}
-                onChange={(e) => setForm({ ...form, host: e.target.value })}
-                placeholder="127.0.0.1"
-                className="w-full px-3 py-2 bg-light-surface dark:bg-white/[0.04] border border-black/[0.06] dark:border-white/[0.04] rounded-lg text-gray-900 dark:text-text-primary text-sm focus:ring-2 focus:ring-brand-violet focus:border-transparent outline-none"
-              />
-            </div>
+        {form.enabled && (
+          <div className="space-y-4">
+            {/* Proxy Type */}
             <div>
-              <label className="block text-sm font-medium text-gray-700 dark:text-text-secondary mb-1">
-                {t('端口', 'Port')}
+              <label className="block text-sm font-medium text-gray-700 dark:text-text-secondary mb-2">
+                {t('代理类型', 'Proxy Type')}
               </label>
-              <input
-                type="number"
-                value={form.port || ''}
-                onChange={(e) => setForm({ ...form, port: parseInt(e.target.value) || 0 })}
-                placeholder="7890"
-                min={1}
-                max={65535}
-                className="w-full px-3 py-2 bg-light-surface dark:bg-white/[0.04] border border-black/[0.06] dark:border-white/[0.04] rounded-lg text-gray-900 dark:text-text-primary text-sm focus:ring-2 focus:ring-brand-violet focus:border-transparent outline-none"
-              />
-            </div>
-          </div>
-
-          {/* Authentication (collapsible) */}
-          <div>
-            <button
-              type="button"
-              onClick={() => setShowAuth(!showAuth)}
-              className="text-sm text-gray-500 dark:text-text-tertiary hover:text-gray-700 dark:hover:text-text-secondary transition-colors"
-            >
-              {showAuth ? t('隐藏认证', 'Hide Authentication') : t('需要认证（可选）', 'Authentication (optional)')}
-            </button>
-
-            {showAuth && (
-              <div className="mt-3 grid grid-cols-2 gap-3">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-text-secondary mb-1">
-                    {t('用户名', 'Username')}
-                  </label>
-                  <input
-                    type="text"
-                    value={form.username || ''}
-                    onChange={(e) => setForm({ ...form, username: e.target.value || undefined })}
-                    placeholder={t('可选', 'Optional')}
-                    className="w-full px-3 py-2 bg-light-surface dark:bg-white/[0.04] border border-black/[0.06] dark:border-white/[0.04] rounded-lg text-gray-900 dark:text-text-primary text-sm focus:ring-2 focus:ring-brand-violet focus:border-transparent outline-none"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-text-secondary mb-1">
-                    {t('密码', 'Password')}
-                  </label>
-                  <div className="relative">
+              <div className="grid grid-cols-2 gap-3 max-w-md">
+                {(['http', 'socks5'] as ProxyType[]).map((type) => (
+                  <label
+                    key={type}
+                    className={`flex items-center space-x-3 cursor-pointer p-3 rounded-lg border transition-colors ${
+                      form.type === type
+                        ? 'border-brand-indigo bg-brand-indigo/5 dark:bg-brand-indigo/10'
+                        : 'border-black/[0.06] dark:border-white/[0.04] hover:bg-light-bg dark:hover:bg-white/10'
+                    }`}
+                  >
                     <input
-                      type={showPassword ? 'text' : 'password'}
-                      value={form.password || ''}
-                      onChange={(e) => setForm({ ...form, password: e.target.value || undefined })}
-                      placeholder={t('可选', 'Optional')}
-                      className="w-full px-3 py-2 pr-10 bg-light-surface dark:bg-white/[0.04] border border-black/[0.06] dark:border-white/[0.04] rounded-lg text-gray-900 dark:text-text-primary text-sm focus:ring-2 focus:ring-brand-violet focus:border-transparent outline-none"
+                      type="radio"
+                      name="proxyType"
+                      value={type}
+                      checked={form.type === type}
+                      onChange={() => setForm({ ...form, type })}
+                      className="w-4 h-4 text-brand-violet bg-light-surface border-black/[0.06] focus:ring-brand-violet dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-white/[0.04] dark:border-white/[0.04]"
                     />
-                    <button
-                      type="button"
-                      aria-label={showPassword ? t('隐藏密码', 'Hide password') : t('显示密码', 'Show password')}
-                      onClick={() => setShowPassword(!showPassword)}
-                      className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-text-secondary"
-                    >
-                      {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-                    </button>
+                    <span className="text-sm font-medium text-gray-900 dark:text-text-primary uppercase">
+                      {type}
+                    </span>
+                  </label>
+                ))}
+              </div>
+            </div>
+
+            {/* Host and Port */}
+            <div className="grid grid-cols-3 gap-3">
+              <div className="col-span-2">
+                <label className="block text-sm font-medium text-gray-700 dark:text-text-secondary mb-1">
+                  {t('主机地址', 'Host')}
+                </label>
+                <input
+                  type="text"
+                  value={form.host}
+                  onChange={(e) => setForm({ ...form, host: e.target.value })}
+                  placeholder="127.0.0.1"
+                  className="w-full px-3 py-2 bg-light-surface dark:bg-white/[0.04] border border-black/[0.06] dark:border-white/[0.04] rounded-lg text-gray-900 dark:text-text-primary text-sm focus:ring-2 focus:ring-brand-violet focus:border-transparent outline-none"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-text-secondary mb-1">
+                  {t('端口', 'Port')}
+                </label>
+                <input
+                  type="number"
+                  value={form.port || ''}
+                  onChange={(e) => setForm({ ...form, port: parseInt(e.target.value) || 0 })}
+                  placeholder="7890"
+                  min={1}
+                  max={65535}
+                  className="w-full px-3 py-2 bg-light-surface dark:bg-white/[0.04] border border-black/[0.06] dark:border-white/[0.04] rounded-lg text-gray-900 dark:text-text-primary text-sm focus:ring-2 focus:ring-brand-violet focus:border-transparent outline-none"
+                />
+              </div>
+            </div>
+
+            {/* Authentication (collapsible) */}
+            <div>
+              <button
+                type="button"
+                onClick={() => setShowAuth(!showAuth)}
+                className="text-sm text-gray-500 dark:text-text-tertiary hover:text-gray-700 dark:hover:text-text-secondary transition-colors"
+              >
+                {showAuth ? t('隐藏认证', 'Hide Authentication') : t('需要认证（可选）', 'Authentication (optional)')}
+              </button>
+
+              {showAuth && (
+                <div className="mt-3 grid grid-cols-2 gap-3">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-text-secondary mb-1">
+                      {t('用户名', 'Username')}
+                    </label>
+                    <input
+                      type="text"
+                      value={form.username || ''}
+                      onChange={(e) => setForm({ ...form, username: e.target.value || undefined })}
+                      placeholder={t('可选', 'Optional')}
+                      className="w-full px-3 py-2 bg-light-surface dark:bg-white/[0.04] border border-black/[0.06] dark:border-white/[0.04] rounded-lg text-gray-900 dark:text-text-primary text-sm focus:ring-2 focus:ring-brand-violet focus:border-transparent outline-none"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-text-secondary mb-1">
+                      {t('密码', 'Password')}
+                    </label>
+                    <div className="relative">
+                      <input
+                        type={showPassword ? 'text' : 'password'}
+                        value={form.password || ''}
+                        onChange={(e) => setForm({ ...form, password: e.target.value || undefined })}
+                        placeholder={t('可选', 'Optional')}
+                        className="w-full px-3 py-2 pr-10 bg-light-surface dark:bg-white/[0.04] border border-black/[0.06] dark:border-white/[0.04] rounded-lg text-gray-900 dark:text-text-primary text-sm focus:ring-2 focus:ring-brand-violet focus:border-transparent outline-none"
+                      />
+                      <button
+                        type="button"
+                        aria-label={showPassword ? t('隐藏密码', 'Hide password') : t('显示密码', 'Show password')}
+                        onClick={() => setShowPassword(!showPassword)}
+                        className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-text-secondary"
+                      >
+                        {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                      </button>
+                    </div>
                   </div>
                 </div>
+              )}
+            </div>
+
+            {/* Actions */}
+            <div className="flex items-center space-x-3 pt-2">
+              <button
+                onClick={handleTest}
+                disabled={testing || !form.host || !form.port}
+                className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-text-secondary bg-light-surface dark:bg-white/[0.04] border border-black/[0.06] dark:border-white/[0.04] rounded-lg hover:bg-gray-200 dark:hover:bg-white/[0.08] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {testing ? (
+                  <span className="flex items-center space-x-2">
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    <span>{t('测试中...', 'Testing...')}</span>
+                  </span>
+                ) : (
+                  t('测试连接', 'Test Connection')
+                )}
+              </button>
+
+              <button
+                onClick={handleSave}
+                disabled={saving || !hasChanges || !isFormValid}
+                className="px-4 py-2 text-sm font-medium text-white bg-brand-indigo hover:bg-brand-hover rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {saving ? (
+                  <span className="flex items-center space-x-2">
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    <span>{t('保存中...', 'Saving...')}</span>
+                  </span>
+                ) : (
+                  t('保存', 'Save')
+                )}
+              </button>
+            </div>
+
+            {/* Test Result */}
+            {testResult && (
+              <div className={`flex items-start space-x-2 p-3 rounded-lg text-sm ${
+                testResult.success
+                  ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400'
+                  : 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400'
+              }`}>
+                {testResult.success ? (
+                  <CheckCircle2 className="w-4 h-4 mt-0.5 flex-shrink-0" />
+                ) : (
+                  <XCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
+                )}
+                <span>
+                  {testResult.success
+                    ? t('代理连接成功', 'Proxy connection successful')
+                    : testResult.error || t('代理连接失败', 'Proxy connection failed')}
+                </span>
               </div>
             )}
           </div>
+        )}
+      </div>
 
-          {/* Actions */}
-          <div className="flex items-center space-x-3 pt-2">
-            <button
-              onClick={handleTest}
-              disabled={testing || !form.host || !form.port}
-              className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-text-secondary bg-light-surface dark:bg-white/[0.04] border border-black/[0.06] dark:border-white/[0.04] rounded-lg hover:bg-gray-200 dark:hover:bg-white/[0.08] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {testing ? (
-                <span className="flex items-center space-x-2">
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                  <span>{t('测试中...', 'Testing...')}</span>
-                </span>
-              ) : (
-                t('测试连接', 'Test Connection')
-              )}
-            </button>
-
-            <button
-              onClick={handleSave}
-              disabled={saving || !hasChanges || !isFormValid}
-              className="px-4 py-2 text-sm font-medium text-white bg-brand-indigo hover:bg-brand-hover rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {saving ? (
-                <span className="flex items-center space-x-2">
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                  <span>{t('保存中...', 'Saving...')}</span>
-                </span>
-              ) : (
-                t('保存', 'Save')
-              )}
-            </button>
+      {/* RPC Download Card */}
+      <div className="p-6 bg-white dark:bg-panel-dark rounded-xl border border-black/[0.06] dark:border-white/[0.04]">
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center space-x-3">
+            <Download className="w-5 h-5 text-gray-700 dark:text-text-secondary" />
+            <h4 className="font-medium text-gray-900 dark:text-text-primary">
+              {t('远程下载', 'Remote Download')}
+            </h4>
           </div>
-
-          {/* Test Result */}
-          {testResult && (
-            <div className={`flex items-start space-x-2 p-3 rounded-lg text-sm ${
-              testResult.success
-                ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400'
-                : 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400'
-            }`}>
-              {testResult.success ? (
-                <CheckCircle2 className="w-4 h-4 mt-0.5 flex-shrink-0" />
-              ) : (
-                <XCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
-              )}
-              <span>
-                {testResult.success
-                  ? t('代理连接成功', 'Proxy connection successful')
-                  : testResult.error || t('代理连接失败', 'Proxy connection failed')}
-              </span>
-            </div>
-          )}
+          <button
+            type="button"
+            role="switch"
+            aria-checked={rpcForm.enabled}
+            aria-label={t('启用远程下载', 'Enable remote download')}
+            onClick={handleRpcToggle}
+            className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${rpcForm.enabled ? 'bg-brand-indigo' : 'bg-gray-300 dark:bg-gray-600'}`}
+          >
+            <span
+              className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${rpcForm.enabled ? 'translate-x-[18px]' : 'translate-x-[2px]'}`}
+            />
+          </button>
         </div>
-      )}
+
+        {rpcForm.enabled && (
+          <div className="space-y-4">
+            {/* Host and Port */}
+            <div className="grid grid-cols-3 gap-3">
+              <div className="col-span-2">
+                <label className="block text-sm font-medium text-gray-700 dark:text-text-secondary mb-1">
+                  {t('主机地址', 'Host')}
+                </label>
+                <input
+                  type="text"
+                  value={rpcForm.host}
+                  onChange={(e) => setRpcForm({ ...rpcForm, host: e.target.value })}
+                  placeholder="127.0.0.1"
+                  className="w-full px-3 py-2 bg-light-surface dark:bg-white/[0.04] border border-black/[0.06] dark:border-white/[0.04] rounded-lg text-gray-900 dark:text-text-primary text-sm focus:ring-2 focus:ring-brand-violet focus:border-transparent outline-none"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-text-secondary mb-1">
+                  {t('端口', 'Port')}
+                </label>
+                <input
+                  type="number"
+                  value={rpcForm.port || ''}
+                  onChange={(e) => setRpcForm({ ...rpcForm, port: parseInt(e.target.value) || 0 })}
+                  placeholder="6800"
+                  min={1}
+                  max={65535}
+                  className="w-full px-3 py-2 bg-light-surface dark:bg-white/[0.04] border border-black/[0.06] dark:border-white/[0.04] rounded-lg text-gray-900 dark:text-text-primary text-sm focus:ring-2 focus:ring-brand-violet focus:border-transparent outline-none"
+                />
+              </div>
+            </div>
+
+            {/* Secret */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-text-secondary mb-1">
+                {t('密钥', 'Secret')}
+              </label>
+              <div className="relative">
+                <input
+                  type={showSecret ? 'text' : 'password'}
+                  value={rpcForm.secret}
+                  onChange={(e) => setRpcForm({ ...rpcForm, secret: e.target.value })}
+                  placeholder={t('可选，对应 aria2 的 --rpc-secret', 'Optional, aria2 --rpc-secret')}
+                  className="w-full px-3 py-2 pr-10 bg-light-surface dark:bg-white/[0.04] border border-black/[0.06] dark:border-white/[0.04] rounded-lg text-gray-900 dark:text-text-primary text-sm focus:ring-2 focus:ring-brand-violet focus:border-transparent outline-none"
+                />
+                <button
+                  type="button"
+                  aria-label={showSecret ? t('隐藏密钥', 'Hide secret') : t('显示密钥', 'Show secret')}
+                  onClick={() => setShowSecret(!showSecret)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 dark:hover:text-text-secondary"
+                >
+                  {showSecret ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                </button>
+              </div>
+            </div>
+
+            {/* Hint */}
+            <p className="text-xs text-gray-500 dark:text-text-tertiary">
+              {t(
+                '需要运行 aria2 并启用 RPC（aria2c --enable-rpc --rpc-listen-port=6800）',
+                'Requires aria2 with RPC enabled (aria2c --enable-rpc --rpc-listen-port=6800)'
+              )}
+            </p>
+
+            {/* Actions */}
+            <div className="flex items-center space-x-3 pt-2">
+              <button
+                onClick={handleRpcTest}
+                disabled={rpcTesting || !rpcForm.host || !rpcForm.port}
+                className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-text-secondary bg-light-surface dark:bg-white/[0.04] border border-black/[0.06] dark:border-white/[0.04] rounded-lg hover:bg-gray-200 dark:hover:bg-white/[0.08] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {rpcTesting ? (
+                  <span className="flex items-center space-x-2">
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    <span>{t('测试中...', 'Testing...')}</span>
+                  </span>
+                ) : (
+                  t('测试连接', 'Test Connection')
+                )}
+              </button>
+
+              <button
+                onClick={handleRpcSave}
+                disabled={rpcSaving || !rpcHasChanges || !isRpcFormValid}
+                className="px-4 py-2 text-sm font-medium text-white bg-brand-indigo hover:bg-brand-hover rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {rpcSaving ? (
+                  <span className="flex items-center space-x-2">
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    <span>{t('保存中...', 'Saving...')}</span>
+                  </span>
+                ) : (
+                  t('保存', 'Save')
+                )}
+              </button>
+            </div>
+
+            {/* Test Result */}
+            {rpcTestResult && (
+              <div className={`flex items-start space-x-2 p-3 rounded-lg text-sm ${
+                rpcTestResult.success
+                  ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400'
+                  : 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400'
+              }`}>
+                {rpcTestResult.success ? (
+                  <CheckCircle2 className="w-4 h-4 mt-0.5 flex-shrink-0" />
+                ) : (
+                  <XCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
+                )}
+                <span>
+                  {rpcTestResult.success
+                    ? `${t('连接成功', 'Connection successful')}${rpcTestResult.version ? ` (aria2 v${rpcTestResult.version})` : ''}`
+                    : rpcTestResult.error || t('连接失败', 'Connection failed')}
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/services/rpcDownloadService.ts
+++ b/src/services/rpcDownloadService.ts
@@ -1,5 +1,6 @@
 import type { RpcDownloadConfig } from '../types';
 import { backend } from './backendAdapter';
+import { isElectron } from './electronProxy';
 
 interface RpcTestResult {
   success: boolean;
@@ -21,15 +22,49 @@ function getAuthHeaders(apiSecret?: string): Record<string, string> {
   return headers;
 }
 
-async function getBaseUrl(): Promise<string> {
-  // Ensure backendAdapter has probed for the backend URL
+/**
+ * Resolve API base URL.
+ *  - Backend mode: use backend.backendUrl (proxied through Express)
+ *  - Client-only mode: call aria2 directly at http://host:port
+ */
+async function getBaseUrl(config?: RpcDownloadConfig): Promise<string> {
+  // Try backend first
   if (!backend.isAvailable) {
     await backend.init();
   }
-  if (!backend.backendUrl) {
-    throw new Error('Backend not available');
+  if (backend.backendUrl) {
+    return backend.backendUrl;
   }
-  return backend.backendUrl;
+  // Fallback: direct aria2 call (client-only mode)
+  if (config && config.host && config.port) {
+    return `http://${config.host}:${config.port}`;
+  }
+  throw new Error('Backend not available and no RPC config');
+}
+
+/** Call aria2 JSON-RPC directly (client-only mode) */
+async function callAria2Direct(
+  config: RpcDownloadConfig,
+  method: string,
+  params: unknown[],
+): Promise<Record<string, unknown>> {
+  const rpcUrl = `http://${config.host}:${config.port}/jsonrpc`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5000);
+  try {
+    const resp = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: '1', method, params }),
+      signal: controller.signal,
+    });
+    if (!resp.ok) {
+      throw new Error(`aria2 returned HTTP ${resp.status}`);
+    }
+    return await resp.json();
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 export async function testRpcDownload(
@@ -37,6 +72,19 @@ export async function testRpcDownload(
   apiSecret?: string,
 ): Promise<RpcTestResult> {
   try {
+    // Client-only mode: call aria2 directly
+    if (!backend.isAvailable) {
+      const params = config.secret ? [`token:${config.secret}`] : [];
+      const data = await callAria2Direct(config, 'aria2.getVersion', params);
+      if (data.error) {
+        const err = data.error as { message?: string };
+        return { success: false, error: err.message || 'RPC error' };
+      }
+      const result = data.result as Record<string, unknown> | undefined;
+      return { success: true, version: result?.version as string | undefined };
+    }
+
+    // Backend mode: proxy through Express
     const base = await getBaseUrl();
     const resp = await fetch(`${base}/settings/rpc-download/test`, {
       method: 'POST',
@@ -44,7 +92,6 @@ export async function testRpcDownload(
       body: JSON.stringify({
         host: config.host,
         port: config.port,
-        // Only send secret if user typed one; omit to let backend use stored value
         ...(config.secret ? { secret: config.secret } : {}),
       }),
     });
@@ -66,6 +113,25 @@ export async function sendToRpcDownload(
   apiSecret?: string,
 ): Promise<RpcDownloadResult> {
   try {
+    // Client-only mode: call aria2 directly
+    if (!backend.isAvailable) {
+      const { rpcDownloadConfig } = await import('../store/useAppStore').then(m => m.useAppStore.getState());
+      if (!rpcDownloadConfig.enabled || !rpcDownloadConfig.host || !rpcDownloadConfig.port) {
+        return { success: false, error: 'RPC download not configured' };
+      }
+      const params: unknown[] = rpcDownloadConfig.secret
+        ? [`token:${rpcDownloadConfig.secret}`, [url]]
+        : [[url]];
+      if (filename) params.push({ out: filename });
+      const data = await callAria2Direct(rpcDownloadConfig, 'aria2.addUri', params);
+      if (data.error) {
+        const err = data.error as { message?: string };
+        return { success: false, error: err.message || 'RPC error' };
+      }
+      return { success: true, gid: data.result as string };
+    }
+
+    // Backend mode: proxy through Express
     const base = await getBaseUrl();
     const resp = await fetch(`${base}/download/rpc`, {
       method: 'POST',

--- a/src/services/rpcDownloadService.ts
+++ b/src/services/rpcDownloadService.ts
@@ -1,6 +1,5 @@
 import type { RpcDownloadConfig } from '../types';
 import { backend } from './backendAdapter';
-import { isElectron } from './electronProxy';
 
 interface RpcTestResult {
   success: boolean;

--- a/src/services/rpcDownloadService.ts
+++ b/src/services/rpcDownloadService.ts
@@ -1,5 +1,4 @@
 import type { RpcDownloadConfig } from '../types';
-import { backend } from './backendAdapter';
 
 interface RpcTestResult {
   success: boolean;
@@ -21,18 +20,12 @@ function getAuthHeaders(apiSecret?: string): Record<string, string> {
   return headers;
 }
 
-/** Resolve API base: use backendUrl if probed, else fall back to relative path (same-origin) */
-function resolveBaseUrl(): string {
-  return backend.backendUrl || '/api';
-}
-
 export async function testRpcDownload(
   config: RpcDownloadConfig,
   apiSecret?: string,
 ): Promise<RpcTestResult> {
-  const base = resolveBaseUrl();
   try {
-    const resp = await fetch(`${base}/settings/rpc-download/test`, {
+    const resp = await fetch('/api/settings/rpc-download/test', {
       method: 'POST',
       headers: getAuthHeaders(apiSecret),
       body: JSON.stringify({
@@ -58,9 +51,8 @@ export async function sendToRpcDownload(
   filename: string,
   apiSecret?: string,
 ): Promise<RpcDownloadResult> {
-  const base = resolveBaseUrl();
   try {
-    const resp = await fetch(`${base}/download/rpc`, {
+    const resp = await fetch('/api/download/rpc', {
       method: 'POST',
       headers: getAuthHeaders(apiSecret),
       body: JSON.stringify({ url, filename }),

--- a/src/services/rpcDownloadService.ts
+++ b/src/services/rpcDownloadService.ts
@@ -1,4 +1,5 @@
 import type { RpcDownloadConfig } from '../types';
+import { backend } from './backendAdapter';
 
 interface RpcTestResult {
   success: boolean;
@@ -24,8 +25,12 @@ export async function testRpcDownload(
   config: RpcDownloadConfig,
   apiSecret?: string,
 ): Promise<RpcTestResult> {
+  const baseUrl = backend.backendUrl;
+  if (!baseUrl) {
+    return { success: false, error: 'Backend not available' };
+  }
   try {
-    const resp = await fetch('/api/settings/rpc-download/test', {
+    const resp = await fetch(`${baseUrl}/settings/rpc-download/test`, {
       method: 'POST',
       headers: getAuthHeaders(apiSecret),
       body: JSON.stringify({
@@ -51,8 +56,12 @@ export async function sendToRpcDownload(
   filename: string,
   apiSecret?: string,
 ): Promise<RpcDownloadResult> {
+  const baseUrl = backend.backendUrl;
+  if (!baseUrl) {
+    return { success: false, error: 'Backend not available' };
+  }
   try {
-    const resp = await fetch('/api/download/rpc', {
+    const resp = await fetch(`${baseUrl}/download/rpc`, {
       method: 'POST',
       headers: getAuthHeaders(apiSecret),
       body: JSON.stringify({ url, filename }),

--- a/src/services/rpcDownloadService.ts
+++ b/src/services/rpcDownloadService.ts
@@ -21,16 +21,18 @@ function getAuthHeaders(apiSecret?: string): Record<string, string> {
   return headers;
 }
 
+/** Resolve API base: use backendUrl if probed, else fall back to relative path (same-origin) */
+function resolveBaseUrl(): string {
+  return backend.backendUrl || '/api';
+}
+
 export async function testRpcDownload(
   config: RpcDownloadConfig,
   apiSecret?: string,
 ): Promise<RpcTestResult> {
-  const baseUrl = backend.backendUrl;
-  if (!baseUrl) {
-    return { success: false, error: 'Backend not available' };
-  }
+  const base = resolveBaseUrl();
   try {
-    const resp = await fetch(`${baseUrl}/settings/rpc-download/test`, {
+    const resp = await fetch(`${base}/settings/rpc-download/test`, {
       method: 'POST',
       headers: getAuthHeaders(apiSecret),
       body: JSON.stringify({
@@ -56,12 +58,9 @@ export async function sendToRpcDownload(
   filename: string,
   apiSecret?: string,
 ): Promise<RpcDownloadResult> {
-  const baseUrl = backend.backendUrl;
-  if (!baseUrl) {
-    return { success: false, error: 'Backend not available' };
-  }
+  const base = resolveBaseUrl();
   try {
-    const resp = await fetch(`${baseUrl}/download/rpc`, {
+    const resp = await fetch(`${base}/download/rpc`, {
       method: 'POST',
       headers: getAuthHeaders(apiSecret),
       body: JSON.stringify({ url, filename }),

--- a/src/services/rpcDownloadService.ts
+++ b/src/services/rpcDownloadService.ts
@@ -1,0 +1,64 @@
+import type { RpcDownloadConfig } from '../types';
+
+interface RpcTestResult {
+  success: boolean;
+  error?: string;
+  version?: string;
+}
+
+interface RpcDownloadResult {
+  success: boolean;
+  error?: string;
+  gid?: string;
+}
+
+function getAuthHeaders(apiSecret?: string): Record<string, string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (apiSecret) {
+    headers['Authorization'] = `Bearer ${apiSecret}`;
+  }
+  return headers;
+}
+
+export async function testRpcDownload(
+  config: RpcDownloadConfig,
+  apiSecret?: string,
+): Promise<RpcTestResult> {
+  try {
+    const resp = await fetch('/api/settings/rpc-download/test', {
+      method: 'POST',
+      headers: getAuthHeaders(apiSecret),
+      body: JSON.stringify({
+        host: config.host,
+        port: config.port,
+        secret: config.secret,
+      }),
+    });
+    return await resp.json();
+  } catch (e) {
+    return {
+      success: false,
+      error: e instanceof Error ? e.message : 'Request failed',
+    };
+  }
+}
+
+export async function sendToRpcDownload(
+  url: string,
+  filename: string,
+  apiSecret?: string,
+): Promise<RpcDownloadResult> {
+  try {
+    const resp = await fetch('/api/download/rpc', {
+      method: 'POST',
+      headers: getAuthHeaders(apiSecret),
+      body: JSON.stringify({ url, filename }),
+    });
+    return await resp.json();
+  } catch (e) {
+    return {
+      success: false,
+      error: e instanceof Error ? e.message : 'Request failed',
+    };
+  }
+}

--- a/src/services/rpcDownloadService.ts
+++ b/src/services/rpcDownloadService.ts
@@ -1,4 +1,5 @@
 import type { RpcDownloadConfig } from '../types';
+import { backend } from './backendAdapter';
 
 interface RpcTestResult {
   success: boolean;
@@ -20,18 +21,31 @@ function getAuthHeaders(apiSecret?: string): Record<string, string> {
   return headers;
 }
 
+async function getBaseUrl(): Promise<string> {
+  // Ensure backendAdapter has probed for the backend URL
+  if (!backend.isAvailable) {
+    await backend.init();
+  }
+  if (!backend.backendUrl) {
+    throw new Error('Backend not available');
+  }
+  return backend.backendUrl;
+}
+
 export async function testRpcDownload(
   config: RpcDownloadConfig,
   apiSecret?: string,
 ): Promise<RpcTestResult> {
   try {
-    const resp = await fetch('/api/settings/rpc-download/test', {
+    const base = await getBaseUrl();
+    const resp = await fetch(`${base}/settings/rpc-download/test`, {
       method: 'POST',
       headers: getAuthHeaders(apiSecret),
       body: JSON.stringify({
         host: config.host,
         port: config.port,
-        secret: config.secret,
+        // Only send secret if user typed one; omit to let backend use stored value
+        ...(config.secret ? { secret: config.secret } : {}),
       }),
     });
     if (!resp.ok) {
@@ -52,7 +66,8 @@ export async function sendToRpcDownload(
   apiSecret?: string,
 ): Promise<RpcDownloadResult> {
   try {
-    const resp = await fetch('/api/download/rpc', {
+    const base = await getBaseUrl();
+    const resp = await fetch(`${base}/download/rpc`, {
       method: 'POST',
       headers: getAuthHeaders(apiSecret),
       body: JSON.stringify({ url, filename }),

--- a/src/services/rpcDownloadService.ts
+++ b/src/services/rpcDownloadService.ts
@@ -34,6 +34,9 @@ export async function testRpcDownload(
         secret: config.secret,
       }),
     });
+    if (!resp.ok) {
+      return { success: false, error: `Server returned ${resp.status}` };
+    }
     return await resp.json();
   } catch (e) {
     return {
@@ -54,6 +57,9 @@ export async function sendToRpcDownload(
       headers: getAuthHeaders(apiSecret),
       body: JSON.stringify({ url, filename }),
     });
+    if (!resp.ok) {
+      return { success: false, error: `Server returned ${resp.status}` };
+    }
     return await resp.json();
   } catch (e) {
     return {

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -8,6 +8,7 @@ import {
   AIConfig,
   WebDAVConfig,
   ProxyConfig,
+  RpcDownloadConfig,
   SearchFilters,
   GitHubUser,
   Category,
@@ -172,6 +173,9 @@ interface AppActions {
   // Proxy actions
   setProxyConfig: (updates: Partial<ProxyConfig>) => void;
 
+  // RPC Download actions
+  setRpcDownloadConfig: (updates: Partial<RpcDownloadConfig>) => void;
+
   // Release Timeline View actions
   setReleaseViewMode: (mode: 'timeline' | 'repository') => void;
   setReleaseShowMode: (mode: 'all' | 'unread') => void;
@@ -279,6 +283,7 @@ type PersistedAppState = Partial<
     | 'discoverySortBy'
     | 'discoverySortOrder'
     | 'proxyConfig'
+    | 'rpcDownloadConfig'
     | 'subscriptionRepos'
     | 'subscriptionLastRefresh'
     | 'subscriptionIsLoading'
@@ -550,6 +555,20 @@ const normalizePersistedState = (
       }
       return { enabled: false, type: 'http' as const, host: '', port: 7890 };
     })(),
+    rpcDownloadConfig: (() => {
+      const r = (safePersisted as Record<string, unknown>).rpcDownloadConfig;
+      if (r && typeof r === 'object') {
+        const obj = r as Record<string, unknown>;
+        return {
+          enabled: typeof obj.enabled === 'boolean' ? obj.enabled : false,
+          host: typeof obj.host === 'string' ? obj.host : '',
+          port: typeof obj.port === 'number' && Number.isFinite(obj.port) ? obj.port : 6800,
+          // secret 不从持久化恢复，仅在内存中
+          secret: '',
+        };
+      }
+      return { enabled: false, host: '', port: 6800, secret: '' };
+    })(),
   };
 };
 
@@ -738,6 +757,7 @@ export const useAppStore = create<AppState & AppActions>()(
       analysisProgress: { current: 0, total: 0 },
       backendApiSecret: readSessionBackendSecret(),
       proxyConfig: { enabled: false, type: 'http', host: '', port: 7890 },
+      rpcDownloadConfig: { enabled: false, host: '', port: 6800, secret: '' },
       isSidebarCollapsed: false,
       readmeModalOpen: false,
       releaseViewMode: 'timeline',
@@ -1266,6 +1286,9 @@ export const useAppStore = create<AppState & AppActions>()(
       setProxyConfig: (updates) => set((state) => ({
         proxyConfig: { ...state.proxyConfig, ...updates }
       })),
+      setRpcDownloadConfig: (updates) => set((state) => ({
+        rpcDownloadConfig: { ...state.rpcDownloadConfig, ...updates }
+      })),
 
       // Release Timeline View actions
       setReleaseViewMode: (releaseViewMode) => set({ releaseViewMode }),
@@ -1517,6 +1540,13 @@ export const useAppStore = create<AppState & AppActions>()(
         username: state.proxyConfig.username,
         // password 不持久化，仅保留在内存中
       },
+      // 持久化 RPC 下载配置，但排除密钥（安全考虑）
+      rpcDownloadConfig: {
+        enabled: state.rpcDownloadConfig.enabled,
+        host: state.rpcDownloadConfig.host,
+        port: state.rpcDownloadConfig.port,
+        // secret 不持久化，仅保留在内存中
+      },
       }),
       migrate: (persistedState) => {
         // 版本升级适配处理
@@ -1641,6 +1671,11 @@ export const useAppStore = create<AppState & AppActions>()(
   // v5→v6: 初始化 proxyConfig
   if (state && !(state as Record<string, unknown>).proxyConfig) {
     (state as Record<string, unknown>).proxyConfig = { enabled: false, type: 'http', host: '', port: 7890 };
+  }
+
+  // 初始化 rpcDownloadConfig
+  if (state && !(state as Record<string, unknown>).rpcDownloadConfig) {
+    (state as Record<string, unknown>).rpcDownloadConfig = { enabled: false, host: '', port: 6800, secret: '' };
   }
 
         return state as PersistedAppState;

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -564,10 +564,9 @@ const normalizePersistedState = (
           host: typeof obj.host === 'string' ? obj.host : '',
           port: typeof obj.port === 'number' && Number.isFinite(obj.port) ? obj.port : 6800,
           // secret 不从持久化恢复，仅在内存中
-          secret: '',
         };
       }
-      return { enabled: false, host: '', port: 6800, secret: '' };
+      return { enabled: false, host: '', port: 6800 };
     })(),
   };
 };
@@ -757,7 +756,7 @@ export const useAppStore = create<AppState & AppActions>()(
       analysisProgress: { current: 0, total: 0 },
       backendApiSecret: readSessionBackendSecret(),
       proxyConfig: { enabled: false, type: 'http', host: '', port: 7890 },
-      rpcDownloadConfig: { enabled: false, host: '', port: 6800, secret: '' },
+      rpcDownloadConfig: { enabled: false, host: '', port: 6800 },
       isSidebarCollapsed: false,
       readmeModalOpen: false,
       releaseViewMode: 'timeline',
@@ -1675,7 +1674,7 @@ export const useAppStore = create<AppState & AppActions>()(
 
   // 初始化 rpcDownloadConfig
   if (state && !(state as Record<string, unknown>).rpcDownloadConfig) {
-    (state as Record<string, unknown>).rpcDownloadConfig = { enabled: false, host: '', port: 6800, secret: '' };
+    (state as Record<string, unknown>).rpcDownloadConfig = { enabled: false, host: '', port: 6800 };
   }
 
         return state as PersistedAppState;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -169,6 +169,13 @@ export interface ProxyConfig {
   password?: string;
 }
 
+export interface RpcDownloadConfig {
+  enabled: boolean;
+  host: string;
+  port: number;
+  secret: string;
+}
+
 export interface SearchFilters {
   query: string;
   tags: string[];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -173,7 +173,7 @@ export interface RpcDownloadConfig {
   enabled: boolean;
   host: string;
   port: number;
-  secret: string;
+  secret?: string;
 }
 
 export interface SearchFilters {


### PR DESCRIPTION
## 概述

在网络设置中新增远程 RPC 下载配置，支持将 Release 资产下载任务发送到 aria2 远程下载器。

## 功能

- **默认关闭**：在 设置 > 网络设置 > 网络代理 下方新增「远程下载」配置卡片
- **可配置项**：RPC 地址、端口（默认 6800）、密钥（可选）
- **测试连接**：调用 aria2.getVersion 验证连接，成功显示版本号
- **下载行为切换**：开启后 Release 资产点击下载会发送到远程下载器，关闭则恢复浏览器直接下载
- **服务未运行提示**：aria2 未运行时 toast 提示「远程下载服务未运行，请检查配置」

## 改动文件

| 文件 | 说明 |
|---|---|
| src/types/index.ts | 新增 RpcDownloadConfig 接口 |
| src/store/useAppStore.ts | 新增 rpcDownloadConfig 状态（7 处 touchpoint） |
| src/services/rpcDownloadService.ts | 新增：测试连接 + 发送下载 API |
| src/components/settings/NetworkPanel.tsx | 新增 RPC 下载配置 UI |
| src/components/ReleaseCard.tsx | 下载链接行为改造 |
| server/src/routes/proxy.ts | 新增 4 个 API 端点 |
| server/src/services/proxyService.ts | 导出 validateUrl 供复用 |

## 安全措施

- 密钥前端不持久化（IndexedDB），后端 AES-256-GCM 加密存储
- /api/download/rpc 端点有 SSRF 防护（阻止 localhost、内网 IP）
- 测试连接 5s 超时，下载转发 10s 超时

## 测试

1. 启动 aria2：aria2c --enable-rpc --rpc-listen-port=6800 --rpc-secret=test
2. 设置中配置 RPC → 测试连接 → 显示版本号
3. 开启 RPC → Release 页面点击下载 → 任务出现在 aria2
4. 关闭 aria2 → 点击下载 → toast 提示服务未运行
5. 关闭 RPC 开关 → 恢复浏览器直接下载

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote RPC Download: configure host/port and optional secret, test connectivity, save settings, and route downloads via the RPC service with per-link status and toasts.
  * Settings syncs with backend when available and reflects whether a secret is stored; secrets are not persisted locally.

* **Bug Fixes**
  * URL validation to block invalid/unsafe URLs before remote-download requests and clearer JSON error responses for RPC/connection failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->