### PR TITLE
fix: clear stale search query on manual input reset

### DIFF
--- a/src/components/SearchBar.test.tsx
+++ b/src/components/SearchBar.test.tsx
@@ -1,0 +1,127 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SearchBar } from './SearchBar';
+import { useAppStore } from '../store/useAppStore';
+import type { SearchFilters } from '../types';
+
+vi.mock('../store/useAppStore', () => ({
+  useAppStore: vi.fn(),
+  getAllCategories: vi.fn(() => []),
+}));
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+  };
+})();
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: localStorageMock,
+  configurable: true,
+});
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+  configurable: true,
+});
+
+const defaultSearchFilters: SearchFilters = {
+  query: '',
+  tags: [],
+  languages: [],
+  platforms: [],
+  sortBy: 'stars',
+  sortOrder: 'desc',
+};
+
+const createStoreState = (overrides: Partial<ReturnType<typeof baseStoreState>> = {}) => ({
+  ...baseStoreState(),
+  ...overrides,
+});
+
+const baseStoreState = () => ({
+  searchFilters: { ...defaultSearchFilters },
+  repositories: [],
+  releaseSubscriptions: new Set<number>(),
+  aiConfigs: [],
+  activeAIConfig: null,
+  language: 'zh',
+  setSearchFilters: vi.fn(),
+  setSearchResults: vi.fn(),
+  customCategories: [],
+  hiddenDefaultCategoryIds: [],
+  defaultCategoryOverrides: {},
+});
+
+const mockUseAppStore = vi.mocked(useAppStore);
+
+describe('SearchBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('clears the committed query when the search input is manually emptied', () => {
+    const setSearchFilters = vi.fn();
+    mockUseAppStore.mockReturnValue(createStoreState({
+      searchFilters: {
+        ...defaultSearchFilters,
+        query: 'react',
+      },
+      setSearchFilters,
+    }) as ReturnType<typeof useAppStore>);
+
+    render(<SearchBar />);
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '' } });
+
+    expect(setSearchFilters).toHaveBeenCalledWith({ query: '' });
+  });
+
+  it('keeps the committed query empty when sorting after manual clearing', () => {
+    const storeState = createStoreState({
+      searchFilters: {
+        ...defaultSearchFilters,
+        query: 'react',
+        sortOrder: 'desc',
+      },
+    });
+
+    const setSearchFilters = vi.fn((filters: Partial<SearchFilters>) => {
+      storeState.searchFilters = {
+        ...storeState.searchFilters,
+        ...filters,
+      };
+    });
+    storeState.setSearchFilters = setSearchFilters;
+
+    mockUseAppStore.mockReturnValue(storeState as ReturnType<typeof useAppStore>);
+
+    const { rerender } = render(<SearchBar />);
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '' } });
+
+    expect(storeState.searchFilters.query).toBe('');
+
+    rerender(<SearchBar />);
+    fireEvent.click(screen.getByText('↓'));
+
+    expect(storeState.searchFilters).toMatchObject({
+      query: '',
+      sortOrder: 'asc',
+    });
+    expect(setSearchFilters).toHaveBeenCalledWith({ query: '' });
+    expect(setSearchFilters).toHaveBeenCalledWith({ sortOrder: 'asc' });
+  });
+});

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -608,7 +608,11 @@ export const SearchBar: React.FC = () => {
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setSearchQuery(value);
-    
+
+    if (!value.trim() && searchFilters.query) {
+      setSearchFilters({ query: '' });
+    }
+
     // Enable real-time search mode when user starts typing
     if (value && !isRealTimeSearch) {
       setIsRealTimeSearch(true);


### PR DESCRIPTION
## Summary
- Clear the committed repository search query when the search input is manually emptied
- Add SearchBar regression coverage for manual clear followed by sort direction toggling
- Keep existing sort/filter store merge behavior unchanged

Fixes #195

## Testing
- ✅ npm run test:run -- src/components/SearchBar.test.tsx
- ✅ npm run build
- ⚠️ npm run test:run currently fails in existing MarkdownRenderer line-number coverage unrelated to this change
- ⚠️ npm run lint currently fails on existing project lint errors unrelated to this change

## Notes
- Untracked local files .claude/hook-log.txt and star-growth-chart.html were not included in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed search input clearing behavior. Previously, clearing the search input field would not properly reset the search query state. The search now correctly clears when the input becomes empty, preventing stale query information from persisting and affecting subsequent filtering and sorting operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->