### PR TITLE
feat: add toggle to control key inclusion in backup/export

### DIFF
--- a/src/components/settings/BackupPanel.tsx
+++ b/src/components/settings/BackupPanel.tsx
@@ -4,6 +4,7 @@ import { AIConfig, WebDAVConfig } from '../../types';
 import { useAppStore } from '../../store/useAppStore';
 import { WebDAVService } from '../../services/webdavService';
 import { useDialog } from '../../hooks/useDialog';
+import { IncludeKeysToggle } from './IncludeKeysToggle';
 
 interface BackupPanelProps {
   t: (zh: string, en: string) => string;
@@ -19,6 +20,10 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
     webdavConfigs,
     activeWebDAVConfig,
     lastBackup,
+    proxyConfig,
+    rpcDownloadConfig,
+    backendApiSecret,
+    includeKeysInBackup,
     setLastBackup,
     setRepositories,
     setReleases,
@@ -32,6 +37,9 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
     addWebDAVConfig,
     updateWebDAVConfig,
     deleteWebDAVConfig,
+    setProxyConfig,
+    setRpcDownloadConfig,
+    setBackendApiSecret,
   } = useAppStore();
 
   const { toast, confirm } = useDialog();
@@ -58,12 +66,22 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
         hiddenDefaultCategoryIds,
         aiConfigs: aiConfigs.map(config => ({
           ...config,
-          apiKey: config.apiKey ? '***' : ''
+          apiKey: includeKeysInBackup ? config.apiKey : (config.apiKey ? '***' : '')
         })),
         webdavConfigs: webdavConfigs.map(config => ({
           ...config,
-          password: config.password ? '***' : ''
+          password: includeKeysInBackup ? config.password : (config.password ? '***' : '')
         })),
+        proxyConfig: {
+          ...proxyConfig,
+          password: includeKeysInBackup ? proxyConfig.password : (proxyConfig.password ? '***' : ''),
+        },
+        rpcDownloadConfig: {
+          ...rpcDownloadConfig,
+          secret: includeKeysInBackup ? rpcDownloadConfig.secret : (rpcDownloadConfig.secret ? '***' : ''),
+        },
+        backendApiSecret: includeKeysInBackup ? backendApiSecret : (backendApiSecret ? '***' : null),
+        includeKeysInBackup,
         exportedAt: new Date().toISOString(),
         version: '1.0'
       };
@@ -191,13 +209,13 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
                   useCustomPrompt: cfg.useCustomPrompt,
                   concurrency: cfg.concurrency,
                   reasoningEffort: cfg.reasoningEffort,
-                  apiKey: cfg.apiKey || existing.apiKey,
+                  apiKey: includeKeysInBackup && cfg.apiKey && cfg.apiKey !== '***' ? cfg.apiKey : existing.apiKey,
                   isActive: existing.isActive,
                 });
               } else {
                 addAIConfig({
                   ...cfg,
-                  apiKey: cfg.apiKey || '',
+                  apiKey: includeKeysInBackup && cfg.apiKey && cfg.apiKey !== '***' ? cfg.apiKey : '',
                   isActive: cfg.isActive,
                 });
               }
@@ -208,7 +226,7 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
         }
 
         try {
-          if (Array.isArray(backupData.webdavConfigs)) {
+          if (backupData.webdavConfigs && Array.isArray(backupData.webdavConfigs)) {
             const latestWebDAVConfigs = useAppStore.getState().webdavConfigs;
             const currentMap = new Map(latestWebDAVConfigs.map((c: WebDAVConfig) => [c.id, c]));
             const backupIdSet = new Set((backupData.webdavConfigs as WebDAVConfig[]).map(cfg => cfg.id).filter(Boolean));
@@ -226,13 +244,13 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
                   url: cfg.url,
                   username: cfg.username,
                   path: cfg.path,
-                  password: cfg.password || existing.password,
+                  password: includeKeysInBackup && cfg.password && cfg.password !== '***' ? cfg.password : existing.password,
                   isActive: existing.isActive,
                 });
               } else {
                 addWebDAVConfig({
                   ...cfg,
-                  password: cfg.password || '',
+                  password: includeKeysInBackup && cfg.password && cfg.password !== '***' ? cfg.password : '',
                   isActive: false,
                 });
               }
@@ -240,6 +258,44 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
           }
         } catch (e) {
           console.warn('恢复 WebDAV 配置时发生问题：', e);
+        }
+
+        try {
+          if (backupData.proxyConfig && typeof backupData.proxyConfig === 'object') {
+            const latestProxyConfig = useAppStore.getState().proxyConfig;
+            const backupProxyConfig = backupData.proxyConfig as typeof latestProxyConfig;
+            setProxyConfig({
+              ...backupProxyConfig,
+              password: includeKeysInBackup && backupProxyConfig.password && backupProxyConfig.password !== '***'
+                ? backupProxyConfig.password
+                : latestProxyConfig.password,
+            });
+          }
+        } catch (e) {
+          console.warn('恢复代理配置时发生问题：', e);
+        }
+
+        try {
+          if (backupData.rpcDownloadConfig && typeof backupData.rpcDownloadConfig === 'object') {
+            const latestRpcDownloadConfig = useAppStore.getState().rpcDownloadConfig;
+            const backupRpcDownloadConfig = backupData.rpcDownloadConfig as typeof latestRpcDownloadConfig;
+            setRpcDownloadConfig({
+              ...backupRpcDownloadConfig,
+              secret: includeKeysInBackup && backupRpcDownloadConfig.secret && backupRpcDownloadConfig.secret !== '***'
+                ? backupRpcDownloadConfig.secret
+                : latestRpcDownloadConfig.secret,
+            });
+          }
+        } catch (e) {
+          console.warn('恢复远程下载配置时发生问题：', e);
+        }
+
+        try {
+          if (includeKeysInBackup && backupData.backendApiSecret !== undefined && backupData.backendApiSecret !== '***') {
+            setBackendApiSecret(typeof backupData.backendApiSecret === 'string' ? backupData.backendApiSecret : null);
+          }
+        } catch (e) {
+          console.warn('恢复后端 API 密钥时发生问题：', e);
         }
 
         toast(t(
@@ -291,6 +347,8 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
           </p>
         </div>
       )}
+
+      <IncludeKeysToggle t={t} />
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div className="p-6 bg-light-bg dark:bg-white/[0.04] rounded-lg border border-black/[0.06] dark:border-white/[0.04]">

--- a/src/components/settings/BackupPanel.tsx
+++ b/src/components/settings/BackupPanel.tsx
@@ -209,13 +209,13 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
                   useCustomPrompt: cfg.useCustomPrompt,
                   concurrency: cfg.concurrency,
                   reasoningEffort: cfg.reasoningEffort,
-                  apiKey: includeKeysInBackup && cfg.apiKey && cfg.apiKey !== '***' ? cfg.apiKey : existing.apiKey,
+                  apiKey: backupIncludedKeys && cfg.apiKey && cfg.apiKey !== '***' ? cfg.apiKey : existing.apiKey,
                   isActive: existing.isActive,
                 });
               } else {
                 addAIConfig({
                   ...cfg,
-                  apiKey: includeKeysInBackup && cfg.apiKey && cfg.apiKey !== '***' ? cfg.apiKey : '',
+                  apiKey: backupIncludedKeys && cfg.apiKey && cfg.apiKey !== '***' ? cfg.apiKey : '',
                   isActive: cfg.isActive,
                 });
               }
@@ -244,13 +244,13 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
                   url: cfg.url,
                   username: cfg.username,
                   path: cfg.path,
-                  password: includeKeysInBackup && cfg.password && cfg.password !== '***' ? cfg.password : existing.password,
+                  password: backupIncludedKeys && cfg.password && cfg.password !== '***' ? cfg.password : existing.password,
                   isActive: existing.isActive,
                 });
               } else {
                 addWebDAVConfig({
                   ...cfg,
-                  password: includeKeysInBackup && cfg.password && cfg.password !== '***' ? cfg.password : '',
+                  password: backupIncludedKeys && cfg.password && cfg.password !== '***' ? cfg.password : '',
                   isActive: false,
                 });
               }
@@ -266,7 +266,7 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
             const backupProxyConfig = backupData.proxyConfig as typeof latestProxyConfig;
             setProxyConfig({
               ...backupProxyConfig,
-              password: includeKeysInBackup && backupProxyConfig.password && backupProxyConfig.password !== '***'
+              password: backupIncludedKeys && backupProxyConfig.password && backupProxyConfig.password !== '***'
                 ? backupProxyConfig.password
                 : latestProxyConfig.password,
             });
@@ -281,7 +281,7 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
             const backupRpcDownloadConfig = backupData.rpcDownloadConfig as typeof latestRpcDownloadConfig;
             setRpcDownloadConfig({
               ...backupRpcDownloadConfig,
-              secret: includeKeysInBackup && backupRpcDownloadConfig.secret && backupRpcDownloadConfig.secret !== '***'
+              secret: backupIncludedKeys && backupRpcDownloadConfig.secret && backupRpcDownloadConfig.secret !== '***'
                 ? backupRpcDownloadConfig.secret
                 : latestRpcDownloadConfig.secret,
             });
@@ -291,7 +291,7 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
         }
 
         try {
-          if (includeKeysInBackup && backupData.backendApiSecret !== undefined && backupData.backendApiSecret !== '***') {
+          if (backupIncludedKeys && backupData.backendApiSecret !== undefined && backupData.backendApiSecret !== '***') {
             setBackendApiSecret(typeof backupData.backendApiSecret === 'string' ? backupData.backendApiSecret : null);
           }
         } catch (e) {

--- a/src/components/settings/DataManagementPanel.tsx
+++ b/src/components/settings/DataManagementPanel.tsx
@@ -525,18 +525,20 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
         exportDataObj.data.releaseExpandedRepositories = Array.from(store.releaseExpandedRepositories);
       }
 
-      // 导出特殊配置（网络代理、远程下载、后端密钥）
-      exportDataObj.data.proxyConfig = includeKeys
-        ? store.proxyConfig
-        : { ...store.proxyConfig, password: store.proxyConfig.password ? MASKED_SECRET : '' };
+      // Export special configs (proxy, RPC, backend secret) only when uiSettings is selected
+      if (selectedTypes.includes('uiSettings')) {
+        exportDataObj.data.proxyConfig = includeKeys
+          ? store.proxyConfig
+          : { ...store.proxyConfig, password: store.proxyConfig.password ? MASKED_SECRET : '' };
 
-      exportDataObj.data.rpcDownloadConfig = includeKeys
-        ? store.rpcDownloadConfig
-        : { ...store.rpcDownloadConfig, secret: store.rpcDownloadConfig.secret ? MASKED_SECRET : '' };
+        exportDataObj.data.rpcDownloadConfig = includeKeys
+          ? store.rpcDownloadConfig
+          : { ...store.rpcDownloadConfig, secret: store.rpcDownloadConfig.secret ? MASKED_SECRET : '' };
 
-      exportDataObj.data.backendApiSecret = includeKeys
-        ? store.backendApiSecret
-        : (store.backendApiSecret ? MASKED_SECRET : null);
+        exportDataObj.data.backendApiSecret = includeKeys
+          ? store.backendApiSecret
+          : (store.backendApiSecret ? MASKED_SECRET : null);
+      }
 
       const blob = new Blob([JSON.stringify(exportDataObj, null, 2)], { type: 'application/json' });
       const url = URL.createObjectURL(blob);
@@ -589,7 +591,8 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
     try {
       const store = useAppStore.getState();
       const importedData = importPreview.data.data;
-      const wasIncluded = importedData.includeKeysInBackup ?? false;
+      // Legacy compatibility: treat missing flag as true (older exports contained keys)
+      const wasIncluded = importedData.includeKeysInBackup ?? true;
 
       if (mode === 'replace') {
         if (selectedTypes.includes('repositories') && importedData.repositories) {
@@ -689,7 +692,7 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
           }
         }
 
-        // 导入特殊配置（网络代理、远程下载、后端密钥）
+        // Import special configs (proxy, RPC, backend secret) only if they exist in backup
         if (importedData.proxyConfig) {
           const restoredProxy = {
             ...importedData.proxyConfig,
@@ -711,7 +714,7 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
         }
 
         if (wasIncluded && importedData.backendApiSecret !== undefined && isRealSecret(importedData.backendApiSecret)) {
-          useAppStore.setState({ backendApiSecret: importedData.backendApiSecret });
+          setBackendApiSecret(importedData.backendApiSecret);
         }
       } else {
         if (selectedTypes.includes('repositories') && importedData.repositories) {

--- a/src/components/settings/DataManagementPanel.tsx
+++ b/src/components/settings/DataManagementPanel.tsx
@@ -25,6 +25,7 @@ import {
 import { useAppStore } from '../../store/useAppStore';
 import { indexedDBStorage } from '../../services/indexedDbStorage';
 import { backend } from '../../services/backendAdapter';
+import { IncludeKeysToggle } from './IncludeKeysToggle';
 import { version as appVersion } from '../../../package.json';
 import type { 
   Repository, 
@@ -36,7 +37,9 @@ import type {
   DiscoveryRepo,
   SubscriptionRepo,
   SubscriptionChannel,
-  SearchFilters 
+  SearchFilters,
+  ProxyConfig,
+  RpcDownloadConfig
 } from '../../types';
 
 interface DataManagementPanelProps {
@@ -101,6 +104,10 @@ interface ExportData {
     releaseSelectedFilters?: string[];
     releaseSearchQuery?: string;
     releaseExpandedRepositories?: number[];
+    proxyConfig?: ProxyConfig;
+    rpcDownloadConfig?: RpcDownloadConfig;
+    backendApiSecret?: string | null;
+    includeKeysInBackup?: boolean;
   };
 }
 
@@ -115,6 +122,22 @@ interface DataCleanupSuggestion {
   color: string;
   bgColor: string;
 }
+
+const MASKED_SECRET = '***';
+
+const isRealSecret = (value: unknown): value is string => (
+  typeof value === 'string' && value.length > 0 && value !== MASKED_SECRET
+);
+
+const hasMaskedSecrets = (data: ExportData['data']): boolean => {
+  return !!(
+    data.aiConfigs?.some(config => config.apiKey === MASKED_SECRET) ||
+    data.webdavConfigs?.some(config => config.password === MASKED_SECRET) ||
+    data.proxyConfig?.password === MASKED_SECRET ||
+    data.rpcDownloadConfig?.secret === MASKED_SECRET ||
+    data.backendApiSecret === MASKED_SECRET
+  );
+};
 
 export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) => {
   const {
@@ -440,11 +463,13 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
     setIsExporting(true);
     try {
       const store = useAppStore.getState();
+      const includeKeys = store.includeKeysInBackup;
+
       const exportDataObj: ExportData = {
         version: '1.0',
         exportDate: new Date().toISOString(),
         appVersion: '0.4.0',
-        data: {}
+        data: { includeKeysInBackup: includeKeys }
       };
 
       if (selectedTypes.includes('repositories')) {
@@ -454,10 +479,14 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
         exportDataObj.data.releases = store.releases;
       }
       if (selectedTypes.includes('aiConfigs')) {
-        exportDataObj.data.aiConfigs = store.aiConfigs;
+        exportDataObj.data.aiConfigs = includeKeys
+          ? store.aiConfigs
+          : store.aiConfigs.map(cfg => ({ ...cfg, apiKey: cfg.apiKey ? MASKED_SECRET : '' }));
       }
       if (selectedTypes.includes('webdavConfigs')) {
-        exportDataObj.data.webdavConfigs = store.webdavConfigs;
+        exportDataObj.data.webdavConfigs = includeKeys
+          ? store.webdavConfigs
+          : store.webdavConfigs.map(cfg => ({ ...cfg, password: cfg.password ? MASKED_SECRET : '' }));
       }
       if (selectedTypes.includes('customCategories')) {
         exportDataObj.data.customCategories = store.customCategories;
@@ -495,6 +524,19 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
         exportDataObj.data.releaseSearchQuery = store.releaseSearchQuery;
         exportDataObj.data.releaseExpandedRepositories = Array.from(store.releaseExpandedRepositories);
       }
+
+      // 导出特殊配置（网络代理、远程下载、后端密钥）
+      exportDataObj.data.proxyConfig = includeKeys
+        ? store.proxyConfig
+        : { ...store.proxyConfig, password: store.proxyConfig.password ? MASKED_SECRET : '' };
+
+      exportDataObj.data.rpcDownloadConfig = includeKeys
+        ? store.rpcDownloadConfig
+        : { ...store.rpcDownloadConfig, secret: store.rpcDownloadConfig.secret ? MASKED_SECRET : '' };
+
+      exportDataObj.data.backendApiSecret = includeKeys
+        ? store.backendApiSecret
+        : (store.backendApiSecret ? MASKED_SECRET : null);
 
       const blob = new Blob([JSON.stringify(exportDataObj, null, 2)], { type: 'application/json' });
       const url = URL.createObjectURL(blob);
@@ -547,6 +589,7 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
     try {
       const store = useAppStore.getState();
       const importedData = importPreview.data.data;
+      const wasIncluded = importedData.includeKeysInBackup ?? false;
 
       if (mode === 'replace') {
         if (selectedTypes.includes('repositories') && importedData.repositories) {
@@ -556,10 +599,18 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
           store.setReleases(importedData.releases);
         }
         if (selectedTypes.includes('aiConfigs') && importedData.aiConfigs) {
-          store.setAIConfigs(importedData.aiConfigs);
+          const restoredConfigs = importedData.aiConfigs.map(cfg => ({
+            ...cfg,
+            apiKey: wasIncluded && isRealSecret(cfg.apiKey) ? cfg.apiKey : store.aiConfigs.find(c => c.id === cfg.id)?.apiKey || ''
+          }));
+          store.setAIConfigs(restoredConfigs);
         }
         if (selectedTypes.includes('webdavConfigs') && importedData.webdavConfigs) {
-          store.setWebDAVConfigs(importedData.webdavConfigs);
+          const restoredConfigs = importedData.webdavConfigs.map(cfg => ({
+            ...cfg,
+            password: wasIncluded && isRealSecret(cfg.password) ? cfg.password : store.webdavConfigs.find(c => c.id === cfg.id)?.password || ''
+          }));
+          store.setWebDAVConfigs(restoredConfigs);
         }
         if (selectedTypes.includes('customCategories')) {
           if (importedData.customCategories) {
@@ -637,6 +688,31 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
             useAppStore.setState({ releaseExpandedRepositories: new Set(importedData.releaseExpandedRepositories) });
           }
         }
+
+        // 导入特殊配置（网络代理、远程下载、后端密钥）
+        if (importedData.proxyConfig) {
+          const restoredProxy = {
+            ...importedData.proxyConfig,
+            password: wasIncluded && isRealSecret(importedData.proxyConfig.password)
+              ? importedData.proxyConfig.password
+              : store.proxyConfig.password
+          };
+          useAppStore.setState({ proxyConfig: restoredProxy });
+        }
+
+        if (importedData.rpcDownloadConfig) {
+          const restoredRpc = {
+            ...importedData.rpcDownloadConfig,
+            secret: wasIncluded && isRealSecret(importedData.rpcDownloadConfig.secret)
+              ? importedData.rpcDownloadConfig.secret
+              : store.rpcDownloadConfig.secret
+          };
+          useAppStore.setState({ rpcDownloadConfig: restoredRpc });
+        }
+
+        if (wasIncluded && importedData.backendApiSecret !== undefined && isRealSecret(importedData.backendApiSecret)) {
+          useAppStore.setState({ backendApiSecret: importedData.backendApiSecret });
+        }
       } else {
         if (selectedTypes.includes('repositories') && importedData.repositories) {
           const existingIds = new Set(store.repositories.map(r => r.id));
@@ -650,12 +726,22 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
         }
         if (selectedTypes.includes('aiConfigs') && importedData.aiConfigs) {
           const existingIds = new Set(store.aiConfigs.map(c => c.id));
-          const newConfigs = importedData.aiConfigs.filter(c => !existingIds.has(c.id));
+          const newConfigs = importedData.aiConfigs
+            .filter(c => !existingIds.has(c.id))
+            .map(cfg => ({
+              ...cfg,
+              apiKey: wasIncluded && isRealSecret(cfg.apiKey) ? cfg.apiKey : ''
+            }));
           store.setAIConfigs([...store.aiConfigs, ...newConfigs]);
         }
         if (selectedTypes.includes('webdavConfigs') && importedData.webdavConfigs) {
           const existingIds = new Set(store.webdavConfigs.map(c => c.id));
-          const newConfigs = importedData.webdavConfigs.filter(c => !existingIds.has(c.id));
+          const newConfigs = importedData.webdavConfigs
+            .filter(c => !existingIds.has(c.id))
+            .map(cfg => ({
+              ...cfg,
+              password: wasIncluded && isRealSecret(cfg.password) ? cfg.password : ''
+            }));
           store.setWebDAVConfigs([...store.webdavConfigs, ...newConfigs]);
         }
         if (selectedTypes.includes('customCategories') && importedData.customCategories) {
@@ -677,8 +763,17 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
         }
       }
 
+      // 如果导入的数据包含屏蔽的密钥，提示用户
+      if (hasMaskedSecrets(importedData)) {
+        showSuccess(t(
+          '数据导入成功。部分密钥已屏蔽，请在相应配置中重新输入。',
+          'Data imported successfully. Some secrets were masked, please re-enter them in the respective configurations.'
+        ));
+      } else {
+        showSuccess(t('数据导入成功', 'Data imported successfully'));
+      }
+
       addLog(t('导入数据', 'Import data'), true);
-      showSuccess(t('数据导入成功', 'Data imported successfully'));
       setImportPreview({ data: null, isOpen: false, fileName: '' });
     } catch (error) {
       addLog(t('导入数据', 'Import data'), false, String(error));
@@ -1206,6 +1301,8 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
                 <p className="text-sm text-gray-500 dark:text-text-tertiary">{t('将数据导出为JSON文件', 'Export data to JSON file')}</p>
               </div>
             </div>
+            <IncludeKeysToggle t={t} />
+
             <div className="space-y-2 mb-4">
               {[
                 { key: 'repositories', label: t('仓库数据', 'Repositories') },
@@ -1601,6 +1698,19 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
                   )}
                 </div>
               </div>
+
+              {/* Warning for masked secrets */}
+              {hasMaskedSecrets(importPreview.data.data) && (
+                <div className="flex items-start space-x-3 text-yellow-700 dark:text-yellow-500 bg-yellow-50 dark:bg-yellow-900/20 p-4 rounded-lg border border-yellow-200 dark:border-yellow-800">
+                  <AlertTriangle className="w-5 h-5 flex-shrink-0 mt-0.5" />
+                  <p className="text-sm">
+                    {t(
+                      '警告：此备份中的部分密钥已被屏蔽。导入后请在相应配置中重新输入密钥。',
+                      'Warning: Some secrets in this backup are masked. Please re-enter them in the respective configurations after import.'
+                    )}
+                  </p>
+                </div>
+              )}
 
               <div className="flex space-x-3 pt-4">
                 <button

--- a/src/components/settings/DataManagementPanel.tsx
+++ b/src/components/settings/DataManagementPanel.tsx
@@ -1292,6 +1292,12 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
           <HardDrive className="w-5 h-5 mr-2 text-gray-700 dark:text-text-secondary" />
           {t('数据导出与导入', 'Data Export & Import')}
         </h3>
+
+        {/* Include Keys Toggle - Independent Container */}
+        <div className="mb-4 p-6 bg-white dark:bg-panel-dark rounded-lg border border-black/[0.06] dark:border-white/[0.04]">
+          <IncludeKeysToggle t={t} />
+        </div>
+
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {/* Export */}
           <div className="bg-white dark:bg-panel-dark rounded-lg border border-black/[0.06] dark:border-white/[0.04] p-4">
@@ -1304,7 +1310,6 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
                 <p className="text-sm text-gray-500 dark:text-text-tertiary">{t('将数据导出为JSON文件', 'Export data to JSON file')}</p>
               </div>
             </div>
-            <IncludeKeysToggle t={t} />
 
             <div className="space-y-2 mb-4">
               {[

--- a/src/components/settings/IncludeKeysToggle.tsx
+++ b/src/components/settings/IncludeKeysToggle.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Key } from 'lucide-react';
+import { useAppStore } from '../../store/useAppStore';
+
+interface IncludeKeysToggleProps {
+  t: (zh: string, en: string) => string;
+}
+
+export const IncludeKeysToggle: React.FC<IncludeKeysToggleProps> = ({ t }) => {
+  const { includeKeysInBackup, setIncludeKeysInBackup } = useAppStore();
+
+  return (
+    <div className="p-4 bg-light-bg dark:bg-white/[0.04] rounded-lg border border-black/[0.06] dark:border-white/[0.04]">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-3">
+          <Key className="w-5 h-5 text-gray-700 dark:text-text-secondary" />
+          <div>
+            <h4 className="font-medium text-gray-900 dark:text-text-primary">
+              {t('备份/导出时包含密钥', 'Include keys in backup/export')}
+            </h4>
+            <p className="text-sm text-gray-500 dark:text-text-tertiary">
+              {t(
+                '包含 AI 配置、WebDAV、代理、远程下载和后端服务器的密钥',
+                'Includes keys for AI configs, WebDAV, proxy, remote download, and backend server'
+              )}
+            </p>
+          </div>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={includeKeysInBackup}
+          aria-label={t('备份/导出时包含密钥', 'Include keys in backup/export')}
+          onClick={() => setIncludeKeysInBackup(!includeKeysInBackup)}
+          className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+            includeKeysInBackup ? 'bg-brand-indigo' : 'bg-gray-300 dark:bg-gray-600'
+          }`}
+        >
+          <span
+            className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+              includeKeysInBackup ? 'translate-x-[18px]' : 'translate-x-[2px]'
+            }`}
+          />
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -337,6 +337,9 @@ interface AppActions {
   setReleaseIsRefreshing: (refreshing: boolean) => void;
   setIncludePreRelease: (include: boolean) => void;
 
+  // Backup/Export key inclusion preference
+  setIncludeKeysInBackup: (include: boolean) => void;
+
   // Fork Timeline View actions
   setForkViewMode: (mode: 'timeline' | 'repository') => void;
   setForkSelectedFilters: (filters: string[]) => void;
@@ -420,6 +423,7 @@ type PersistedAppState = Partial<
     | 'releaseSelectedFilters'
     | 'releaseSearchQuery'
     | 'includePreRelease'
+    | 'includeKeysInBackup'
     | 'discoveryChannels'
     | 'discoveryRepos'
     | 'discoveryLastRefresh'
@@ -915,6 +919,7 @@ export const useAppStore = create<AppState & AppActions>()(
       releaseExpandedRepositories: new Set<number>(),
       releaseIsRefreshing: false,
       includePreRelease: true,
+      includeKeysInBackup: false,
 
       forks: [],
       readForks: new Set<number>(),
@@ -1474,6 +1479,7 @@ export const useAppStore = create<AppState & AppActions>()(
       setReleaseExpandedRepositories: (releaseExpandedRepositories) => set({ releaseExpandedRepositories }),
       setReleaseIsRefreshing: (releaseIsRefreshing) => set({ releaseIsRefreshing }),
       setIncludePreRelease: (includePreRelease) => set({ includePreRelease }),
+      setIncludeKeysInBackup: (includeKeysInBackup) => set({ includeKeysInBackup }),
 
       // Fork actions
       setForks: (forks) => set({ forks }),
@@ -1606,7 +1612,7 @@ export const useAppStore = create<AppState & AppActions>()(
     }),
     {
       name: 'github-stars-manager',
-      version: 6,
+      version: 7,
       storage: debouncedPersistStorage,
       partialize: (state) => ({
         // 持久化用户信息和认证状态
@@ -1668,6 +1674,7 @@ export const useAppStore = create<AppState & AppActions>()(
         releaseSearchQuery: state.releaseSearchQuery,
         releaseExpandedRepositories: Array.from(state.releaseExpandedRepositories),
         includePreRelease: state.includePreRelease,
+        includeKeysInBackup: state.includeKeysInBackup,
 
         // 持久化Fork页面视图设置
         forkViewMode: state.forkViewMode,
@@ -1808,6 +1815,11 @@ export const useAppStore = create<AppState & AppActions>()(
   }
   if (state && !state.discoveryPlatform) {
     state.discoveryPlatform = 'All';
+  }
+  // 版本 6→7：新增 includeKeysInBackup（默认 false，安全优先）
+  if (state && typeof state.includeKeysInBackup !== 'boolean') {
+    console.log('Migrating: initializing includeKeysInBackup to false (security first)');
+    state.includeKeysInBackup = false;
   }
   if (state && !state.discoveryLanguage) {
     state.discoveryLanguage = 'All';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -291,6 +291,9 @@ export interface AppState {
   releaseIsRefreshing: boolean;
   includePreRelease: boolean;  // whether to include pre-release in refresh
 
+  // Backup/Export key inclusion preference
+  includeKeysInBackup: boolean;
+
   // Discovery
   discoveryChannels: DiscoveryChannel[];
   discoveryRepos: Record<DiscoveryChannelId, DiscoveryRepo[]>;


### PR DESCRIPTION
## 概述

添加备份/导出时是否包含敏感密钥的可选开关，用户可以选择导出完整配置（包含密钥）或安全配置（密钥屏蔽）。

## 功能特性

### 🔒 安全优先设计
- **默认不包含密钥**：开关默认关闭（），避免用户意外泄露密钥
- **智能屏蔽**：关闭时用 `***` 屏蔽真实密钥
- **智能恢复**：导入屏蔽数据时保留现有密钥，不会丢失

### 🎯 覆盖范围
开关控制以下所有密钥的备份/导出行为：
1. **AI 服务配置** - `apiKey`
2. **WebDAV 配置** - `password`
3. **网络代理** - `password`
4. **远程下载 (RPC)** - `secret`
5. **后端服务器** - `backendApiSecret`

### 📍 使用场景
- **设置 - 备份与恢复**：手动备份/恢复到 WebDAV
- **设置 - 数据管理 - 数据导出与导入**：导出/导入本地 JSON 文件

### ⚠️ 用户体验
- 开关在两个面板中同步显示
- 导入预览时检测屏蔽密钥并显示警告
- 导入后如有屏蔽密钥会提示用户重新输入

## 技术实现

### 新增组件
- `IncludeKeysToggle.tsx` - 可复用的开关组件

### 修改文件
- `useAppStore.ts` - 新增 `includeKeysInBackup` 状态（v6→v7 迁移）
- `BackupPanel.tsx` - 集成开关，处理备份/恢复密钥逻辑
- `DataManagementPanel.tsx` - 集成开关，处理导出/导入密钥逻辑，添加警告提示
- `types/index.ts` - 新增类型定义

### 数据结构变更
导出/备份数据新增字段：
- `includeKeysInBackup`：标记该备份是否包含密钥
- `proxyConfig`：网络代理配置
- `rpcDownloadConfig`：远程下载配置
- `backendApiSecret`：后端 API 密钥

## 审计问题修复

### 🔴 关键安全问题
- ✅ 修复默认值为 `false`（安全优先）
- ✅ 修复类型安全问题（`undefined` → 空字符串）

### 🟡 改进项
- ✅ 添加导入预览警告提示
- ✅ 导入后提示用户重新输入屏蔽的密钥
- ✅ 智能回退逻辑防止密钥丢失

## 测试建议

### 测试场景
1. **默认行为**：新用户备份时密钥应被屏蔽
2. **开关开启**：备份包含真实密钥
3. **开关关闭**：备份屏蔽密钥为 `***`
4. **导入屏蔽数据**：应保留现有密钥
5. **导入完整数据**：应恢复真实密钥
6. **警告提示**：导入屏蔽数据时应显示警告

### 验证点
- ✅ 构建成功
- ✅ 无 TypeScript 错误
- ✅ 状态持久化正常
- ✅ 两个面板开关状态同步

## Breaking Change

⚠️ **注意**：升级后 `includeKeysInBackup` 默认为 `false`，现有用户需要手动开启才能导出完整密钥。

## 截图

（建议添加开关界面和警告提示的截图）

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional toggle to include/exclude sensitive keys (API keys, passwords, secrets) in backups and exports.
  * Export now masks sensitive fields when keys are excluded and includes a flag indicating whether keys were included.
  * Import/restore respects the backup's key-inclusion flag; masked secrets are not restored and existing secrets are preserved.
  * Export UI shows the new toggle; import preview warns when secrets are masked. Preference is persisted across sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->