### PR TITLE
fix: resolve AI category sync and README proxy errors

### DIFF
--- a/server/src/routes/configs.ts
+++ b/server/src/routes/configs.ts
@@ -26,7 +26,7 @@ function getMaskedSecretResult(params: {
       decryptedValue: decrypt(encryptedValue, encryptionKey),
       status: 'ok',
     };
-  } catch (error) {
+  } catch {
     logger.warn('configs.decrypt', 'Failed to decrypt stored secret', { kind, configId, configName });
     return { decryptedValue: '', status: 'decrypt_failed' };
   }

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -259,7 +259,8 @@ router.post('/api/proxy/webdav', async (req, res) => {
     const targetUrl = `${baseUrl}${path}`;
     const credentials = Buffer.from(`${username}:${password}`).toString('base64');
 
-    const { Authorization: _ignored, ...safeHeaders } = extraHeaders || {};
+    const safeHeaders = { ...(extraHeaders || {}) };
+    delete safeHeaders.Authorization;
     const headers: Record<string, string> = {
       ...safeHeaders,
       'Authorization': `Basic ${credentials}`,

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -260,7 +260,11 @@ router.post('/api/proxy/webdav', async (req, res) => {
     const credentials = Buffer.from(`${username}:${password}`).toString('base64');
 
     const safeHeaders = { ...(extraHeaders || {}) };
-    delete safeHeaders.Authorization;
+    for (const key of Object.keys(safeHeaders)) {
+      if (key.toLowerCase() === 'authorization') {
+        delete safeHeaders[key];
+      }
+    }
     const headers: Record<string, string> = {
       ...safeHeaders,
       'Authorization': `Basic ${credentials}`,

--- a/server/src/routes/repositories.ts
+++ b/server/src/routes/repositories.ts
@@ -35,7 +35,7 @@ function transformRepo(row: Record<string, unknown>) {
     analysis_failed: !!row.analysis_failed,
     custom_description: row.custom_description,
     custom_tags: parseJsonColumn(row.custom_tags),
-    custom_category: row.custom_category,
+    custom_category: row.custom_category ?? undefined,
     category_locked: !!row.category_locked,
     last_edited: row.last_edited,
     subscribed_to_releases: !!row.subscribed_to_releases,

--- a/server/src/routes/repositories.ts
+++ b/server/src/routes/repositories.ts
@@ -149,7 +149,7 @@ router.put('/api/repositories', (req, res) => {
         analysis_failed = excluded.analysis_failed,
         custom_description = CASE WHEN excluded.custom_description IS NOT NULL AND excluded.custom_description != '' THEN excluded.custom_description ELSE repositories.custom_description END,
         custom_tags = CASE WHEN excluded.custom_tags IS NOT NULL AND excluded.custom_tags != '[]' THEN excluded.custom_tags ELSE repositories.custom_tags END,
-        custom_category = CASE WHEN excluded.custom_category IS NOT NULL AND excluded.custom_category != '' THEN excluded.custom_category ELSE repositories.custom_category END,
+        custom_category = excluded.custom_category,
         category_locked = excluded.category_locked,
         last_edited = CASE WHEN excluded.last_edited IS NOT NULL AND excluded.last_edited != '' THEN excluded.last_edited ELSE repositories.last_edited END,
         subscribed_to_releases = excluded.subscribed_to_releases

--- a/server/tests/routes/webdavProxyRoute.test.ts
+++ b/server/tests/routes/webdavProxyRoute.test.ts
@@ -1,0 +1,79 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const proxyRequestMock = vi.fn();
+
+vi.mock('../../src/db/connection.js', () => ({
+  getDb: () => ({
+    prepare: (sql: string) => ({
+      get: (keyOrId: string) => {
+        if (sql.includes('FROM webdav_configs')) {
+          return {
+            id: keyOrId,
+            username: 'alice',
+            password_encrypted: 'secret',
+            url: 'https://dav.example.com',
+          };
+        }
+        if (sql.includes('FROM settings')) {
+          return undefined;
+        }
+        return undefined;
+      },
+    }),
+  }),
+}));
+
+vi.mock('../../src/services/crypto.js', () => ({
+  decrypt: (value: string) => value,
+  encrypt: (value: string) => value,
+}));
+
+vi.mock('../../src/services/proxyService.js', () => ({
+  validateUrl: vi.fn(),
+  proxyRequest: proxyRequestMock,
+}));
+
+const { default: proxyRouter } = await import('../../src/routes/proxy.js');
+
+const createTestApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use(proxyRouter);
+  return app;
+};
+
+describe('WebDAV proxy route', () => {
+  beforeEach(() => {
+    proxyRequestMock.mockReset();
+    proxyRequestMock.mockResolvedValue({ status: 200, data: { ok: true }, headers: {} });
+  });
+
+  it('strips client Authorization headers case-insensitively before adding proxy auth', async () => {
+    const app = createTestApp();
+
+    await request(app)
+      .post('/api/proxy/webdav')
+      .send({
+        configId: 'webdav-1',
+        method: 'PUT',
+        path: '/backup.json',
+        body: '{"ok":true}',
+        headers: {
+          authorization: 'Bearer lower-case-token',
+          AuthorIzation: 'Bearer mixed-case-token',
+          'Content-Type': 'application/json',
+        },
+      })
+      .expect(200, { ok: true });
+
+    expect(proxyRequestMock).toHaveBeenCalledOnce();
+    const options = proxyRequestMock.mock.calls[0][0];
+    expect(options.url).toBe('https://dav.example.com/backup.json');
+    expect(options.headers.authorization).toBeUndefined();
+    expect(options.headers.AuthorIzation).toBeUndefined();
+    expect(options.headers['Content-Type']).toBe('application/json');
+    expect(options.headers.Authorization).toBe(`Basic ${Buffer.from('alice:secret').toString('base64')}`);
+  });
+});

--- a/src/components/BulkRestoreModal.tsx
+++ b/src/components/BulkRestoreModal.tsx
@@ -70,7 +70,7 @@ export const BulkRestoreModal: React.FC<BulkRestoreModalProps> = ({
     for (const repo of repositories) {
       if (repo.custom_description !== undefined && repo.custom_description !== null) hasCustomDesc++;
       if (repo.custom_tags !== undefined) hasCustomTags++;
-      if (repo.custom_category !== undefined && repo.custom_category !== '') hasCustomCategory++;
+      if (repo.custom_category != null && repo.custom_category !== '') hasCustomCategory++;
       if (repo.ai_summary && repo.ai_summary.trim() !== '') hasAiSummary++;
       if (repo.ai_tags && repo.ai_tags.length > 0) hasAiTags++;
       if (getAICategory(repo, allCategories) !== '') hasAiCategory++;

--- a/src/components/ForkCard.tsx
+++ b/src/components/ForkCard.tsx
@@ -37,8 +37,6 @@ const ForkCard: React.FC<ForkCardProps> = memo(({
   const t = useCallback((zh: string, en: string) => language === 'zh' ? zh : en, [language]);
 
   const sourceFullName = fork.source?.full_name || fork.parent?.full_name || '';
-  // A repo is only a fork if it has a parent/source OR the fork boolean is true
-  const isFork = !!fork.parent || !!fork.source || fork.fork === true;
 
   return (
     <div

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,7 +17,6 @@ export const Header: React.FC = () => {
     setTheme,
     setCurrentView,
     setRepositories,
-    setReleases,
     setLoading,
     setLastSync,
     logout,

--- a/src/components/LoginScreen.tsx
+++ b/src/components/LoginScreen.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Github, Key, ArrowRight, AlertCircle, Moon, Sun } from 'lucide-react';
 import { useAppStore } from '../store/useAppStore';
 import { GitHubApiService } from '../services/githubApi';
+import { backend } from '../services/backendAdapter';
 import { safeReadText } from '../utils/clipboardUtils';
 
 export const LoginScreen: React.FC = () => {
@@ -27,7 +28,18 @@ export const LoginScreen: React.FC = () => {
       // If successful, save the token and user info
       setGitHubToken(token);
       setUser(user);
-      
+
+      if (backend.isAvailable) {
+        try {
+          await backend.syncSettings({ github_token: token });
+        } catch (backendError) {
+          console.warn('Failed to save GitHub token to backend:', backendError);
+          setError(language === 'zh'
+            ? '已登录，但 GitHub Token 未能保存到后端，README 等后端代理功能可能不可用。'
+            : 'Signed in, but failed to save GitHub token to backend. README and other backend proxy features may be unavailable.');
+        }
+      }
+
       console.log('Successfully authenticated user:', user);
     } catch (error) {
       console.error('Authentication failed:', error);

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -182,22 +182,22 @@ const CodeBlock: React.FC<{
               ? 'bg-gradient-to-br from-cyan-50/40 to-slate-100/20 dark:from-[#0d1117] dark:to-[#161b22]'
               : 'bg-light-bg dark:bg-[#0d1117]'
       }`}>
-        <pre className={`p-4 overflow-x-auto ${className || ''}`}>
-          <div className={showLineNumbers ? 'flex items-start' : undefined}>
+        <div className={`p-4 overflow-x-auto ${className || ''}`}>
+          <pre className={showLineNumbers ? 'flex items-start' : undefined}>
             {showLineNumbers && (
-              <div className="select-none pr-4 text-right flex-shrink-0" aria-hidden="true">
+              <span className="select-none pr-4 text-right flex-shrink-0" aria-hidden="true">
                 {codeLines.map((_, index) => (
                   <span key={index} className="block text-gray-400 text-sm font-mono leading-6">
                     {index + 1}
                   </span>
                 ))}
-              </div>
+              </span>
             )}
             <code ref={codeRef} className={`text-sm font-mono leading-6 text-gray-800 dark:text-[#e6edf3] ${showLineNumbers ? 'block min-w-0 flex-1' : ''} ${normalizedLanguage ? `language-${normalizedLanguage}` : ''}`}>
               {codeText}
             </code>
-          </div>
-        </pre>
+          </pre>
+        </div>
       </div>
     </div>
   );

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -69,6 +69,9 @@ const CodeBlock: React.FC<{
     return String(children).replace(/\n$/, '');
   }, [children]);
 
+  const codeLines = useMemo(() => codeText.split('\n'), [codeText]);
+  const showLineNumbers = codeLines.length > 3;
+
   useEffect(() => {
     if (codeRef.current) {
       try {
@@ -180,9 +183,20 @@ const CodeBlock: React.FC<{
               : 'bg-light-bg dark:bg-[#0d1117]'
       }`}>
         <pre className={`p-4 overflow-x-auto ${className || ''}`}>
-          <code ref={codeRef} className={`text-sm font-mono leading-6 text-gray-800 dark:text-[#e6edf3] ${normalizedLanguage ? `language-${normalizedLanguage}` : ''}`}>
-            {codeText}
-          </code>
+          <div className={showLineNumbers ? 'flex items-start' : undefined}>
+            {showLineNumbers && (
+              <div className="select-none pr-4 text-right flex-shrink-0" aria-hidden="true">
+                {codeLines.map((_, index) => (
+                  <span key={index} className="block text-gray-400 text-sm font-mono leading-6">
+                    {index + 1}
+                  </span>
+                ))}
+              </div>
+            )}
+            <code ref={codeRef} className={`text-sm font-mono leading-6 text-gray-800 dark:text-[#e6edf3] ${showLineNumbers ? 'block min-w-0 flex-1' : ''} ${normalizedLanguage ? `language-${normalizedLanguage}` : ''}`}>
+              {codeText}
+            </code>
+          </div>
         </pre>
       </div>
     </div>

--- a/src/components/ReadmeModal.test.tsx
+++ b/src/components/ReadmeModal.test.tsx
@@ -95,4 +95,15 @@ describe('ReadmeModal multilingual README switching', () => {
     });
     expect(screen.queryByLabelText('切换 README 语言')).not.toBeInTheDocument();
   });
+
+  it('shows backend README errors instead of treating them as missing README', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    (backend.getRepositoryReadme as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('GitHub token not configured'));
+
+    render(<ReadmeModal isOpen onClose={vi.fn()} repository={mockRepository} />);
+
+    expect(await screen.findByText('GitHub token not configured')).toBeInTheDocument();
+    expect(screen.queryByText('该仓库没有 README 文件')).not.toBeInTheDocument();
+    consoleErrorSpy.mockRestore();
+  });
 });

--- a/src/components/ReadmeModal.test.tsx
+++ b/src/components/ReadmeModal.test.tsx
@@ -98,12 +98,15 @@ describe('ReadmeModal multilingual README switching', () => {
 
   it('shows backend README errors instead of treating them as missing README', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
-    (backend.getRepositoryReadme as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('GitHub token not configured'));
+    try {
+      (backend.getRepositoryReadme as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('GitHub token not configured'));
 
-    render(<ReadmeModal isOpen onClose={vi.fn()} repository={mockRepository} />);
+      render(<ReadmeModal isOpen onClose={vi.fn()} repository={mockRepository} />);
 
-    expect(await screen.findByText('GitHub token not configured')).toBeInTheDocument();
-    expect(screen.queryByText('该仓库没有 README 文件')).not.toBeInTheDocument();
-    consoleErrorSpy.mockRestore();
+      expect(await screen.findByText('GitHub token not configured')).toBeInTheDocument();
+      expect(screen.queryByText('该仓库没有 README 文件')).not.toBeInTheDocument();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 });

--- a/src/components/ReadmeModal.tsx
+++ b/src/components/ReadmeModal.tsx
@@ -365,9 +365,10 @@ export const ReadmeModal: React.FC<ReadmeModalProps> = ({
       if (abortController.signal.aborted) return;
       console.error('Failed to fetch README:', err);
       setReadmeContent('');
-      setError(variant.isDefault
+      const fallbackMessage = variant.isDefault
         ? (language === 'zh' ? '加载 README 失败，请检查网络连接或稍后重试' : 'Failed to load README. Please check your network connection and try again later')
-        : (language === 'zh' ? '加载所选 README 失败，请稍后重试' : 'Failed to load selected README. Please try again later'));
+        : (language === 'zh' ? '加载所选 README 失败，请稍后重试' : 'Failed to load selected README. Please try again later');
+      setError(err instanceof Error && err.message ? err.message : fallbackMessage);
     } finally {
       if (!abortController.signal.aborted) {
         setLoading(false);

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -419,7 +419,7 @@ export const ReleaseTimeline: React.FC = () => {
       markAllReleasesAsRead();
       await backend.markAllReleasesAsRead();
       toast(t('已全部标记为已读', 'All marked as read'), 'success');
-    } catch (error) {
+    } catch {
       toast(t('标记全部已读失败', 'Failed to mark all as read'), 'error');
     } finally {
       setIsMarkingAllRead(false);

--- a/src/components/RepositoryEditModal.tsx
+++ b/src/components/RepositoryEditModal.tsx
@@ -54,7 +54,7 @@ export const RepositoryEditModal: React.FC<RepositoryEditModalProps> = ({
   onClose,
   repository
 }) => {
-  const { updateRepository, language, customCategories, hiddenDefaultCategoryIds, defaultCategoryOverrides, theme } = useAppStore();
+  const { updateRepository, language, customCategories, hiddenDefaultCategoryIds, defaultCategoryOverrides } = useAppStore();
 
   const [formData, setFormData] = useState({
     description: '',

--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -10,7 +10,7 @@ import { useAppStore, getAllCategories } from '../store/useAppStore';
 import { GitHubApiService } from '../services/githubApi';
 import { AIService } from '../services/aiService';
 import { AIAnalysisOptimizer, AnalysisResult } from '../services/aiAnalysisOptimizer';
-import { resolveCategoryAssignment, getAICategory, getDefaultCategory, computeCustomCategory } from '../utils/categoryUtils';
+import { resolveCategoryAssignment, getAICategory, getDefaultCategory, computeCustomCategory, matchesCategory } from '../utils/categoryUtils';
 import { forceSyncToBackend } from '../services/autoSync';
 import { useDialog } from '../hooks/useDialog';
 
@@ -75,41 +75,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
     
     const selectedCategoryObj = allCategories.find(cat => cat.id === selectedCategory);
     if (!selectedCategoryObj) return [];
-    const selectedCategoryKeywords = selectedCategoryObj.keywords.map(keyword => keyword.toLowerCase());
-
-    return repositories.filter(repo => {
-      if (repo.custom_category !== undefined) {
-        if (repo.custom_category === '') {
-          return false;
-        }
-        return repo.custom_category === selectedCategoryObj.name;
-      }
-      
-      // 如果没有自定义分类，使用AI标签和关键词匹配
-      // 优先使用AI标签进行匹配
-      if (repo.ai_tags && repo.ai_tags.length > 0) {
-        return repo.ai_tags.some(tag => {
-          const tagLower = tag.toLowerCase();
-          return selectedCategoryKeywords.some(keyword =>
-            tagLower.includes(keyword) ||
-            keyword.includes(tagLower)
-          )
-        });
-      }
-      
-      // 如果没有AI标签，使用传统方式匹配
-      const repoText = [
-        repo.name,
-        repo.description || '',
-        repo.language || '',
-        ...(repo.topics || []),
-        repo.ai_summary || ''
-      ].join(' ').toLowerCase();
-      
-      return selectedCategoryKeywords.some(keyword =>
-        repoText.includes(keyword)
-      );
-    });
+    return repositories.filter(repo => matchesCategory(repo, selectedCategoryObj));
   }, [repositories, selectedCategory, allCategories]);
 
   // 根据当前筛选的仓库中是否有AI分析内容来动态设置默认显示模式

--- a/src/components/settings/DataManagementPanel.tsx
+++ b/src/components/settings/DataManagementPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo, useEffect } from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import {
   Trash2,
   AlertTriangle,
@@ -24,9 +24,7 @@ import {
 } from 'lucide-react';
 import { useAppStore } from '../../store/useAppStore';
 import { indexedDBStorage } from '../../services/indexedDbStorage';
-import { backend } from '../../services/backendAdapter';
 import { IncludeKeysToggle } from './IncludeKeysToggle';
-import { version as appVersion } from '../../../package.json';
 import type { 
   Repository, 
   Release, 
@@ -187,8 +185,6 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
     };
     setOperationLogs((prev) => [newLog, ...prev].slice(0, 50));
   }, []);
-
-  const backendAvailable = backend.isAvailable;
 
   const showSuccess = useCallback((message: string) => {
     setShowSuccessMessage(message);
@@ -355,7 +351,7 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
     }
   };
 
-  const deleteDiscoveryData = async () => {
+  const deleteDiscoveryData = useCallback(async () => {
     try {
       const emptyDiscoveryRepos = {
         'trending': [],
@@ -364,7 +360,7 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
         'topic': [],
         'search': []
       } as Record<string, DiscoveryRepo[]>;
-      useAppStore.setState({ 
+      useAppStore.setState({
         discoveryRepos: emptyDiscoveryRepos,
         discoveryLastRefresh: {
           'trending': null,
@@ -385,7 +381,7 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
       showError(t('删除失败，请重试', 'Delete failed, please try again'));
       throw error;
     }
-  };
+  }, [addLog, showSuccess, showError, t]);
 
   const deleteSubscriptionData = async () => {
     try {

--- a/src/services/aiAnalysisHelper.ts
+++ b/src/services/aiAnalysisHelper.ts
@@ -36,9 +36,14 @@ export const analyzeRepository = async (options: AnalyzeRepositoryOptions): Prom
   const [owner, name] = repository.full_name.split('/');
   
   onProgress?.('Fetching README...');
-  const readmeContent = backend.isAvailable
-    ? await backend.getRepositoryReadme(owner, name)
-    : await githubApi.getRepositoryReadme(owner, name, signal);
+  let readmeContent = '';
+  try {
+    readmeContent = backend.isAvailable
+      ? await backend.getRepositoryReadme(owner, name)
+      : await githubApi.getRepositoryReadme(owner, name, signal);
+  } catch (error) {
+    console.warn(`Failed to fetch README for ${repository.full_name}, continuing with metadata only:`, error);
+  }
 
   const categoryNames = categories
     .filter(cat => cat.id !== 'all')

--- a/src/services/aiAnalysisHelper.ts
+++ b/src/services/aiAnalysisHelper.ts
@@ -39,9 +39,12 @@ export const analyzeRepository = async (options: AnalyzeRepositoryOptions): Prom
   let readmeContent = '';
   try {
     readmeContent = backend.isAvailable
-      ? await backend.getRepositoryReadme(owner, name)
+      ? await backend.getRepositoryReadme(owner, name, signal)
       : await githubApi.getRepositoryReadme(owner, name, signal);
   } catch (error) {
+    if (signal?.aborted || (error as { name?: string })?.name === 'AbortError') {
+      throw error;
+    }
     console.warn(`Failed to fetch README for ${repository.full_name}, continuing with metadata only:`, error);
   }
 

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -995,7 +995,7 @@ ${repoInfo}
         const searchTerms = this.parseSearchResponse(content);
         return this.performEnhancedSearch(repositories, query, searchTerms);
       }
-    } catch (error) {
+    } catch {
       logger.warn('ai', 'AI search failed, falling back to basic search', { configId: this.config.id, durationMs: Date.now() - startTime });
     }
 

--- a/src/services/backendAdapter.ts
+++ b/src/services/backendAdapter.ts
@@ -198,7 +198,7 @@ class BackendAdapter {
         await new Promise(resolve => setTimeout(resolve, delay));
       }
     }
-    throw lastError!; // eslint-disable-line @typescript-eslint/no-unnecessary-type-assertion -- TypeScript control flow can't prove this is unreachable
+    throw lastError!;
   }
   private async throwTranslatedError(res: Response, fallbackPrefix: string): Promise<never> {
     let code: string | undefined;
@@ -271,19 +271,16 @@ class BackendAdapter {
   async getRepositoryReadme(owner: string, repo: string, signal?: AbortSignal): Promise<string> {
     if (!this._backendUrl) throw new Error('Backend not available');
 
-    try {
-      const res = await this.fetchWithTimeout(`${this._backendUrl}/proxy/github/repos/${owner}/${repo}/readme`, {
-        method: 'POST',
-        headers: this.getAuthHeaders(),
-        body: JSON.stringify({ method: 'GET' }),
-        signal,
-      });
-      if (!res.ok) return '';
-      const data = await res.json() as GitHubContentResponse;
-      return this.decodeContentResponse(data);
-    } catch {
-      return '';
-    }
+    const res = await this.fetchWithTimeout(`${this._backendUrl}/proxy/github/repos/${owner}/${repo}/readme`, {
+      method: 'POST',
+      headers: this.getAuthHeaders(),
+      body: JSON.stringify({ method: 'GET' }),
+      signal,
+    });
+    if (res.status === 404) return '';
+    if (!res.ok) await this.throwTranslatedError(res, 'Backend proxy error');
+    const data = await res.json() as GitHubContentResponse;
+    return this.decodeContentResponse(data);
   }
 
   async listRepositoryReadmeCandidates(owner: string, repo: string, defaultBranch?: string, signal?: AbortSignal): Promise<GitHubReadmeCandidateItem[]> {
@@ -354,19 +351,16 @@ class BackendAdapter {
   async getRepositoryReadmeByPath(owner: string, repo: string, path: string, signal?: AbortSignal): Promise<string> {
     if (!this._backendUrl) throw new Error('Backend not available');
 
-    try {
-      const res = await this.fetchWithTimeout(`${this._backendUrl}/proxy/github/repos/${owner}/${repo}/contents/${this.encodeContentPath(path)}`, {
-        method: 'POST',
-        headers: this.getAuthHeaders(),
-        body: JSON.stringify({ method: 'GET' }),
-        signal,
-      });
-      if (!res.ok) return '';
-      const data = await res.json() as GitHubContentResponse;
-      return this.decodeContentResponse(data);
-    } catch {
-      return '';
-    }
+    const res = await this.fetchWithTimeout(`${this._backendUrl}/proxy/github/repos/${owner}/${repo}/contents/${this.encodeContentPath(path)}`, {
+      method: 'POST',
+      headers: this.getAuthHeaders(),
+      body: JSON.stringify({ method: 'GET' }),
+      signal,
+    });
+    if (res.status === 404) return '';
+    if (!res.ok) await this.throwTranslatedError(res, 'Backend proxy error');
+    const data = await res.json() as GitHubContentResponse;
+    return this.decodeContentResponse(data);
   }
 
   async getRepositoryReleases(owner: string, repo: string, page = 1, perPage = 30): Promise<Record<string, unknown>[]> {

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -643,15 +643,15 @@ export class GitHubApiService {
         description = description.replace(/\s+/g, ' ').trim();
 
         // 解析 link 获取 owner/repo 格式
-        const match = link.match(/github\.com\/([^\/]+)\/([^\/\?#]+)/);
+        const match = link.match(/github\.com\/([^/]+)\/([^/?#]+)/);
         const owner = match?.[1] || '';
         const repoName = match?.[2] || title;
 
         // 从 description 中提取 stars 和 forks（格式如 "⭐ 1,234 | 🍴 456"）
         const starsMatch = description.match(/⭐\s*([\d,]+)/);
         const forksMatch = description.match(/🍴\s*([\d,]+)/);
-        let stars = starsMatch ? parseInt(starsMatch[1].replace(/,/g, '')) : 0;
-        let forks = forksMatch ? parseInt(forksMatch[1].replace(/,/g, '')) : 0;
+        const stars = starsMatch ? parseInt(starsMatch[1].replace(/,/g, '')) : 0;
+        const forks = forksMatch ? parseInt(forksMatch[1].replace(/,/g, '')) : 0;
 
         repos.push({
           id: i + 1,
@@ -730,7 +730,8 @@ export class GitHubApiService {
       };
       try {
         userDetail = await this.makeRequest<GitHubUserDetail>(`/users/${searchUser.login}`);
-      } catch {
+      } catch (error) {
+        logger.warn('githubApi', `Failed to fetch user details for ${searchUser.login}`, error);
       }
 
       let topRepo: SubscriptionRepo | null = null;
@@ -745,7 +746,8 @@ export class GitHubApiService {
             channel: 'most-dev' as const,
           };
         }
-      } catch {
+      } catch (error) {
+        logger.warn('githubApi', `Failed to fetch top repo for ${searchUser.login}`, error);
       }
       devs.push({
         rank: i + 1,
@@ -849,7 +851,7 @@ export class GitHubApiService {
         description = description.replace(/\s+/g, ' ').trim();
 
         // Parse link to get owner/repo
-        const match = link.match(/github\.com\/([^\/]+)\/([^\/\?#]+)/);
+        const match = link.match(/github\.com\/([^/]+)\/([^/?#]+)/);
         const owner = match?.[1] || '';
         const repoName = match?.[2] || title;
 

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -57,7 +57,7 @@ const cancelIdleTask = (id: number): void => {
 let persistTimeoutId: ReturnType<typeof setTimeout> | null = null;
 let persistIdleTaskId: number | null = null;
 let latestPersistName: string | null = null;
-let latestPersistValue: StorageValue<any> | null = null;
+let latestPersistValue: StorageValue<unknown> | null = null;
 let persistWriteVersion = 0;
 let persistFlushListenersRegistered = false;
 
@@ -75,7 +75,7 @@ const cancelPendingPersistTasks = (): void => {
 
 const writePersistSnapshot = (
   name: string,
-  value: StorageValue<any>,
+  value: StorageValue<unknown>,
   version: number,
   source: 'idle' | 'flush'
 ): void => {
@@ -144,7 +144,7 @@ const registerPersistFlushListeners = (): void => {
 
 // Create a debounced storage to avoid frequent JSON.stringify calls on large state objects
 // which causes V8 JIT assertion failures (EXC_BREAKPOINT) on macOS ARM64.
-const debouncedPersistStorage: PersistStorage<any> = {
+const debouncedPersistStorage: PersistStorage<unknown> = {
   getItem: async (name) => {
     const str = await indexedDBStorage.getItem(name);
     if (!str) return null;
@@ -154,7 +154,7 @@ const debouncedPersistStorage: PersistStorage<any> = {
       return null;
     }
   },
-  setItem: (name: string, value: StorageValue<any>) => {
+  setItem: (name: string, value: StorageValue<unknown>) => {
     registerPersistFlushListeners();
     latestPersistName = name;
     latestPersistValue = value;

--- a/src/utils/categoryUtils.test.ts
+++ b/src/utils/categoryUtils.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import type { Category, Repository } from '../types';
+import { matchesCategory } from './categoryUtils';
+
+const aiCategory: Category = {
+  id: 'ai',
+  name: 'AI/机器学习',
+  icon: 'bot',
+  keywords: ['AI', '机器学习'],
+};
+
+const webCategory: Category = {
+  id: 'web',
+  name: 'Web应用',
+  icon: 'globe',
+  keywords: ['Web'],
+};
+
+const baseRepository: Repository = {
+  id: 1,
+  name: 'demo',
+  full_name: 'owner/demo',
+  description: null,
+  html_url: 'https://github.com/owner/demo',
+  stargazers_count: 1,
+  forks_count: 0,
+  forks: 0,
+  language: null,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  pushed_at: '2026-01-01T00:00:00Z',
+  owner: {
+    login: 'owner',
+    avatar_url: 'https://example.com/avatar.png',
+  },
+  topics: [],
+  ai_tags: ['AI/机器学习'],
+};
+
+describe('matchesCategory', () => {
+  it('uses AI tags when custom_category is undefined', () => {
+    expect(matchesCategory(baseRepository, aiCategory)).toBe(true);
+  });
+
+  it('uses AI tags when legacy backend data has custom_category null', () => {
+    const legacyRepository = {
+      ...baseRepository,
+      custom_category: null,
+    } as unknown as Repository;
+
+    expect(matchesCategory(legacyRepository, aiCategory)).toBe(true);
+  });
+
+  it('does not match any category when custom_category is explicitly empty', () => {
+    const repository = {
+      ...baseRepository,
+      custom_category: '',
+    };
+
+    expect(matchesCategory(repository, aiCategory)).toBe(false);
+  });
+
+  it('honors non-empty custom_category over AI tags', () => {
+    const repository = {
+      ...baseRepository,
+      custom_category: 'Web应用',
+    };
+
+    expect(matchesCategory(repository, aiCategory)).toBe(false);
+    expect(matchesCategory(repository, webCategory)).toBe(true);
+  });
+});

--- a/src/utils/categoryUtils.ts
+++ b/src/utils/categoryUtils.ts
@@ -83,7 +83,7 @@ export const computeCustomCategory = (
 export const matchesCategory = (repo: Repository, category: Category): boolean => {
   if (category.id === 'all') return true;
 
-  if (repo.custom_category !== undefined) {
+  if (repo.custom_category != null) {
     if (repo.custom_category === '') {
       return false;
     }

--- a/src/utils/clipboardUtils.ts
+++ b/src/utils/clipboardUtils.ts
@@ -107,7 +107,7 @@ export const safeWriteText = async (text: string): Promise<{ success: boolean; e
   try {
     await navigator.clipboard.writeText(text);
     return { success: true };
-  } catch (err) {
+  } catch {
     return {
       success: false,
       error: getClipboardErrorMessage('write'),
@@ -132,7 +132,7 @@ export const safeReadText = async (): Promise<{ success: boolean; text?: string;
   try {
     const text = await navigator.clipboard.readText();
     return { success: true, text };
-  } catch (err) {
+  } catch {
     return {
       success: false,
       error: getClipboardErrorMessage('read'),


### PR DESCRIPTION
## Summary
- Fix category counts resetting to zero after backend sync by normalizing nullable custom categories and reusing shared category matching.
- Persist GitHub token to backend settings after login so Docker/web GitHub proxy requests can load README content.
- Surface backend README proxy errors instead of misreporting them as missing README files.
- Restore code block line-number rendering and clean existing lint errors.

Fixes #200

## Testing
- npm run lint
- npm run test:run
- npm run build

## Notes
- `npm run lint` still reports existing warnings only; no lint errors remain.
- `npm run test:run` passes all 68 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Code blocks show line numbers for blocks >3 lines.
  * GitHub tokens are persisted to the backend when available.

* **Bug Fixes**
  * Prevented client Authorization header from being forwarded in WebDAV proxy requests.
  * README fetch errors now surface clearer error text.

* **Improvements**
  * Repository analysis continues when README fetch fails (metadata-only fallback).
  * Improved handling of custom category values and category-matching behavior.

* **Tests**
  * Added tests for category-matching logic and WebDAV proxy header stripping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->