### PR TITLE
ci: 自动构建后端 Docker 镜像并发布到 GHCR (#106)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,57 @@
+name: Publish Docker Image to GHCR
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/github-stars-manager-server
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # branch push → "latest"
+            type=raw,value=latest,enable={{is_default_branch}}
+            # tag push → "v1.2.3", "1.2.3", "1.2", "1"
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            # every build → sha-abc1234
+            type=sha,prefix=sha-
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./server
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,15 +19,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -35,7 +35,7 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -49,7 +49,7 @@ jobs:
             type=sha,prefix=sha-
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./server
           push: true

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -18,10 +18,22 @@ docker-compose up -d
 # The application will be available at http://localhost:8080
 ```
 
+> **Note:** If the GHCR package is set to private, you must authenticate before pulling:
+> ```bash
+> docker login ghcr.io -u YOUR_GITHUB_USERNAME
+> ```
+> Use a [Personal Access Token](https://github.com/settings/tokens) (with `read:packages` scope) as the password.
+
 Available image tags:
 - `latest` — latest build from the `main` branch
 - `v0.6.2`, `0.6.2` — specific version tags
 - `sha-abc1234` — specific commit builds
+
+To pin a specific version in `docker-compose.yml`, set `BACKEND_IMAGE_TAG` in your `.env` file:
+
+```bash
+BACKEND_IMAGE_TAG=v0.6.2
+```
 
 ## Backend Server (docker run)
 
@@ -77,6 +89,7 @@ To customize secrets, create a `.env` file in the project root:
 ```bash
 API_SECRET=my-strong-secret
 ENCRYPTION_KEY=my-encryption-key
+BACKEND_IMAGE_TAG=v0.6.2    # pin backend image version (default: latest)
 ```
 
 Then `docker-compose up -d` reads them automatically.

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -98,13 +98,27 @@ Then `docker-compose up -d` reads them automatically.
 
 ### Using Docker Compose (local build)
 
-Edit `docker-compose.yml` — comment out the `image:` line and uncomment `build: ./server`, then:
+**Option A — Edit `docker-compose.yml` directly:**
+
+Comment out the `image:` line and uncomment `build: ./server`, then:
 
 ```bash
 docker-compose up -d --build
-
-# The application will be available at http://localhost:8080
 ```
+
+**Option B — Use an override file (no editing needed):**
+
+Create `docker-compose.override.yml` in the project root:
+
+```yaml
+services:
+  backend:
+    build: ./server
+```
+
+Then run `docker-compose up -d --build`. The override file takes precedence automatically. To switch back to GHCR images, simply delete the override file.
+
+> **Note:** Do NOT commit the override file to git — it would force local builds for all users.
 
 ### Using Docker directly (frontend only)
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -7,18 +7,38 @@ This application can be deployed using Docker with minimal configuration. The Do
 - Docker installed on your system
 - Docker Compose (optional, but recommended)
 
-## Building and Running with Docker
+## Quick Start (Using Pre-built Images from GHCR)
 
-### Using Docker Compose (Recommended)
+The fastest way to get started — no build required:
 
 ```bash
-# Build and start the container
+# Pull the latest backend image
+docker pull ghcr.io/amintacccp/github-stars-manager-server:latest
+
+# Using Docker Compose (pulls images automatically)
 docker-compose up -d
 
 # The application will be available at http://localhost:8080
 ```
 
-### Using Docker directly
+Available image tags:
+- `latest` — latest build from the `main` branch
+- `v0.6.2`, `0.6.2` — specific version tags
+- `sha-abc1234` — specific commit builds
+
+## Building Locally with Docker
+
+### Using Docker Compose (local build)
+
+Edit `docker-compose.yml` — comment out the `image:` line and uncomment `build: ./server`, then:
+
+```bash
+docker-compose up -d --build
+
+# The application will be available at http://localhost:8080
+```
+
+### Using Docker directly (frontend only)
 
 ```bash
 # Build the image

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -12,9 +12,6 @@ This application can be deployed using Docker with minimal configuration. The Do
 The fastest way to get started — no build required:
 
 ```bash
-# Pull the latest backend image
-docker pull ghcr.io/amintacccp/github-stars-manager-server:latest
-
 # Using Docker Compose (pulls images automatically)
 docker-compose up -d
 
@@ -25,6 +22,64 @@ Available image tags:
 - `latest` — latest build from the `main` branch
 - `v0.6.2`, `0.6.2` — specific version tags
 - `sha-abc1234` — specific commit builds
+
+## Backend Server (docker run)
+
+The backend image is published to GHCR and can be run standalone:
+
+```bash
+# Basic — no auth, port 3000, data persisted in volume
+docker run -d \
+  --name github-stars-backend \
+  -v github-stars-data:/app/data \
+  -p 3000:3000 \
+  ghcr.io/amintacccp/github-stars-manager-server:latest
+
+# With custom API secret and encryption key
+docker run -d \
+  --name github-stars-backend \
+  -v github-stars-data:/app/data \
+  -p 3000:3000 \
+  -e API_SECRET="your-secret-here" \
+  -e ENCRYPTION_KEY="your-encryption-key" \
+  ghcr.io/amintacccp/github-stars-manager-server:latest
+
+# Map to a different host port (e.g. 8080)
+docker run -d \
+  --name github-stars-backend \
+  -v github-stars-data:/app/data \
+  -p 8080:3000 \
+  -e API_SECRET="your-secret-here" \
+  ghcr.io/amintacccp/github-stars-manager-server:latest
+```
+
+### Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `API_SECRET` | No | `null` (auth disabled) | Bearer token for API authentication |
+| `ENCRYPTION_KEY` | No | Auto-generated (saved to `data/.encryption-key`) | AES-256 key for encrypting stored secrets. Accepts any format — 64-char hex, shorter hex, base64, or plain text (all normalized via SHA-256) |
+| `PORT` | No | `3000` | Server listening port |
+| `DB_PATH` | No | `data/data.db` | Path to SQLite database file |
+
+> **Note:** The data volume (`/app/data`) stores both the database and the auto-generated encryption key. Always mount it to persist data across container restarts.
+
+## Full Stack with Docker Compose
+
+`docker-compose.yml` runs both frontend and backend:
+
+```bash
+docker-compose up -d
+```
+
+To customize secrets, create a `.env` file in the project root:
+
+```bash
+API_SECRET=my-strong-secret
+ENCRYPTION_KEY=my-encryption-key
+```
+
+Then `docker-compose up -d` reads them automatically.
 
 ## Building Locally with Docker
 
@@ -58,18 +113,6 @@ This Docker setup handles CORS in two ways:
 
 2. **Client-Side Handling**: The application is designed to work with any AI or WebDAV service URL configured by the user, without requiring proxying.
 
-## Configuration
-
-No special configuration is needed for the Docker container itself. All application settings (API URLs, credentials, etc.) are configured through the application UI.
-
-## Environment Variables
-
-While not required, you can pass environment variables to the container if needed:
-
-```bash
-docker run -d -p 8080:80 -e NODE_ENV=production --name github-stars-manager github-stars-manager
-```
-
 ## Stopping the Container
 
 ```bash
@@ -77,8 +120,10 @@ docker run -d -p 8080:80 -e NODE_ENV=production --name github-stars-manager gith
 docker-compose down
 
 # With Docker directly
-docker stop github-stars-manager
-docker rm github-stars-manager
+docker stop github-stars-manager && docker rm github-stars-manager
+
+# Stop backend only
+docker stop github-stars-backend && docker rm github-stars-backend
 ```
 
 ## Note on Desktop Packaging

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ docker pull ghcr.io/amintacccp/github-stars-manager-server:latest
 docker-compose up -d
 ```
 
+> If the package is private, run `docker login ghcr.io` first (use a [PAT](https://github.com/settings/tokens) with `read:packages` scope).
+
 See [DOCKER.md](DOCKER.md) for detailed instructions. The Docker setup handles CORS properly and allows you to configure any AI or WebDAV service URLs directly in the application.
 
 ### 🖥️ Backend Server (Optional)

--- a/README.md
+++ b/README.md
@@ -193,6 +193,13 @@ docker-compose up -d
 ```
 Frontend on port 8080, backend on port 3000. Data persisted in a Docker volume.
 
+To customize, create a `.env` file:
+```bash
+API_SECRET=your-secret
+ENCRYPTION_KEY=your-key
+BACKEND_IMAGE_TAG=v0.6.2   # pin a specific version (default: latest)
+```
+
 #### Backend only (docker run)
 ```bash
 # Basic — no auth, port 3000

--- a/README.md
+++ b/README.md
@@ -171,7 +171,14 @@ https://github.com/AmintaCCCP/GithubStarsManager/releases
 
 ### 🐳 Run With Docker
 
-You can also run this application using Docker. See [DOCKER.md](DOCKER.md) for detailed instructions on how to build and deploy using Docker. The Docker setup handles CORS properly and allows you to configure any AI or WebDAV service URLs directly in the application.
+Pre-built backend image is available on GHCR — no local build required:
+
+```bash
+docker pull ghcr.io/amintacccp/github-stars-manager-server:latest
+docker-compose up -d
+```
+
+See [DOCKER.md](DOCKER.md) for detailed instructions. The Docker setup handles CORS properly and allows you to configure any AI or WebDAV service URLs directly in the application.
 
 ### 🖥️ Backend Server (Optional)
 
@@ -182,7 +189,8 @@ The app works fully without a backend (pure frontend, localStorage). An optional
 
 #### Quick Start (Docker — recommended)
 ```bash
-docker-compose up --build
+docker pull ghcr.io/amintacccp/github-stars-manager-server:latest
+docker-compose up -d
 ```
 Frontend on port 8080, backend on port 3000. Data persisted in a Docker volume.
 

--- a/README.md
+++ b/README.md
@@ -189,10 +189,26 @@ The app works fully without a backend (pure frontend, localStorage). An optional
 
 #### Quick Start (Docker — recommended)
 ```bash
-docker pull ghcr.io/amintacccp/github-stars-manager-server:latest
 docker-compose up -d
 ```
 Frontend on port 8080, backend on port 3000. Data persisted in a Docker volume.
+
+#### Backend only (docker run)
+```bash
+# Basic — no auth, port 3000
+docker run -d --name github-stars-backend \
+  -v github-stars-data:/app/data \
+  -p 3000:3000 \
+  ghcr.io/amintacccp/github-stars-manager-server:latest
+
+# With custom secret and encryption key
+docker run -d --name github-stars-backend \
+  -v github-stars-data:/app/data \
+  -p 3000:3000 \
+  -e API_SECRET="your-secret" \
+  -e ENCRYPTION_KEY="your-key" \
+  ghcr.io/amintacccp/github-stars-manager-server:latest
+```
 
 #### Manual Setup
 ```bash

--- a/README_zh.md
+++ b/README_zh.md
@@ -252,6 +252,13 @@ docker-compose up -d
 ```
 前端运行在 8080 端口，后端运行在 3000 端口。数据持久化存储在 Docker 卷中。
 
+自定义配置，创建 `.env` 文件：
+```bash
+API_SECRET=your-secret
+ENCRYPTION_KEY=your-key
+BACKEND_IMAGE_TAG=v0.6.2   # 固定版本（默认：latest）
+```
+
 #### 仅后端（docker run）
 ```bash
 # 基础运行 — 无认证，端口 3000

--- a/README_zh.md
+++ b/README_zh.md
@@ -248,10 +248,26 @@ docker-compose up -d
 
 #### 快速启动（推荐使用 Docker）
 ```bash
-docker pull ghcr.io/amintacccp/github-stars-manager-server:latest
 docker-compose up -d
 ```
 前端运行在 8080 端口，后端运行在 3000 端口。数据持久化存储在 Docker 卷中。
+
+#### 仅后端（docker run）
+```bash
+# 基础运行 — 无认证，端口 3000
+docker run -d --name github-stars-backend \
+  -v github-stars-data:/app/data \
+  -p 3000:3000 \
+  ghcr.io/amintacccp/github-stars-manager-server:latest
+
+# 自定义密钥和端口
+docker run -d --name github-stars-backend \
+  -v github-stars-data:/app/data \
+  -p 3000:3000 \
+  -e API_SECRET="your-secret" \
+  -e ENCRYPTION_KEY="your-key" \
+  ghcr.io/amintacccp/github-stars-manager-server:latest
+```
 
 #### 手动启动
 ```bash

--- a/README_zh.md
+++ b/README_zh.md
@@ -228,7 +228,15 @@ npm run build
 - 自建服务器
 
 ### Docker 部署
-您也可以使用 Docker 来运行此应用程序。请参阅 [DOCKER.md](DOCKER.md) 获取详细的构建和部署说明。Docker 设置正确处理了 CORS，并允许您直接在应用程序中配置任何 AI 或 WebDAV 服务 URL。
+
+GHCR 上有预构建的后端镜像，无需本地构建：
+
+```bash
+docker pull ghcr.io/amintacccp/github-stars-manager-server:latest
+docker-compose up -d
+```
+
+请参阅 [DOCKER.md](DOCKER.md) 获取详细的构建和部署说明。Docker 设置正确处理了 CORS，并允许您直接在应用程序中配置任何 AI 或 WebDAV 服务 URL。
 
 ### 🖥️ 后端服务器（可选）
 
@@ -240,7 +248,8 @@ npm run build
 
 #### 快速启动（推荐使用 Docker）
 ```bash
-docker-compose up --build
+docker pull ghcr.io/amintacccp/github-stars-manager-server:latest
+docker-compose up -d
 ```
 前端运行在 8080 端口，后端运行在 3000 端口。数据持久化存储在 Docker 卷中。
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -236,6 +236,8 @@ docker pull ghcr.io/amintacccp/github-stars-manager-server:latest
 docker-compose up -d
 ```
 
+> 如果镜像为私有，需先执行 `docker login ghcr.io`（使用具有 `read:packages` 权限的 [PAT](https://github.com/settings/tokens)）。
+
 请参阅 [DOCKER.md](DOCKER.md) 获取详细的构建和部署说明。Docker 设置正确处理了 CORS，并允许您直接在应用程序中配置任何 AI 或 WebDAV 服务 URL。
 
 ### 🖥️ 后端服务器（可选）

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,9 @@ services:
     restart: unless-stopped
 
   backend:
-    build: ./server
+    image: ghcr.io/amintacccp/github-stars-manager-server:latest
+    # Uncomment below (and comment out 'image') to build locally instead:
+    # build: ./server
     expose:
       - "3000"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     restart: unless-stopped
 
   backend:
-    image: ghcr.io/amintacccp/github-stars-manager-server:latest
+    image: ghcr.io/amintacccp/github-stars-manager-server:${BACKEND_IMAGE_TAG:-latest}
     # Uncomment below (and comment out 'image') to build locally instead:
     # build: ./server
     expose:


### PR DESCRIPTION
## 概述

解决 #106 — 自动构建后端 Docker 镜像并发布到 GitHub Container Registry (ghcr.io)，用户无需本地构建即可直接拉取使用。

## 变更内容

### 新增 `.github/workflows/docker-publish.yml`
- Push 到 `main` 分支 → 自动构建并推送 `latest` 标签
- Push `v*` 标签 → 自动生成语义化版本标签 (`v1.2.3`, `1.2.3`, `1.2`, `1`)
- 所有构建 → 附带 `sha-<commit>` 标签便于追溯
- 使用 `GITHUB_TOKEN` 认证，**无需配置额外 Secrets**
- Docker Buildx + GHA 缓存加速后续构建

### 更新 `docker-compose.yml`
- Backend 服务默认从 `ghcr.io/amintacccp/github-stars-manager-server:latest` 拉取
- 保留注释中的本地构建选项

### 更新文档
- `DOCKER.md` — 新增 Quick Start 章节
- `README.md` / `README_zh.md` — 添加 ghcr.io 拉取命令

## 使用方式

```bash
docker-compose up -d
```

合并后首次运行前，需要在 repo → Settings → Packages 中将镜像可见性设为 **Public**，否则用户需先 `docker login ghcr.io`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-built backend container images published to the registry for quicker, simpler deployments.

* **Documentation**
  * Quick Start and deployment docs updated with pulling/pinning image tags, backend-only run examples (optional secrets), full-stack compose workflow, and README updates in English and Chinese.

* **Chores**
  * CI workflow added to automate building and publishing backend container images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->