### PR TITLE
fix: 启用多架构 Docker 构建 (amd64 + arm64)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -52,6 +55,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./server
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## 问题

当前 GHCR 上的镜像只有 `linux/amd64` 平台，Apple Silicon Mac (M1/M2/M3) 用户无法直接使用。

## 修复

- 添加 `docker/setup-qemu-action` 步骤启用跨平台模拟
- 在 `docker/build-push-action` 中声明 `platforms: linux/amd64,linux/arm64`

合并后发布的镜像将同时支持：
- `linux/amd64` — Intel/AMD 服务器和 PC
- `linux/arm64` — Apple Silicon Mac、ARM 服务器（如 AWS Graviton）

> **注意：** 多架构构建时间会比单架构长约 2-3 倍（arm64 通过 QEMU 模拟编译）。`better-sqlite3` 原生模块在 arm64 Alpine 上会从源码编译，`node:22-alpine` 已包含所需构建工具。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker images are now built and published for both x86_64 and ARM64 architectures, extending compatibility across different hardware platforms and environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->