### PR TITLE
fix: 改进 Markdown 代码块渲染 (#206)

### DIFF
--- a/src/components/BilingualMarkdownRenderer.tsx
+++ b/src/components/BilingualMarkdownRenderer.tsx
@@ -234,7 +234,8 @@ const BilingualMarkdownRenderer = forwardRef<BilingualMarkdownRendererHandle, Bi
           'mt-1 pl-3 border-l-2 border-blue-400 dark:border-blue-500 text-gray-600 dark:text-text-tertiary text-sm leading-relaxed';
 
         if (segments[i].hasInlineCode) {
-          const codeRegex = /<code>([\s\S]*?)<\/code>/g;
+          // 修改正则以支持带属性的 code 标签（如 <code class="...">）
+          const codeRegex = /<code(?:\s+[^>]*)?>([\s\S]*?)<\/code>/g;
           let lastIndex = 0;
           let match: RegExpExecArray | null;
           while ((match = codeRegex.exec(translatedTexts[i])) !== null) {

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -860,7 +860,9 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = memo(({
       <del className="line-through text-gray-500 dark:text-text-tertiary">{children}</del>
     ),
     code: ({ className, children, ...props }) => {
-      const isInline = !className;
+      // 检查 props 中是否有 'data-code-block' 标记（由 pre 组件添加）
+      const isCodeBlock = 'data-code-block' in props || !!className;
+      const isInline = !isCodeBlock;
       const match = /language-(\w+)/.exec(className || '');
       const language = match ? match[1] : '';
 
@@ -874,7 +876,13 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = memo(({
         </CodeBlock>
       );
     },
-    pre: ({ children }) => <>{children}</>,
+    pre: ({ children }) => {
+      // 给 code 子元素添加标记，表明它是代码块而不是行内代码
+      if (React.isValidElement(children) && children.type === 'code') {
+        return <>{React.cloneElement(children as React.ReactElement<any>, { 'data-code-block': true })}</>;
+      }
+      return <>{children}</>;
+    },
     blockquote: ({ children }) => (
       <blockquote className="border-l-4 border-black/[0.06] dark:border-white/[0.04] pl-4 py-1 my-2 text-gray-700 dark:text-text-tertiary italic bg-light-bg dark:bg-panel-dark/50 rounded-r">
         {children}

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -879,7 +879,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = memo(({
     pre: ({ children }) => {
       // 给 code 子元素添加标记，表明它是代码块而不是行内代码
       if (React.isValidElement(children) && children.type === 'code') {
-        return <>{React.cloneElement(children as React.ReactElement<any>, { 'data-code-block': true })}</>;
+        return <>{React.cloneElement(children as React.ReactElement<React.ComponentPropsWithoutRef<'code'>>, { 'data-code-block': true })}</>;
       }
       return <>{children}</>;
     },

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -881,7 +881,8 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = memo(({
       if (React.isValidElement(children) && children.type === 'code') {
         return <>{React.cloneElement(children as React.ReactElement<React.ComponentPropsWithoutRef<'code'>>, { 'data-code-block': true })}</>;
       }
-      return <>{children}</>;
+      // 对于非 code 子元素（如 ASCII 字符画），保留 pre 标签
+      return <pre>{children}</pre>;
     },
     blockquote: ({ children }) => (
       <blockquote className="border-l-4 border-black/[0.06] dark:border-white/[0.04] pl-4 py-1 my-2 text-gray-700 dark:text-text-tertiary italic bg-light-bg dark:bg-panel-dark/50 rounded-r">

--- a/src/index.css
+++ b/src/index.css
@@ -194,7 +194,7 @@
   .prose pre {
     overflow-x: auto;
     white-space: pre;
-    word-wrap: normal;
+    overflow-wrap: normal;
     word-break: normal;
   }
 
@@ -207,9 +207,26 @@
     tab-size: 2;
     -moz-tab-size: 2;
     white-space: pre;
-    word-wrap: normal;
+    overflow-wrap: normal;
     word-break: normal;
     overflow-x: auto;
+  }
+
+  /* 纯 pre 标签样式（如字符画、ASCII art），不包含 code 子元素 */
+  .prose pre:not(:has(code)) {
+    padding: 1rem;
+    background-color: #f8fafc;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    line-height: 1.5rem;
+    font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+    border: 1px solid rgba(0, 0, 0, 0.06);
+  }
+
+  .dark .prose pre:not(:has(code)) {
+    background-color: #1e293b;
+    border-color: rgba(255, 255, 255, 0.04);
+    color: #e6edf3;
   }
 
   .prose :not(pre) > code {

--- a/src/index.css
+++ b/src/index.css
@@ -191,6 +191,13 @@
 
 /* ========== Markdown Prose Component Styles ========== */
 @layer components {
+  .prose pre {
+    overflow-x: auto;
+    white-space: pre;
+    word-wrap: normal;
+    word-break: normal;
+  }
+
   .prose pre code {
     display: block;
     padding: 1rem;
@@ -199,6 +206,10 @@
     line-height: 1.5rem;
     tab-size: 2;
     -moz-tab-size: 2;
+    white-space: pre;
+    word-wrap: normal;
+    word-break: normal;
+    overflow-x: auto;
   }
 
   .prose :not(pre) > code {


### PR DESCRIPTION
## 问题描述

修复 Issue #206 报告的 Markdown 代码块渲染问题：
1. 反引号符号错误渲染
2. 多行代码块发生换行，破坏代码布局

## 根本原因

### 问题 1：行内代码 vs 代码块判断错误
- **原逻辑**：仅通过 `!className` 判断是否为行内代码
- **问题**：没有语言标注的代码块（如 \`\`\`\ncode\n\`\`\`）也没有 className，会被误判为行内代码
- **结果**：代码块被渲染成行内代码样式，反引号可能显示异常

### 问题 2：CSS 样式未明确禁止换行
- **问题**：没有显式设置 `white-space: pre` 等属性
- **结果**：某些情况下浏览器可能对代码进行换行

### 问题 3：翻译模式下的代码标签匹配不完整
- **原逻辑**：使用 `/<code>([\s\S]*?)<\/code>/g` 匹配
- **问题**：只能匹配不带属性的 `<code>` 标签
- **结果**：带属性的代码标签在翻译后可能丢失

## 实施的修复

### 修复 1：改进行内代码 vs 代码块判断逻辑
**文件**：`src/components/MarkdownRenderer.tsx`

- `pre` 组件给其子 `code` 元素添加 `data-code-block` 属性
- `code` 组件通过检查该属性或 `className` 来判断是否为代码块
- 即使没有语言标注的代码块也能正确识别

### 修复 2：增强代码块 CSS 样式
**文件**：`src/index.css`

- 添加 `white-space: pre` 保留空白字符，不折行
- 添加 `word-wrap: normal` 和 `word-break: normal` 防止单词断行
- 添加 `overflow-x: auto` 提供横向滚动条
- 确保代码块保持原始布局，不会因窗口宽度而换行

### 修复 3：修复翻译模式下的代码标签匹配
**文件**：`src/components/BilingualMarkdownRenderer.tsx`

- 修改正则表达式为 `/<code(?:\s+[^>]*)?>([\s\S]*?)<\/code>/g`
- 现在可以正确匹配 `<code>`、`<code class="...">`、`<code data-code-block>` 等
- 翻译后的代码标签不会丢失

## 测试建议

1. 测试有语言标注的代码块
2. 测试无语言标注的代码块
3. 测试行内代码
4. 测试长代码行是否有横向滚动条而不是换行
5. 测试翻译模式下代码是否正常显示
6. 在用户提供的示例仓库中验证：
   - https://github.com/farion1231/cc-switch
   - https://github.com/chopratejas/headroom

## 修改的文件

- `src/index.css` - 增强代码块 CSS 样式
- `src/components/MarkdownRenderer.tsx` - 改进代码块判断逻辑
- `src/components/BilingualMarkdownRenderer.tsx` - 修复翻译模式代码匹配

## 兼容性说明

- ✅ 所有修改都是向后兼容的
- ✅ 不影响现有功能
- ✅ 只是增强了边缘情况的处理

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable detection of inline vs. block code so code renders in the correct style.
  * Improved support for styled inline code (e.g., with attributes) so formatting displays correctly.

* **Style**
  * Code blocks now allow horizontal scrolling and preserve preformatted layout.
  * Refined visual styling for standalone preformatted blocks to improve readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->