### PR TITLE
feat: add multilingual README switching

### DIFF
--- a/src/components/ReadmeModal.test.tsx
+++ b/src/components/ReadmeModal.test.tsx
@@ -7,7 +7,10 @@ import type { Repository } from '../types';
 vi.mock('./BilingualMarkdownRenderer', async () => {
   const React = await import('react');
   return {
-    default: React.forwardRef(({ markdown }: { markdown: string }, _ref) => <div>{markdown}</div>),
+    default: React.forwardRef(({ markdown }: { markdown: string }, ref) => {
+      void ref;
+      return <div>{markdown}</div>;
+    }),
   };
 });
 

--- a/src/components/ReadmeModal.test.tsx
+++ b/src/components/ReadmeModal.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ReadmeModal } from './ReadmeModal';
+import { backend } from '../services/backendAdapter';
+import type { Repository } from '../types';
+
+vi.mock('./BilingualMarkdownRenderer', async () => {
+  const React = await import('react');
+  return {
+    default: React.forwardRef(({ markdown }: { markdown: string }, _ref) => <div>{markdown}</div>),
+  };
+});
+
+vi.mock('../services/backendAdapter', () => ({
+  backend: {
+    isAvailable: true,
+    getRepositoryReadme: vi.fn(),
+    getRepositoryReadmeByPath: vi.fn(),
+    listRepositoryReadmeCandidates: vi.fn(),
+  },
+}));
+
+const mockRepository: Repository = {
+  id: 1,
+  name: 'demo',
+  full_name: 'owner/demo',
+  description: 'Demo repository',
+  html_url: 'https://github.com/owner/demo',
+  stargazers_count: 10,
+  forks_count: 2,
+  forks: 2,
+  language: 'TypeScript',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-02T00:00:00Z',
+  pushed_at: '2026-01-03T00:00:00Z',
+  owner: {
+    login: 'owner',
+    avatar_url: 'https://example.com/avatar.png',
+  },
+  topics: [],
+};
+
+describe('ReadmeModal multilingual README switching', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (backend.getRepositoryReadme as ReturnType<typeof vi.fn>).mockResolvedValue('Default README content');
+    (backend.getRepositoryReadmeByPath as ReturnType<typeof vi.fn>).mockResolvedValue('中文 README 内容');
+    (backend.listRepositoryReadmeCandidates as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { path: 'README.md', type: 'blob' },
+      { path: 'README_zh.md', type: 'blob' },
+      { path: 'docs/README.ja.md', type: 'blob' },
+    ]);
+  });
+
+  it('loads the default README first and then shows all detected README variants', async () => {
+    render(<ReadmeModal isOpen onClose={vi.fn()} repository={mockRepository} />);
+
+    expect(await screen.findByText('Default README content')).toBeInTheDocument();
+    expect(backend.getRepositoryReadme).toHaveBeenCalledWith('owner', 'demo', expect.any(AbortSignal));
+
+    const selector = await screen.findByLabelText('切换 README 语言');
+    expect(selector).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: '默认 README' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: '中文 · README_zh.md' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: '日语 · docs/README.ja.md' })).toBeInTheDocument();
+  });
+
+  it('loads the selected README variant by path', async () => {
+    render(<ReadmeModal isOpen onClose={vi.fn()} repository={mockRepository} />);
+
+    await screen.findByText('Default README content');
+    const selector = await screen.findByLabelText('切换 README 语言');
+
+    fireEvent.change(selector, { target: { value: 'README_zh.md' } });
+
+    await waitFor(() => {
+      expect(backend.getRepositoryReadmeByPath).toHaveBeenCalledWith('owner', 'demo', 'README_zh.md', expect.any(AbortSignal));
+    });
+    expect(await screen.findByText('中文 README 内容')).toBeInTheDocument();
+  });
+
+  it('does not show the selector when no localized README exists', async () => {
+    (backend.listRepositoryReadmeCandidates as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { path: 'README.md', type: 'blob' },
+    ]);
+
+    render(<ReadmeModal isOpen onClose={vi.fn()} repository={mockRepository} />);
+
+    expect(await screen.findByText('Default README content')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(backend.listRepositoryReadmeCandidates).toHaveBeenCalled();
+    });
+    expect(screen.queryByLabelText('切换 README 语言')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ReadmeModal.tsx
+++ b/src/components/ReadmeModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback, useRef } from 'react';
+import React, { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import { X, Loader2, AlertCircle, FileText, ExternalLink, List, Type, ArrowUp, Languages, Eye } from 'lucide-react';
 import BilingualMarkdownRenderer, { DisplayMode, BilingualMarkdownRendererHandle, TranslationStatus } from './BilingualMarkdownRenderer';
 import { stripMarkdownFormatting } from '../utils/markdownUtils';
@@ -6,6 +6,7 @@ import { Repository } from '../types';
 import { GitHubApiService } from '../services/githubApi';
 import { backend } from '../services/backendAdapter';
 import { useAppStore } from '../store/useAppStore';
+import { buildReadmeVariants, DEFAULT_README_VARIANT, type GitHubReadmeCandidateItem, type ReadmeVariant } from '../utils/readmeVariants';
 
 interface TocItem {
   id: string;
@@ -27,6 +28,11 @@ const FONT_SIZES = [
 
 const TOC_MAX_LEVEL = 6;
 
+const getDefaultReadmeVariant = (language: 'zh' | 'en'): ReadmeVariant => ({
+  ...DEFAULT_README_VARIANT,
+  label: language === 'zh' ? '默认 README' : 'Default README',
+});
+
 export const ReadmeModal: React.FC<ReadmeModalProps> = ({
   isOpen,
   onClose,
@@ -47,11 +53,18 @@ export const ReadmeModal: React.FC<ReadmeModalProps> = ({
   const [errorExpanded, setErrorExpanded] = useState(false);
   const [tocWidth, setTocWidth] = useState(224);
   const [translatedHeadingMap, setTranslatedHeadingMap] = useState<Map<string, string>>(new Map());
+  const [readmeVariants, setReadmeVariants] = useState<ReadmeVariant[]>(() => [getDefaultReadmeVariant(language)]);
+  const [selectedReadmeKey, setSelectedReadmeKey] = useState('default');
+  const [variantsLoading, setVariantsLoading] = useState(false);
+  const [readmeCache, setReadmeCache] = useState<Record<string, string>>({});
+
+  const defaultReadmeVariant = useMemo(() => getDefaultReadmeVariant(language), [language]);
 
   const modalRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
+  const variantsAbortControllerRef = useRef<AbortController | null>(null);
   const isResizingRef = useRef(false);
   const startXRef = useRef(0);
   const startWidthRef = useRef(0);
@@ -284,7 +297,26 @@ export const ReadmeModal: React.FC<ReadmeModalProps> = ({
     setTranslatedHeadingMap(map);
   }, []);
 
-  const fetchReadme = useCallback(async () => {
+  const resetTranslationState = useCallback(() => {
+    bilingualRef.current?.revert();
+    setDisplayMode('bilingual');
+    setTranslateStatus('idle');
+    setTranslateProgress({ current: 0, total: 0 });
+    setTranslateError(null);
+    setTranslatedHeadingMap(new Map());
+  }, []);
+
+  const resetReadmeViewState = useCallback(() => {
+    resetTranslationState();
+    setTocItems([]);
+    setHeadingIdMap(new Map());
+    setActiveHeadingId(null);
+    setScrollProgress(0);
+    setShowBackToTop(false);
+    scrollToTop();
+  }, [resetTranslationState, scrollToTop]);
+
+  const fetchReadmeContent = useCallback(async (variant: ReadmeVariant) => {
     if (!repository) return;
 
     if (abortControllerRef.current) {
@@ -301,11 +333,16 @@ export const ReadmeModal: React.FC<ReadmeModalProps> = ({
       let content = '';
 
       if (backend.isAvailable) {
-        content = await backend.getRepositoryReadme(owner, name);
+        content = variant.isDefault || !variant.path
+          ? await backend.getRepositoryReadme(owner, name, abortController.signal)
+          : await backend.getRepositoryReadmeByPath(owner, name, variant.path, abortController.signal);
       } else if (githubToken) {
         const githubApi = new GitHubApiService(githubToken);
-        content = await githubApi.getRepositoryReadme(owner, name, abortController.signal);
+        content = variant.isDefault || !variant.path
+          ? await githubApi.getRepositoryReadme(owner, name, abortController.signal)
+          : await githubApi.getRepositoryReadmeByPath(owner, name, variant.path, abortController.signal);
       } else {
+        setReadmeContent('');
         setError(language === 'zh' ? '未登录且后端不可用，无法加载 README' : 'Not logged in and backend unavailable, cannot load README');
         setLoading(false);
         return;
@@ -313,15 +350,24 @@ export const ReadmeModal: React.FC<ReadmeModalProps> = ({
 
       if (abortController.signal.aborted) return;
 
+      setReadmeCache(prev => ({ ...prev, [variant.key]: content }));
+
       if (content.trim()) {
         setReadmeContent(content);
+        setError(null);
       } else {
-        setError(language === 'zh' ? '该仓库没有 README 文件' : 'This repository has no README file');
+        setReadmeContent('');
+        setError(variant.isDefault
+          ? (language === 'zh' ? '该仓库没有 README 文件' : 'This repository has no README file')
+          : (language === 'zh' ? '该 README 文件为空' : 'This README file is empty'));
       }
     } catch (err) {
       if (abortController.signal.aborted) return;
       console.error('Failed to fetch README:', err);
-      setError(language === 'zh' ? '加载 README 失败，请检查网络连接或稍后重试' : 'Failed to load README. Please check your network connection and try again later');
+      setReadmeContent('');
+      setError(variant.isDefault
+        ? (language === 'zh' ? '加载 README 失败，请检查网络连接或稍后重试' : 'Failed to load README. Please check your network connection and try again later')
+        : (language === 'zh' ? '加载所选 README 失败，请稍后重试' : 'Failed to load selected README. Please try again later'));
     } finally {
       if (!abortController.signal.aborted) {
         setLoading(false);
@@ -329,11 +375,85 @@ export const ReadmeModal: React.FC<ReadmeModalProps> = ({
     }
   }, [repository, githubToken, language]);
 
+  const fetchReadmeVariants = useCallback(async () => {
+    if (!repository) return;
+
+    if (variantsAbortControllerRef.current) {
+      variantsAbortControllerRef.current.abort();
+    }
+    const abortController = new AbortController();
+    variantsAbortControllerRef.current = abortController;
+
+    setVariantsLoading(true);
+
+    try {
+      const [owner, name] = repository.full_name.split('/');
+      const defaultBranch = (repository as Repository & { default_branch?: string }).default_branch;
+      let candidates: GitHubReadmeCandidateItem[] = [];
+
+      if (backend.isAvailable) {
+        candidates = await backend.listRepositoryReadmeCandidates(owner, name, defaultBranch, abortController.signal);
+      } else if (githubToken) {
+        const githubApi = new GitHubApiService(githubToken);
+        candidates = await githubApi.listRepositoryReadmeCandidates(owner, name, defaultBranch, abortController.signal);
+      } else {
+        return;
+      }
+
+      if (abortController.signal.aborted) return;
+      setReadmeVariants(buildReadmeVariants(candidates, language));
+    } catch (err) {
+      if (!abortController.signal.aborted) {
+        console.warn('Failed to detect README variants:', err);
+        setReadmeVariants([defaultReadmeVariant]);
+      }
+    } finally {
+      if (!abortController.signal.aborted) {
+        setVariantsLoading(false);
+      }
+    }
+  }, [repository, githubToken, language, defaultReadmeVariant]);
+
+  const fetchReadme = useCallback(async () => {
+    const currentVariant = readmeVariants.find(variant => variant.key === selectedReadmeKey) || defaultReadmeVariant;
+    await fetchReadmeContent(currentVariant);
+  }, [readmeVariants, selectedReadmeKey, defaultReadmeVariant, fetchReadmeContent]);
+
+  const handleReadmeVariantChange = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
+    const nextKey = event.target.value;
+    if (nextKey === selectedReadmeKey) return;
+
+    const nextVariant = readmeVariants.find(variant => variant.key === nextKey);
+    if (!nextVariant) return;
+
+    setSelectedReadmeKey(nextKey);
+    resetReadmeViewState();
+
+    const cachedContent = readmeCache[nextKey];
+    if (cachedContent !== undefined) {
+      setReadmeContent(cachedContent);
+      setError(cachedContent.trim()
+        ? null
+        : nextVariant.isDefault
+          ? (language === 'zh' ? '该仓库没有 README 文件' : 'This repository has no README file')
+          : (language === 'zh' ? '该 README 文件为空' : 'This README file is empty'));
+      return;
+    }
+
+    void fetchReadmeContent(nextVariant);
+  }, [selectedReadmeKey, readmeVariants, readmeCache, resetReadmeViewState, language, fetchReadmeContent]);
+
   useEffect(() => {
     if (isOpen && repository) {
-      fetchReadme();
+      const defaultVariant = getDefaultReadmeVariant(language);
+      setReadmeVariants([defaultVariant]);
+      setSelectedReadmeKey('default');
+      setReadmeCache({});
+      resetReadmeViewState();
+      void fetchReadmeContent(defaultVariant);
+      void fetchReadmeVariants();
     }
-  }, [isOpen, repository, fetchReadme]);
+  }, [isOpen, repository, language, fetchReadmeContent, fetchReadmeVariants, resetReadmeViewState]);
 
   useEffect(() => {
     if (displayContent) {
@@ -355,9 +475,17 @@ export const ReadmeModal: React.FC<ReadmeModalProps> = ({
         abortControllerRef.current.abort();
         abortControllerRef.current = null;
       }
+      if (variantsAbortControllerRef.current) {
+        variantsAbortControllerRef.current.abort();
+        variantsAbortControllerRef.current = null;
+      }
       setReadmeContent('');
       setError(null);
       setLoading(false);
+      setReadmeVariants([getDefaultReadmeVariant(language)]);
+      setSelectedReadmeKey('default');
+      setVariantsLoading(false);
+      setReadmeCache({});
       setTocItems([]);
       setHeadingIdMap(new Map());
       setScrollProgress(0);
@@ -376,13 +504,17 @@ export const ReadmeModal: React.FC<ReadmeModalProps> = ({
     } else {
       setShowToc(true);
     }
-  }, [isOpen]);
+  }, [isOpen, language]);
 
   useEffect(() => {
     return () => {
       if (abortControllerRef.current) {
         abortControllerRef.current.abort();
         abortControllerRef.current = null;
+      }
+      if (variantsAbortControllerRef.current) {
+        variantsAbortControllerRef.current.abort();
+        variantsAbortControllerRef.current = null;
       }
     };
   }, []);
@@ -441,6 +573,7 @@ export const ReadmeModal: React.FC<ReadmeModalProps> = ({
   const isTranslating = translateStatus === 'translating';
   const isTranslated = translateStatus === 'translated';
   const isTranslateError = translateStatus === 'error';
+  const currentReadmeVariant = readmeVariants.find(variant => variant.key === selectedReadmeKey) || defaultReadmeVariant;
 
   return (
     <div className="fixed inset-0 z-50 overflow-y-auto">
@@ -478,12 +611,28 @@ export const ReadmeModal: React.FC<ReadmeModalProps> = ({
                 <h3 id="readme-modal-title" className="text-lg font-semibold text-gray-900 dark:text-text-primary">
                   {repository.full_name}
                 </h3>
-                <p className="text-sm text-gray-500 dark:text-text-secondary">
-                  README
+                <p className="text-sm text-gray-500 dark:text-text-secondary truncate max-w-[260px]" title={currentReadmeVariant.path || 'README'}>
+                  {currentReadmeVariant.isDefault ? 'README' : currentReadmeVariant.path}
                 </p>
               </div>
             </div>
             <div className="flex items-center space-x-1">
+              {readmeVariants.length > 1 && (
+                <select
+                  value={selectedReadmeKey}
+                  onChange={handleReadmeVariantChange}
+                  disabled={loading || variantsLoading}
+                  className="w-28 sm:w-auto max-w-[220px] px-2 py-2 text-sm rounded-lg border border-black/[0.06] dark:border-white/[0.08] bg-white dark:bg-panel-dark text-gray-700 dark:text-text-primary hover:bg-light-surface dark:hover:bg-white/5 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+                  title={t('切换 README 语言', 'Switch README language')}
+                  aria-label={t('切换 README 语言', 'Switch README language')}
+                >
+                  {readmeVariants.map((variant) => (
+                    <option key={variant.key} value={variant.key}>
+                      {variant.label}
+                    </option>
+                  ))}
+                </select>
+              )}
               {readmeContent && !loading && (
                 isTranslated ? (
                   <>

--- a/src/services/backendAdapter.ts
+++ b/src/services/backendAdapter.ts
@@ -3,6 +3,17 @@ import { logger } from './logger';
 
 import { Repository, Release, AIConfig, WebDAVConfig } from '../types';
 import { useAppStore } from '../store/useAppStore';
+import { isReadmeCandidateItem, type GitHubReadmeCandidateItem } from '../utils/readmeVariants';
+
+interface GitHubContentResponse {
+  content?: string;
+  encoding?: string;
+}
+
+interface GitHubTreeResponse {
+  tree?: GitHubReadmeCandidateItem[];
+  truncated?: boolean;
+}
 
 class BackendAdapter {
   private _backendUrl: string | null = null;
@@ -244,23 +255,115 @@ class BackendAdapter {
     return res.json() as Promise<Record<string, unknown>>;
   }
 
-  async getRepositoryReadme(owner: string, repo: string): Promise<string> {
+  private decodeContentResponse(data: GitHubContentResponse): string {
+    if (data.encoding === 'base64' && data.content) {
+      const binaryStr = atob(data.content.replace(/\s/g, ''));
+      const bytes = Uint8Array.from(binaryStr, c => c.charCodeAt(0));
+      return new TextDecoder('utf-8').decode(bytes);
+    }
+    return data.content || '';
+  }
+
+  private encodeContentPath(path: string): string {
+    return path.split('/').map(encodeURIComponent).join('/');
+  }
+
+  async getRepositoryReadme(owner: string, repo: string, signal?: AbortSignal): Promise<string> {
     if (!this._backendUrl) throw new Error('Backend not available');
 
     try {
       const res = await this.fetchWithTimeout(`${this._backendUrl}/proxy/github/repos/${owner}/${repo}/readme`, {
         method: 'POST',
         headers: this.getAuthHeaders(),
-        body: JSON.stringify({ method: 'GET' })
+        body: JSON.stringify({ method: 'GET' }),
+        signal,
       });
       if (!res.ok) return '';
-      const data = await res.json() as { encoding?: string; content?: string };
-      if (data.encoding === 'base64' && data.content) {
-        const binaryStr = atob(data.content);
-        const bytes = Uint8Array.from(binaryStr, c => c.charCodeAt(0));
-        return new TextDecoder().decode(bytes);
+      const data = await res.json() as GitHubContentResponse;
+      return this.decodeContentResponse(data);
+    } catch {
+      return '';
+    }
+  }
+
+  async listRepositoryReadmeCandidates(owner: string, repo: string, defaultBranch?: string, signal?: AbortSignal): Promise<GitHubReadmeCandidateItem[]> {
+    if (!this._backendUrl) throw new Error('Backend not available');
+
+    const fetchRootContents = async (): Promise<GitHubReadmeCandidateItem[]> => {
+      const res = await this.fetchWithTimeout(`${this._backendUrl}/proxy/github/repos/${owner}/${repo}/contents`, {
+        method: 'POST',
+        headers: this.getAuthHeaders(),
+        body: JSON.stringify({ method: 'GET' }),
+        signal,
+      });
+      if (!res.ok) return [];
+      const data = await res.json() as GitHubReadmeCandidateItem[];
+      return data.filter(isReadmeCandidateItem);
+    };
+
+    let branch = defaultBranch;
+    if (!branch) {
+      try {
+        const repoRes = await this.fetchWithTimeout(`${this._backendUrl}/proxy/github/repos/${owner}/${repo}`, {
+          method: 'POST',
+          headers: this.getAuthHeaders(),
+          body: JSON.stringify({ method: 'GET' }),
+          signal,
+        });
+        if (repoRes.ok) {
+          const repoDetails = await repoRes.json() as { default_branch?: string };
+          branch = repoDetails.default_branch;
+        }
+      } catch {
+        // Fall back to root contents below
       }
-      return data.content || '';
+    }
+
+    if (!branch) {
+      try {
+        return await fetchRootContents();
+      } catch {
+        return [];
+      }
+    }
+
+    try {
+      const res = await this.fetchWithTimeout(`${this._backendUrl}/proxy/github/repos/${owner}/${repo}/git/trees/${encodeURIComponent(branch)}?recursive=1`, {
+        method: 'POST',
+        headers: this.getAuthHeaders(),
+        body: JSON.stringify({ method: 'GET' }),
+        signal,
+      });
+      if (!res.ok) return await fetchRootContents();
+      const data = await res.json() as GitHubTreeResponse;
+      const candidates = (data.tree || []).filter(isReadmeCandidateItem);
+      if (data.truncated) {
+        logger.warn('backendAdapter', 'README candidate tree was truncated', { owner, repo });
+        if (candidates.length === 0) return await fetchRootContents();
+      }
+      return candidates;
+    } catch {
+      try {
+        return await fetchRootContents();
+      } catch {
+        return [];
+      }
+    }
+  }
+
+  async getRepositoryReadmeByPath(owner: string, repo: string, path: string, signal?: AbortSignal): Promise<string> {
+    if (!this._backendUrl) throw new Error('Backend not available');
+
+    try {
+      const res = await this.fetchWithTimeout(`${this._backendUrl}/proxy/github/repos/${owner}/${repo}/contents/${this.encodeContentPath(path)}`, {
+        method: 'POST',
+        headers: this.getAuthHeaders(),
+        body: JSON.stringify({ method: 'GET' }),
+        signal,
+      });
+      if (!res.ok) return '';
+      const data = await res.json() as GitHubContentResponse;
+      return this.decodeContentResponse(data);
     } catch {
       return '';
     }

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -7,8 +7,10 @@ import {
   SortBy,
   SortOrder,
   PaginatedDiscoveryRepositories,
+  DiscoveryRepo,
   DiscoveryChannelId,
   TopicCategory,
+  TrendingTimeRange,
   SubscriptionRepo,
   SubscriptionDev,
   GitHubSearchUserResponse,
@@ -17,6 +19,17 @@ import {
   WorkflowDefinition,
 } from '../types';
 import { logger } from './logger';
+import { isReadmeCandidateItem, type GitHubReadmeCandidateItem } from '../utils/readmeVariants';
+
+interface GitHubContentResponse {
+  content?: string;
+  encoding?: string;
+}
+
+interface GitHubTreeResponse {
+  tree?: GitHubReadmeCandidateItem[];
+  truncated?: boolean;
+}
 
 interface GitHubStarredItem {
   starred_at?: string;
@@ -216,26 +229,105 @@ export class GitHubApiService {
     return allRepos;
   }
 
+  private decodeContentResponse(response: GitHubContentResponse): string {
+    if (response.encoding === 'base64' && response.content) {
+      // 使用 TextDecoder 正确处理 UTF-8 编码，避免中文乱码
+      const binaryString = atob(response.content.replace(/\s/g, ''));
+      const bytes = new Uint8Array(binaryString.length);
+      for (let i = 0; i < binaryString.length; i++) {
+        bytes[i] = binaryString.charCodeAt(i);
+      }
+      return new TextDecoder('utf-8').decode(bytes);
+    }
+    return response.content || '';
+  }
+
+  private encodeContentPath(path: string): string {
+    return path.split('/').map(encodeURIComponent).join('/');
+  }
+
   async getRepositoryReadme(owner: string, repo: string, signal?: AbortSignal): Promise<string> {
     try {
-      const response = await this.makeRequest<{ content: string; encoding: string }>(
+      const response = await this.makeRequest<GitHubContentResponse>(
         `/repos/${owner}/${repo}/readme`,
         undefined,
         signal
       );
 
-      if (response.encoding === 'base64') {
-        // 使用 TextDecoder 正确处理 UTF-8 编码，避免中文乱码
-        const binaryString = atob(response.content);
-        const bytes = new Uint8Array(binaryString.length);
-        for (let i = 0; i < binaryString.length; i++) {
-          bytes[i] = binaryString.charCodeAt(i);
-        }
-        return new TextDecoder('utf-8').decode(bytes);
-      }
-      return response.content;
+      return this.decodeContentResponse(response);
     } catch (error) {
       logger.warn('githubApi', `Failed to fetch README for ${owner}/${repo}`, error);
+      return '';
+    }
+  }
+
+  async listRepositoryReadmeCandidates(owner: string, repo: string, defaultBranch?: string, signal?: AbortSignal): Promise<GitHubReadmeCandidateItem[]> {
+    const fetchRootContents = async (): Promise<GitHubReadmeCandidateItem[]> => {
+      const rootItems = await this.makeRequest<GitHubReadmeCandidateItem[]>(
+        `/repos/${owner}/${repo}/contents`,
+        undefined,
+        signal
+      );
+      return rootItems.filter(isReadmeCandidateItem);
+    };
+
+    let branch = defaultBranch;
+    if (!branch) {
+      try {
+        const repoDetails = await this.makeRequest<{ default_branch?: string }>(
+          `/repos/${owner}/${repo}`,
+          undefined,
+          signal
+        );
+        branch = repoDetails.default_branch;
+      } catch (error) {
+        logger.warn('githubApi', `Failed to fetch default branch for ${owner}/${repo}`, error);
+      }
+    }
+
+    if (!branch) {
+      try {
+        return await fetchRootContents();
+      } catch (error) {
+        logger.warn('githubApi', `Failed to list README candidates for ${owner}/${repo}`, error);
+        return [];
+      }
+    }
+
+    try {
+      const tree = await this.makeRequest<GitHubTreeResponse>(
+        `/repos/${owner}/${repo}/git/trees/${encodeURIComponent(branch)}?recursive=1`,
+        undefined,
+        signal
+      );
+      const candidates = (tree.tree || []).filter(isReadmeCandidateItem);
+      if (tree.truncated) {
+        logger.warn('githubApi', `README candidate tree was truncated for ${owner}/${repo}`);
+        if (candidates.length === 0) return await fetchRootContents();
+      }
+      return candidates;
+    } catch (error) {
+      logger.warn('githubApi', `Failed to list README candidates from tree for ${owner}/${repo}`, error);
+      try {
+        return await fetchRootContents();
+      } catch (contentsError) {
+        logger.warn('githubApi', `Failed to list README candidates from root contents for ${owner}/${repo}`, contentsError);
+        return [];
+      }
+    }
+  }
+
+  async getRepositoryReadmeByPath(owner: string, repo: string, path: string, signal?: AbortSignal): Promise<string> {
+    try {
+      const response = await this.makeRequest<GitHubContentResponse>(
+        `/repos/${owner}/${repo}/contents/${this.encodeContentPath(path)}`,
+        undefined,
+        signal
+      );
+
+      return this.decodeContentResponse(response);
+    } catch (error) {
+      logger.warn('githubApi', `Failed to fetch README ${path} for ${owner}/${repo}`, error);
       return '';
     }
   }

--- a/src/utils/readmeVariants.test.ts
+++ b/src/utils/readmeVariants.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { buildReadmeVariants, isReadmeCandidateItem } from './readmeVariants';
+
+const file = (path: string, name?: string) => ({
+  path,
+  name,
+  type: 'blob',
+});
+
+describe('readmeVariants', () => {
+  it('keeps a synthetic default README option first', () => {
+    const variants = buildReadmeVariants([
+      file('README.md'),
+      file('README_zh.md'),
+    ], 'zh');
+
+    expect(variants[0]).toMatchObject({
+      key: 'default',
+      path: null,
+      label: '默认 README',
+      isDefault: true,
+    });
+  });
+
+  it('detects common multilingual README naming styles', () => {
+    const variants = buildReadmeVariants([
+      file('README_zh.md'),
+      file('README.zh-CN.md'),
+      file('README-ja.md'),
+      file('README.pt-BR.md'),
+      file('docs/README.ko.md'),
+      file('readme/README-fr.markdown'),
+    ], 'en');
+
+    expect(variants.map((variant) => variant.path)).toEqual([
+      null,
+      'README_zh.md',
+      'README.zh-CN.md',
+      'README-ja.md',
+      'docs/README.ko.md',
+      'readme/README-fr.markdown',
+      'README.pt-BR.md',
+    ]);
+  });
+
+  it('does not duplicate non-localized README files with the default option', () => {
+    const variants = buildReadmeVariants([
+      file('README.md'),
+      file('docs/README.markdown'),
+      file('README_zh.md'),
+    ], 'zh');
+
+    expect(variants.map((variant) => variant.path)).toEqual([
+      null,
+      'README_zh.md',
+    ]);
+  });
+
+  it('generates localized labels for known and regional language codes', () => {
+    const zhLabels = buildReadmeVariants([
+      file('README_zh.md'),
+      file('README.pt-BR.md'),
+    ], 'zh').map((variant) => variant.label);
+    const enLabels = buildReadmeVariants([
+      file('README_zh.md'),
+      file('README.pt-BR.md'),
+    ], 'en').map((variant) => variant.label);
+
+    expect(zhLabels).toContain('中文 · README_zh.md');
+    expect(zhLabels).toContain('葡萄牙语（巴西） · README.pt-BR.md');
+    expect(enLabels).toContain('Chinese · README_zh.md');
+    expect(enLabels).toContain('Portuguese (Brazil) · README.pt-BR.md');
+  });
+
+  it('ignores directories, non-readme files, and non-markdown README assets', () => {
+    const variants = buildReadmeVariants([
+      { path: 'README_zh.md', type: 'tree' },
+      file('NOT_README_zh.md'),
+      file('README_zh.png'),
+      file('README.zh.mdx'),
+      file('README.en.mdown'),
+      file('README.fr.mkdn'),
+    ], 'en');
+
+    expect(variants.map((variant) => variant.path)).toEqual([
+      null,
+      'README.en.mdown',
+      'README.fr.mkdn',
+    ]);
+  });
+
+  it('matches candidate items case-insensitively', () => {
+    expect(isReadmeCandidateItem(file('DOCS/ReadMe.ZH-cn.MD'))).toBe(true);
+    expect(isReadmeCandidateItem(file('README_ES.MARKDOWN'))).toBe(true);
+  });
+});

--- a/src/utils/readmeVariants.ts
+++ b/src/utils/readmeVariants.ts
@@ -1,0 +1,158 @@
+export interface GitHubReadmeCandidateItem {
+  name?: string;
+  path: string;
+  type?: string;
+}
+
+export interface ReadmeVariant {
+  key: string;
+  name: string;
+  path: string | null;
+  label: string;
+  languageCode?: string;
+  isDefault: boolean;
+}
+
+const README_FILE_REGEX = /^README(?:[._-]([A-Za-z]{2,3}(?:[-_][A-Za-z0-9]+)?))?\.(md|markdown|mdown|mkdn)$/i;
+
+const LANGUAGE_LABELS: Record<string, { zh: string; en: string }> = {
+  ar: { zh: '阿拉伯语', en: 'Arabic' },
+  bg: { zh: '保加利亚语', en: 'Bulgarian' },
+  cs: { zh: '捷克语', en: 'Czech' },
+  da: { zh: '丹麦语', en: 'Danish' },
+  de: { zh: '德语', en: 'German' },
+  el: { zh: '希腊语', en: 'Greek' },
+  en: { zh: '英语', en: 'English' },
+  es: { zh: '西班牙语', en: 'Spanish' },
+  fi: { zh: '芬兰语', en: 'Finnish' },
+  fr: { zh: '法语', en: 'French' },
+  he: { zh: '希伯来语', en: 'Hebrew' },
+  hi: { zh: '印地语', en: 'Hindi' },
+  hu: { zh: '匈牙利语', en: 'Hungarian' },
+  id: { zh: '印尼语', en: 'Indonesian' },
+  it: { zh: '意大利语', en: 'Italian' },
+  ja: { zh: '日语', en: 'Japanese' },
+  ko: { zh: '韩语', en: 'Korean' },
+  nl: { zh: '荷兰语', en: 'Dutch' },
+  no: { zh: '挪威语', en: 'Norwegian' },
+  pl: { zh: '波兰语', en: 'Polish' },
+  pt: { zh: '葡萄牙语', en: 'Portuguese' },
+  'pt-br': { zh: '葡萄牙语（巴西）', en: 'Portuguese (Brazil)' },
+  ro: { zh: '罗马尼亚语', en: 'Romanian' },
+  ru: { zh: '俄语', en: 'Russian' },
+  sv: { zh: '瑞典语', en: 'Swedish' },
+  th: { zh: '泰语', en: 'Thai' },
+  tr: { zh: '土耳其语', en: 'Turkish' },
+  uk: { zh: '乌克兰语', en: 'Ukrainian' },
+  vi: { zh: '越南语', en: 'Vietnamese' },
+  zh: { zh: '中文', en: 'Chinese' },
+  cn: { zh: '中文', en: 'Chinese' },
+  'zh-cn': { zh: '简体中文', en: 'Simplified Chinese' },
+  'zh-hans': { zh: '简体中文', en: 'Simplified Chinese' },
+  'zh-tw': { zh: '繁体中文', en: 'Traditional Chinese' },
+  'zh-hant': { zh: '繁体中文', en: 'Traditional Chinese' },
+};
+
+const COMMON_LANGUAGE_ORDER = [
+  'en', 'zh', 'zh-cn', 'zh-hans', 'zh-tw', 'zh-hant', 'ja', 'ko', 'de', 'fr', 'es', 'pt', 'pt-br', 'ru', 'it', 'tr', 'vi', 'id',
+];
+
+export const DEFAULT_README_VARIANT: ReadmeVariant = {
+  key: 'default',
+  name: 'README',
+  path: null,
+  label: 'Default README',
+  isDefault: true,
+};
+
+const getFileName = (path: string, fallback?: string): string => {
+  if (fallback) return fallback;
+  const parts = path.split('/');
+  return parts[parts.length - 1] || path;
+};
+
+const normalizeLanguageCode = (code: string): string => code.toLowerCase().replace(/_/g, '-');
+
+const getLanguageLabel = (languageCode: string, uiLanguage: 'zh' | 'en'): string => {
+  const normalized = normalizeLanguageCode(languageCode);
+  const exact = LANGUAGE_LABELS[normalized];
+  if (exact) return exact[uiLanguage];
+
+  const baseCode = normalized.split('-')[0];
+  const base = LANGUAGE_LABELS[baseCode];
+  if (base) {
+    const region = normalized.split('-').slice(1).join('-').toUpperCase();
+    return region ? `${base[uiLanguage]} (${region})` : base[uiLanguage];
+  }
+
+  return normalized;
+};
+
+const getLanguagePriority = (languageCode: string | undefined, uiLanguage: 'zh' | 'en'): number => {
+  if (!languageCode) return 999;
+  const normalized = normalizeLanguageCode(languageCode);
+  const currentLanguagePriority = uiLanguage === 'zh'
+    ? ['zh', 'zh-cn', 'zh-hans', 'zh-tw', 'zh-hant', 'cn', 'en']
+    : ['en', 'zh', 'zh-cn', 'zh-hans', 'zh-tw', 'zh-hant', 'cn'];
+
+  const currentIndex = currentLanguagePriority.indexOf(normalized);
+  if (currentIndex >= 0) return currentIndex;
+
+  const commonIndex = COMMON_LANGUAGE_ORDER.indexOf(normalized);
+  if (commonIndex >= 0) return currentLanguagePriority.length + commonIndex;
+
+  const baseIndex = COMMON_LANGUAGE_ORDER.indexOf(normalized.split('-')[0]);
+  if (baseIndex >= 0) return currentLanguagePriority.length + COMMON_LANGUAGE_ORDER.length + baseIndex;
+
+  return 998;
+};
+
+export const isReadmeCandidateItem = (item: GitHubReadmeCandidateItem): boolean => {
+  const type = item.type?.toLowerCase();
+  if (type && type !== 'file' && type !== 'blob') return false;
+  return README_FILE_REGEX.test(getFileName(item.path, item.name));
+};
+
+export const buildReadmeVariants = (
+  items: GitHubReadmeCandidateItem[],
+  uiLanguage: 'zh' | 'en'
+): ReadmeVariant[] => {
+  const defaultVariant: ReadmeVariant = {
+    ...DEFAULT_README_VARIANT,
+    label: uiLanguage === 'zh' ? '默认 README' : 'Default README',
+  };
+
+  const seenPaths = new Set<string>();
+  const variants = items
+    .filter(isReadmeCandidateItem)
+    .map((item): ReadmeVariant | null => {
+      const name = getFileName(item.path, item.name);
+      const match = name.match(README_FILE_REGEX);
+      const languageCode = match?.[1] ? normalizeLanguageCode(match[1]) : undefined;
+
+      if (!languageCode) return null;
+
+      const path = item.path;
+      const pathKey = path.toLowerCase();
+      if (seenPaths.has(pathKey)) return null;
+      seenPaths.add(pathKey);
+
+      const languageLabel = getLanguageLabel(languageCode, uiLanguage);
+      return {
+        key: path,
+        name,
+        path,
+        label: `${languageLabel} · ${path}`,
+        languageCode,
+        isDefault: false,
+      };
+    })
+    .filter((variant): variant is ReadmeVariant => variant !== null)
+    .sort((a, b) => {
+      const priorityDiff = getLanguagePriority(a.languageCode, uiLanguage) - getLanguagePriority(b.languageCode, uiLanguage);
+      if (priorityDiff !== 0) return priorityDiff;
+      return a.path!.localeCompare(b.path!, undefined, { sensitivity: 'base' });
+    });
+
+  return [defaultVariant, ...variants];
+};


### PR DESCRIPTION
  ## Summary
  - add README variant detection for common multilingual README filenames
  across root and subdirectories
  - extend direct GitHub and backend proxy README APIs to discover candidates
  and load README files by path
  - add a README language dropdown in the shared README modal used by
  repository and discovery/trending cards
  - add focused tests for README variant parsing and modal switching behavior

  ## Verification
  - Not run: `npm run test:run -- src/utils/readmeVariants.test.ts
  src/components/ReadmeModal.test.tsx` (Bash safety classifier unavailable
  during attempts)
  - Not run: `npm run build` (Bash safety classifier unavailable during
  attempts)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multilingual README support with automatic detection and a selector to choose variants; UI shows the current variant label/path.
  * Faster switching between variants with cached content and graceful fallbacks when only a default README exists.

* **Bug Fixes**
  * More reliable README loading across varied repository layouts and encodings, reducing failed or empty README views.

* **Tests**
  * Added tests covering variant detection and language selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->