### PR TITLE
fix: 加密密钥长度校验 + AI 标签同步丢失 (#184)

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -10,6 +10,7 @@ interface Config {
   nodeEnv: string;
 }
 
+/** Resolve the data directory path, creating it if it doesn't exist. */
 function resolveDataDir(): string {
   const dataDir = path.resolve(process.cwd(), 'data');
   if (!fs.existsSync(dataDir)) {
@@ -45,6 +46,10 @@ export function normalizeEncryptionKey(key: string): string {
   return crypto.createHash('sha256').update(trimmed, 'utf8').digest('hex');
 }
 
+/**
+ * Resolve the AES-256 encryption key from env var, key file, or auto-generation.
+ * All non-standard formats are normalized to a 64-char hex string (32 bytes).
+ */
 function resolveEncryptionKey(dataDir: string): string {
   const envKey = process.env.ENCRYPTION_KEY;
   if (envKey) {
@@ -69,6 +74,7 @@ function resolveEncryptionKey(dataDir: string): string {
   return newKey;
 }
 
+/** Load all server configuration from environment variables and defaults. */
 function loadConfig(): Config {
   const dataDir = resolveDataDir();
 

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -24,8 +24,7 @@ function resolveDataDir(): string {
  * Backward compatibility:
  * - Valid 64-char hex string → returned as-is (no change for existing users)
  * - Short hex (e.g. 32 chars from `openssl rand -hex 16`) → SHA-256 derived
- * - Non-hex input (base64, plain text) → SHA-256 derived
- * - Too-long hex → truncated to 64 chars
+ * - Non-hex input (base64, plain text, too-long hex) → SHA-256 derived
  */
 export function normalizeEncryptionKey(key: string): string {
   const trimmed = key.trim();
@@ -37,10 +36,6 @@ export function normalizeEncryptionKey(key: string): string {
 
   // Hex string but wrong length — derive via SHA-256 for deterministic 32-byte result
   if (/^[0-9a-fA-F]+$/.test(trimmed)) {
-    if (trimmed.length > 64) {
-      console.warn(`[config] ENCRYPTION_KEY is ${trimmed.length} hex chars, truncating to 64.`);
-      return trimmed.slice(0, 64);
-    }
     console.warn(`[config] ENCRYPTION_KEY is ${trimmed.length} hex chars (expected 64). Deriving 32-byte key via SHA-256. Previously encrypted data may need re-encryption.`);
     return crypto.createHash('sha256').update(trimmed, 'utf8').digest('hex');
   }
@@ -59,7 +54,13 @@ function resolveEncryptionKey(dataDir: string): string {
   const keyFilePath = path.join(dataDir, '.encryption-key');
   if (fs.existsSync(keyFilePath)) {
     const fileKey = fs.readFileSync(keyFilePath, 'utf-8').trim();
-    return normalizeEncryptionKey(fileKey);
+    const normalized = normalizeEncryptionKey(fileKey);
+    // Persist normalized key so future startups (even without normalization) use the correct format
+    if (normalized !== fileKey) {
+      fs.writeFileSync(keyFilePath, normalized, { mode: 0o600 });
+      console.log('[config] Normalized encryption key written back to data/.encryption-key');
+    }
+    return normalized;
   }
 
   const newKey = crypto.randomBytes(32).toString('hex');

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -18,15 +18,48 @@ function resolveDataDir(): string {
   return dataDir;
 }
 
+/**
+ * Normalize an encryption key to a 64-char hex string (32 bytes) suitable for AES-256.
+ *
+ * Backward compatibility:
+ * - Valid 64-char hex string → returned as-is (no change for existing users)
+ * - Short hex (e.g. 32 chars from `openssl rand -hex 16`) → SHA-256 derived
+ * - Non-hex input (base64, plain text) → SHA-256 derived
+ * - Too-long hex → truncated to 64 chars
+ */
+export function normalizeEncryptionKey(key: string): string {
+  const trimmed = key.trim();
+
+  // Already a valid 32-byte hex key — pass through unchanged
+  if (/^[0-9a-fA-F]{64}$/.test(trimmed)) {
+    return trimmed;
+  }
+
+  // Hex string but wrong length — derive via SHA-256 for deterministic 32-byte result
+  if (/^[0-9a-fA-F]+$/.test(trimmed)) {
+    if (trimmed.length > 64) {
+      console.warn(`[config] ENCRYPTION_KEY is ${trimmed.length} hex chars, truncating to 64.`);
+      return trimmed.slice(0, 64);
+    }
+    console.warn(`[config] ENCRYPTION_KEY is ${trimmed.length} hex chars (expected 64). Deriving 32-byte key via SHA-256. Previously encrypted data may need re-encryption.`);
+    return crypto.createHash('sha256').update(trimmed, 'utf8').digest('hex');
+  }
+
+  // Non-hex input (base64, plain text, etc.) — derive via SHA-256
+  console.warn('[config] ENCRYPTION_KEY is not a valid hex string. Deriving 32-byte key via SHA-256.');
+  return crypto.createHash('sha256').update(trimmed, 'utf8').digest('hex');
+}
+
 function resolveEncryptionKey(dataDir: string): string {
   const envKey = process.env.ENCRYPTION_KEY;
   if (envKey) {
-    return envKey;
+    return normalizeEncryptionKey(envKey);
   }
 
   const keyFilePath = path.join(dataDir, '.encryption-key');
   if (fs.existsSync(keyFilePath)) {
-    return fs.readFileSync(keyFilePath, 'utf-8').trim();
+    const fileKey = fs.readFileSync(keyFilePath, 'utf-8').trim();
+    return normalizeEncryptionKey(fileKey);
   }
 
   const newKey = crypto.randomBytes(32).toString('hex');

--- a/server/src/routes/repositories.ts
+++ b/server/src/routes/repositories.ts
@@ -120,7 +120,7 @@ router.put('/api/repositories', (req, res) => {
     }
 
     const stmt = db.prepare(`
-      INSERT OR REPLACE INTO repositories (
+      INSERT INTO repositories (
         id, name, full_name, description, html_url, stargazers_count, language,
         created_at, updated_at, pushed_at, starred_at,
         owner_login, owner_avatar_url, topics,
@@ -128,6 +128,31 @@ router.put('/api/repositories', (req, res) => {
         custom_description, custom_tags, custom_category, category_locked, last_edited,
         subscribed_to_releases
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        name = excluded.name,
+        full_name = excluded.full_name,
+        description = excluded.description,
+        html_url = excluded.html_url,
+        stargazers_count = excluded.stargazers_count,
+        language = excluded.language,
+        created_at = excluded.created_at,
+        updated_at = excluded.updated_at,
+        pushed_at = excluded.pushed_at,
+        starred_at = excluded.starred_at,
+        owner_login = excluded.owner_login,
+        owner_avatar_url = excluded.owner_avatar_url,
+        topics = excluded.topics,
+        ai_summary = CASE WHEN excluded.ai_summary IS NOT NULL AND excluded.ai_summary != '' THEN excluded.ai_summary ELSE repositories.ai_summary END,
+        ai_tags = CASE WHEN excluded.ai_tags IS NOT NULL AND excluded.ai_tags != '[]' THEN excluded.ai_tags ELSE repositories.ai_tags END,
+        ai_platforms = CASE WHEN excluded.ai_platforms IS NOT NULL AND excluded.ai_platforms != '[]' THEN excluded.ai_platforms ELSE repositories.ai_platforms END,
+        analyzed_at = CASE WHEN excluded.analyzed_at IS NOT NULL AND excluded.analyzed_at != '' THEN excluded.analyzed_at ELSE repositories.analyzed_at END,
+        analysis_failed = excluded.analysis_failed,
+        custom_description = CASE WHEN excluded.custom_description IS NOT NULL AND excluded.custom_description != '' THEN excluded.custom_description ELSE repositories.custom_description END,
+        custom_tags = CASE WHEN excluded.custom_tags IS NOT NULL AND excluded.custom_tags != '[]' THEN excluded.custom_tags ELSE repositories.custom_tags END,
+        custom_category = CASE WHEN excluded.custom_category IS NOT NULL AND excluded.custom_category != '' THEN excluded.custom_category ELSE repositories.custom_category END,
+        category_locked = excluded.category_locked,
+        last_edited = CASE WHEN excluded.last_edited IS NOT NULL AND excluded.last_edited != '' THEN excluded.last_edited ELSE repositories.last_edited END,
+        subscribed_to_releases = excluded.subscribed_to_releases
     `);
 
     const deleteAllReleases = db.prepare('DELETE FROM releases');

--- a/server/src/routes/repositories.ts
+++ b/server/src/routes/repositories.ts
@@ -3,7 +3,7 @@ import { getDb } from '../db/connection.js';
 
 const router = Router();
 
-// Helper to parse JSON columns safely
+/** Parse a JSON string column from the database, returning an empty array on failure. */
 function parseJsonColumn(value: unknown): unknown[] {
   if (typeof value !== 'string' || !value) return [];
   try {
@@ -12,7 +12,7 @@ function parseJsonColumn(value: unknown): unknown[] {
   } catch { return []; }
 }
 
-// Helper to transform DB row to API response
+/** Transform a database row into the API response shape, parsing JSON columns. */
 function transformRepo(row: Record<string, unknown>) {
   return {
     id: row.id,

--- a/server/tests/services/config.test.ts
+++ b/server/tests/services/config.test.ts
@@ -51,12 +51,17 @@ describe('normalizeEncryptionKey', () => {
     expect(normalizeEncryptionKey(paddedKey)).toBe(validKey);
   });
 
-  it('should truncate a too-long hex string to 64 chars', () => {
+  it('should derive key from too-long hex string via SHA-256 (not truncate)', () => {
     const longHex = 'a'.repeat(80); // 80 hex chars
     const result = normalizeEncryptionKey(longHex);
 
     expect(result).toHaveLength(64);
-    expect(result).toBe('a'.repeat(64));
+    expect(/^[0-9a-fA-F]{64}$/.test(result)).toBe(true);
+
+    // Should be SHA-256 derived, NOT truncated
+    const expected = crypto.createHash('sha256').update(longHex, 'utf8').digest('hex');
+    expect(result).toBe(expected);
+    expect(result).not.toBe('a'.repeat(64)); // not a truncation
   });
 
   it('should handle the openssl rand -hex 16 scenario (32 chars)', () => {
@@ -88,5 +93,26 @@ describe('normalizeEncryptionKey', () => {
       const keyBuffer = Buffer.from(result, 'hex');
       expect(keyBuffer.length).toBe(32);
     }
+  });
+
+  it('should handle empty string input', () => {
+    const result = normalizeEncryptionKey('');
+    expect(result).toHaveLength(64);
+    expect(/^[0-9a-fA-F]{64}$/.test(result)).toBe(true);
+
+    // Deterministic
+    expect(normalizeEncryptionKey('')).toBe(result);
+  });
+
+  it('should handle 64-char non-hex string (e.g. contains invalid hex chars)', () => {
+    const nonHex64 = 'a'.repeat(63) + 'g'; // 64 chars but 'g' is not hex
+    const result = normalizeEncryptionKey(nonHex64);
+
+    expect(result).toHaveLength(64);
+    expect(/^[0-9a-fA-F]{64}$/.test(result)).toBe(true);
+
+    // Should be SHA-256 derived (not treated as valid hex)
+    const expected = crypto.createHash('sha256').update(nonHex64, 'utf8').digest('hex');
+    expect(result).toBe(expected);
   });
 });

--- a/server/tests/services/config.test.ts
+++ b/server/tests/services/config.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import crypto from 'node:crypto';
+import { normalizeEncryptionKey } from '../../src/config.js';
+
+describe('normalizeEncryptionKey', () => {
+  it('should pass through a valid 64-char hex key unchanged', () => {
+    const validKey = crypto.randomBytes(32).toString('hex'); // 64 hex chars
+    expect(normalizeEncryptionKey(validKey)).toBe(validKey);
+  });
+
+  it('should derive 32-byte key from short hex string (32 chars)', () => {
+    const shortHex = '0123456789abcdef0123456789abcdef'; // 32 chars
+    const result = normalizeEncryptionKey(shortHex);
+
+    // Result should be 64 hex chars (32 bytes)
+    expect(result).toHaveLength(64);
+    expect(/^[0-9a-fA-F]{64}$/.test(result)).toBe(true);
+
+    // Should be deterministic — same input produces same output
+    expect(normalizeEncryptionKey(shortHex)).toBe(result);
+
+    // Should be the SHA-256 of the input
+    const expected = crypto.createHash('sha256').update(shortHex, 'utf8').digest('hex');
+    expect(result).toBe(expected);
+  });
+
+  it('should derive key from non-hex string (base64-like)', () => {
+    const base64Key = 'dGhpcyBpcyBhIGJhc2U2NCBrZXkgMTIzNA==';
+    const result = normalizeEncryptionKey(base64Key);
+
+    expect(result).toHaveLength(64);
+    expect(/^[0-9a-fA-F]{64}$/.test(result)).toBe(true);
+
+    const expected = crypto.createHash('sha256').update(base64Key, 'utf8').digest('hex');
+    expect(result).toBe(expected);
+  });
+
+  it('should derive key from plain text string', () => {
+    const plainKey = 'my-secret-key';
+    const result = normalizeEncryptionKey(plainKey);
+
+    expect(result).toHaveLength(64);
+    expect(/^[0-9a-fA-F]{64}$/.test(result)).toBe(true);
+  });
+
+  it('should trim whitespace before processing', () => {
+    const validKey = crypto.randomBytes(32).toString('hex');
+    const paddedKey = `  ${validKey}  `;
+
+    // Should match the trimmed version
+    expect(normalizeEncryptionKey(paddedKey)).toBe(validKey);
+  });
+
+  it('should truncate a too-long hex string to 64 chars', () => {
+    const longHex = 'a'.repeat(80); // 80 hex chars
+    const result = normalizeEncryptionKey(longHex);
+
+    expect(result).toHaveLength(64);
+    expect(result).toBe('a'.repeat(64));
+  });
+
+  it('should handle the openssl rand -hex 16 scenario (32 chars)', () => {
+    // Simulates what a user would get from: openssl rand -hex 16
+    const opensslKey = crypto.randomBytes(16).toString('hex'); // 32 chars
+    expect(opensslKey).toHaveLength(32);
+
+    const result = normalizeEncryptionKey(opensslKey);
+    expect(result).toHaveLength(64);
+
+    // Must be a valid AES-256 key (32 bytes)
+    const keyBuffer = Buffer.from(result, 'hex');
+    expect(keyBuffer.length).toBe(32);
+  });
+
+  it('should produce a valid AES-256 key from any input', () => {
+    const inputs = [
+      'short',
+      'a'.repeat(32),
+      'a'.repeat(64),
+      'a'.repeat(128),
+      'base64+/==content',
+      crypto.randomBytes(16).toString('hex'),
+      crypto.randomBytes(32).toString('hex'),
+    ];
+
+    for (const input of inputs) {
+      const result = normalizeEncryptionKey(input);
+      const keyBuffer = Buffer.from(result, 'hex');
+      expect(keyBuffer.length).toBe(32);
+    }
+  });
+});


### PR DESCRIPTION
## 问题

Closes #184
Related: #166

**问题 1：AI 配置同步返回 422**
用户设置 `ENCRYPTION_KEY` 为 32 字符 hex（如 `openssl rand -hex 16`），`Buffer.from(key, hex)` 只解出 16 字节，AES-256 要求 32 字节 → 抛 `Invalid key length` → AI config 加密失败 → 422。

**问题 2：AI 标签同步后消失**
`PUT /api/repositories` 用 `INSERT OR REPLACE` 整行替换，前端推送空 `ai_tags`（`[]`）会覆盖后端已有的 AI 标签，导致用户手动恢复的标签在下一次同步后凭空消失。#166 中报告的「同步后自动分类消失」也是同一根因。

## 修复方案

### Fix 1：加密密钥自动规范化 — `server/src/config.ts`

新增 `normalizeEncryptionKey()` 函数，对所有来源的 key 做规范化：

| 输入场景 | 处理方式 | 向后兼容 |
|---|---|---|
| 64 字符 hex（正确格式） | 原样返回 | ✅ 零影响 |
| 短 hex（如 32 字符） | SHA-256 派生为 32 字节 | ⚠️ 日志告警 |
| 非 hex（base64、纯文本） | SHA-256 派生为 32 字节 | ⚠️ 日志告警 |
| 超长 hex | SHA-256 派生 | ✅ |

规范化后的 key 会回写到 `.encryption-key` 文件，确保后续启动即使无规范化代码也能正常使用。

### Fix 2：AI Tags 同步丢失 — `server/src/routes/repositories.ts`

改为 `INSERT ... ON CONFLICT(id) DO UPDATE SET ...`，对 AI 相关字段做条件更新：

```sql
ai_tags = CASE WHEN excluded.ai_tags IS NOT NULL AND excluded.ai_tags != '[]'
          THEN excluded.ai_tags ELSE repositories.ai_tags END
```

仅当推送的值**非空**时才更新，空值保留后端已有数据。受影响字段：`ai_summary`、`ai_tags`、`ai_platforms`、`custom_description`、`custom_tags`、`custom_category`、`analyzed_at`、`last_edited`。

## 测试

- 新增 `server/tests/services/config.test.ts`（10 个用例），覆盖所有 key 格式场景 + 边界条件
- 全部现有 crypto 测试通过
- 前后端 TypeScript 类型检查通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository batch updates now preserve more existing field values, preventing unintended data loss when updating records without providing all fields.

* **Improvements**
  * Enhanced encryption key handling with improved validation and normalization for increased consistency and robustness.

* **Tests**
  * Added comprehensive test coverage for encryption key normalization functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->