### PR TITLE
feat: add 'Latest Only' dropdown to release timeline

### DIFF
--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -56,6 +56,8 @@ export const ReleaseTimeline: React.FC = () => {
     setIncludePreRelease,
     releaseShowMode,
     setReleaseShowMode,
+    releaseLatestMode,
+    setReleaseLatestMode,
   } = useAppStore();
 
   const { toast, confirm } = useDialog();
@@ -70,6 +72,7 @@ export const ReleaseTimeline: React.FC = () => {
   // 视图切换下拉菜单状态（本地UI状态）
   const [isViewDropdownOpen, setIsViewDropdownOpen] = useState(false);
   const [isShowModeDropdownOpen, setIsShowModeDropdownOpen] = useState(false);
+  const [isLatestModeDropdownOpen, setIsLatestModeDropdownOpen] = useState(false);
   const [isReleaseSourceSettingsOpen, setIsReleaseSourceSettingsOpen] = useState(false);
   const [isMarkingAllRead, setIsMarkingAllRead] = useState(false);
 
@@ -233,7 +236,7 @@ export const ReleaseTimeline: React.FC = () => {
     });
     unreadSnapshotRef.current = ids;
     setSnapshotVersion(v => v + 1);
-  }, [releases, resolvedReleaseSources, includePreRelease, releaseShowMode]);
+  }, [releases, resolvedReleaseSources, includePreRelease, releaseShowMode, releaseLatestMode]);
 
   // 预计算每个 release 的下载链接和过滤后的链接
   const releasesWithLinks = useMemo(() => {
@@ -282,15 +285,30 @@ export const ReleaseTimeline: React.FC = () => {
       }));
   }, [releasesWithLinks, searchQuery, selectedFilters]);
 
+  // 仅最新模式过滤：每个仓库只保留最新的 release
+  const latestModeReleases = useMemo(() => {
+    if (releaseLatestMode !== 'latest') return preUnreadFilteredReleases;
+
+    const repoMap = new Map<number, typeof preUnreadFilteredReleases[0]>();
+    for (const item of preUnreadFilteredReleases) {
+      const repoId = item.release.repository.id;
+      const existing = repoMap.get(repoId);
+      if (!existing || new Date(item.release.published_at) > new Date(existing.release.published_at)) {
+        repoMap.set(repoId, item);
+      }
+    }
+    return Array.from(repoMap.values());
+  }, [preUnreadFilteredReleases, releaseLatestMode]);
+
   // 未读模式过滤（使用快照，标记已读后不会立即消失，刷新页面后才更新）
   const filteredReleases = useMemo(() => {
     if (releaseShowMode === 'unread') {
-      return preUnreadFilteredReleases.filter(({ release }) => unreadSnapshotRef.current.has(release.id));
+      return latestModeReleases.filter(({ release }) => unreadSnapshotRef.current.has(release.id));
     }
-    return preUnreadFilteredReleases;
+    return latestModeReleases;
     // snapshotVersion 触发快照更新后重算；readReleases 不在此处以避免标记已读立即消失
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [preUnreadFilteredReleases, releaseShowMode, snapshotVersion]);
+  }, [latestModeReleases, releaseShowMode, snapshotVersion]);
 
   const unreadCount = useMemo(() => {
     return subscribedReleases.filter(r => !readReleases.has(r.id)).length;
@@ -457,6 +475,12 @@ export const ReleaseTimeline: React.FC = () => {
     setReleaseShowMode(mode);
     setCurrentPage(1);
     setIsShowModeDropdownOpen(false);
+  };
+
+  const handleLatestModeChange = (mode: 'all' | 'latest') => {
+    setReleaseLatestMode(mode);
+    setCurrentPage(1);
+    setIsLatestModeDropdownOpen(false);
   };
 
   const handleMarkAllRead = async () => {
@@ -879,6 +903,7 @@ export const ReleaseTimeline: React.FC = () => {
                 onClick={() => {
                   setIsViewDropdownOpen(!isViewDropdownOpen);
                   setIsShowModeDropdownOpen(false);
+                  setIsLatestModeDropdownOpen(false);
                 }}
                 className="flex items-center space-x-2 px-3 py-2 bg-light-surface dark:bg-white/[0.04] rounded-lg hover:bg-gray-200 dark:hover:bg-white/10 transition-all"
                 title={viewMode === 'timeline' ? t('按日期排序视图', 'Timeline View') : t('仓库分类视图', 'Repository View')}
@@ -976,6 +1001,11 @@ export const ReleaseTimeline: React.FC = () => {
                 ({t('已筛选', 'filtered')})
               </span>
             )}
+            {releaseLatestMode === 'latest' && (
+              <span className="text-sm text-brand-violet dark:text-brand-violet">
+                ({t('仅最新', 'latest only')})
+              </span>
+            )}
           </div>
 
           <div className="flex flex-wrap items-center gap-3">
@@ -985,6 +1015,7 @@ export const ReleaseTimeline: React.FC = () => {
                 onClick={() => {
                   setIsShowModeDropdownOpen(!isShowModeDropdownOpen);
                   setIsViewDropdownOpen(false);
+                  setIsLatestModeDropdownOpen(false);
                 }}
                 className="flex items-center space-x-2 px-3 py-2 bg-light-surface dark:bg-white/[0.04] rounded-lg hover:bg-gray-200 dark:hover:bg-white/10 transition-all"
                 title={releaseShowMode === 'all' ? t('显示全部', 'Show All') : t('仅显示未读', 'Show Unread Only')}
@@ -1022,6 +1053,57 @@ export const ReleaseTimeline: React.FC = () => {
                       <div>
                         <div className="text-sm font-medium">{t('仅显示未读', 'Unread Only')}</div>
                         <div className="text-xs text-gray-500 dark:text-text-tertiary">{t('只显示未读的Release', 'Only show unread releases')}</div>
+                      </div>
+                    </button>
+                  </div>
+                </>
+              )}
+            </div>
+
+            {/* Latest Mode Dropdown */}
+            <div className="relative">
+              <button
+                onClick={() => {
+                  setIsLatestModeDropdownOpen(!isLatestModeDropdownOpen);
+                  setIsViewDropdownOpen(false);
+                  setIsShowModeDropdownOpen(false);
+                }}
+                className="flex items-center space-x-2 px-3 py-2 bg-light-surface dark:bg-white/[0.04] rounded-lg hover:bg-gray-200 dark:hover:bg-white/10 transition-all"
+                title={releaseLatestMode === 'all' ? t('显示全部', 'Show All') : t('仅显示最新', 'Latest Only')}
+              >
+                <Package className="w-4 h-4 text-gray-700 dark:text-text-tertiary" />
+                <span className="text-sm font-medium text-gray-900 dark:text-text-secondary">
+                  {releaseLatestMode === 'all' ? t('全部版本', 'All Versions') : t('仅最新', 'Latest')}
+                </span>
+                <ChevronDown className={`w-4 h-4 text-gray-500 dark:text-text-tertiary transition-transform ${isLatestModeDropdownOpen ? 'rotate-180' : ''}`} />
+              </button>
+
+              {isLatestModeDropdownOpen && (
+                <>
+                  <div className="fixed inset-0 z-40" onClick={() => setIsLatestModeDropdownOpen(false)} />
+                  <div className="absolute left-0 mt-2 w-48 bg-white dark:bg-panel-dark rounded-lg shadow-lg border border-black/[0.06] dark:border-white/[0.04] z-50 py-1">
+                    <button
+                      onClick={() => handleLatestModeChange('all')}
+                      className={`w-full flex items-center space-x-3 px-4 py-2.5 text-left hover:bg-light-surface dark:hover:bg-white/10 transition-colors ${
+                        releaseLatestMode === 'all' ? 'bg-gray-100 dark:bg-white/[0.08] text-gray-900 dark:text-text-primary font-medium' : 'text-gray-700 dark:text-text-secondary'
+                      }`}
+                    >
+                      <Package className={`w-4 h-4 ${releaseLatestMode === 'all' ? 'text-gray-900 dark:text-text-primary' : 'text-gray-500 dark:text-text-tertiary'}`} />
+                      <div>
+                        <div className="text-sm font-medium">{t('显示全部版本', 'Show All Versions')}</div>
+                        <div className="text-xs text-gray-500 dark:text-text-tertiary">{t('显示所有Release记录', 'Show all release records')}</div>
+                      </div>
+                    </button>
+                    <button
+                      onClick={() => handleLatestModeChange('latest')}
+                      className={`w-full flex items-center space-x-3 px-4 py-2.5 text-left hover:bg-light-surface dark:hover:bg-white/10 transition-colors ${
+                        releaseLatestMode === 'latest' ? 'bg-gray-100 dark:bg-white/[0.08] text-gray-900 dark:text-text-primary font-medium' : 'text-gray-700 dark:text-text-secondary'
+                      }`}
+                    >
+                      <Package className={`w-4 h-4 ${releaseLatestMode === 'latest' ? 'text-gray-900 dark:text-text-primary' : 'text-gray-500 dark:text-text-tertiary'}`} />
+                      <div>
+                        <div className="text-sm font-medium">{t('仅显示最新版本', 'Latest Version Only')}</div>
+                        <div className="text-xs text-gray-500 dark:text-text-tertiary">{t('每个仓库仅显示最新Release', 'Show only the latest release per repo')}</div>
                       </div>
                     </button>
                   </div>

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -293,7 +293,7 @@ export const ReleaseTimeline: React.FC = () => {
     for (const item of preUnreadFilteredReleases) {
       const repoId = item.release.repository.id;
       const existing = repoMap.get(repoId);
-      if (!existing || new Date(item.release.published_at) > new Date(existing.release.published_at)) {
+      if (!existing || item.release.published_at > existing.release.published_at) {
         repoMap.set(repoId, item);
       }
     }

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -346,6 +346,7 @@ interface AppActions {
   // Release Timeline View actions
   setReleaseViewMode: (mode: 'timeline' | 'repository') => void;
   setReleaseShowMode: (mode: 'all' | 'unread') => void;
+  setReleaseLatestMode: (mode: 'all' | 'latest') => void;
   setReleaseSelectedFilters: (filters: string[]) => void;
   toggleReleaseSelectedFilter: (filterId: string) => void;
   clearReleaseSelectedFilters: () => void;
@@ -439,6 +440,7 @@ type PersistedAppState = Partial<
     | 'forkExpandedRepositories'
     | 'releaseViewMode'
     | 'releaseShowMode'
+    | 'releaseLatestMode'
     | 'releaseSelectedFilters'
     | 'releaseSearchQuery'
     | 'includePreRelease'
@@ -562,6 +564,7 @@ const normalizePersistedState = (
     isAuthenticated: !!(safePersisted.user && safePersisted.githubToken),
     releaseViewMode: safePersisted.releaseViewMode || 'timeline',
     releaseShowMode: safePersisted.releaseShowMode === 'unread' ? 'unread' : 'all',
+    releaseLatestMode: safePersisted.releaseLatestMode === 'latest' ? 'latest' : 'all',
     releaseSelectedFilters: Array.isArray(safePersisted.releaseSelectedFilters) ? safePersisted.releaseSelectedFilters : [],
     releaseSearchQuery: typeof safePersisted.releaseSearchQuery === 'string' ? safePersisted.releaseSearchQuery : '',
     discoveryChannels: (() => {
@@ -1270,6 +1273,22 @@ export const useAppStore = create<AppState & AppActions>()(
       markReleaseAsRead: (releaseId) => set((state) => {
         const newReadReleases = new Set(state.readReleases);
         newReadReleases.add(releaseId);
+
+        // In 'latest' mode, marking the latest release as read also marks all other releases of that repo
+        if (state.releaseLatestMode === 'latest') {
+          const markedRelease = state.releases.find(r => r.id === releaseId);
+          if (markedRelease) {
+            const repoId = markedRelease.repository.id;
+            const repoReleases = state.releases.filter(r => r.repository.id === repoId);
+            const latestRepoRelease = repoReleases.reduce((latest, r) =>
+              new Date(r.published_at) > new Date(latest.published_at) ? r : latest
+            , repoReleases[0]);
+            if (latestRepoRelease && latestRepoRelease.id === releaseId) {
+              repoReleases.forEach(r => newReadReleases.add(r.id));
+            }
+          }
+        }
+
         return { readReleases: newReadReleases };
       }),
       markAllReleasesAsRead: () => set((state) => {
@@ -1569,6 +1588,7 @@ export const useAppStore = create<AppState & AppActions>()(
       // Release Timeline View actions
       setReleaseViewMode: (releaseViewMode) => set({ releaseViewMode }),
       setReleaseShowMode: (releaseShowMode) => set({ releaseShowMode }),
+      setReleaseLatestMode: (releaseLatestMode) => set({ releaseLatestMode }),
       setReleaseSelectedFilters: (releaseSelectedFilters) => set({ releaseSelectedFilters }),
       toggleReleaseSelectedFilter: (filterId) => set((state) => ({
         releaseSelectedFilters: state.releaseSelectedFilters.includes(filterId)

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -938,6 +938,7 @@ export const useAppStore = create<AppState & AppActions>()(
       readmeModalOpen: false,
       releaseViewMode: 'timeline',
       releaseShowMode: 'all',
+      releaseLatestMode: 'all',
       releaseSelectedFilters: [],
       releaseSearchQuery: '',
       releaseExpandedRepositories: new Set<number>(),
@@ -1281,7 +1282,7 @@ export const useAppStore = create<AppState & AppActions>()(
             const repoId = markedRelease.repository.id;
             const repoReleases = state.releases.filter(r => r.repository.id === repoId);
             const latestRepoRelease = repoReleases.reduce((latest, r) =>
-              new Date(r.published_at) > new Date(latest.published_at) ? r : latest
+              r.published_at > latest.published_at ? r : latest
             , repoReleases[0]);
             if (latestRepoRelease && latestRepoRelease.id === releaseId) {
               repoReleases.forEach(r => newReadReleases.add(r.id));
@@ -1801,6 +1802,7 @@ export const useAppStore = create<AppState & AppActions>()(
         // 持久化Release页面视图设置
         releaseViewMode: state.releaseViewMode,
         releaseShowMode: state.releaseShowMode,
+        releaseLatestMode: state.releaseLatestMode,
         releaseSelectedFilters: state.releaseSelectedFilters,
         releaseSearchQuery: state.releaseSearchQuery,
         releaseExpandedRepositories: Array.from(state.releaseExpandedRepositories),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -325,6 +325,7 @@ export interface AppState {
   // Release Timeline View
   releaseViewMode: 'timeline' | 'repository';
   releaseShowMode: 'all' | 'unread';
+  releaseLatestMode: 'all' | 'latest';
   releaseSelectedFilters: string[];
   releaseSearchQuery: string;
   releaseExpandedRepositories: Set<number>;


### PR DESCRIPTION
## Summary

Add a new dropdown next to existing filters on the Release Timeline page that allows showing only the latest release per repository.

## Changes

### New Feature: Latest Only Mode
- Added a new dropdown with two options: **Show All Versions** / **Latest Version Only**
- When "Latest Only" is selected, each repository shows only its most recent release
- The setting is persisted via IndexedDB (survives page refresh and app restart)

### Filter Compatibility
- Works together with existing asset type filters
- Works together with unread-only toggle
- All three filters (asset type, unread, latest) can be active simultaneously

### Smart Mark-as-Read
- When user marks the latest release of a repo as read in "Latest Only" mode, all other releases of that repo are automatically marked as read
- This provides a natural workflow: see only latest → mark as read → repo disappears from list

### UI
- New dropdown follows the same visual pattern as existing dropdowns (Show Mode, View Mode)
- Added "(latest only)" indicator in results info when mode is active
- Dropdowns have mutual exclusion (opening one closes others)

## Files Changed
-  — Added  to AppState
-  — State, action, persistence, cascade logic
-  — UI and filtering logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced "Latest Mode" filter to show all releases or only the latest release per repository.
  * Added a Latest Mode dropdown and header indicator for quick toggling; preference is persisted.
  * When Latest Mode is active, marking a repository's latest release as read will mark that repository's releases as read.
* **Bug Fixes**
  * Improved filtering so Latest Mode works correctly with view and unread filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->