### PR TITLE
fix: data cleanup only removes orphaned read-release markers

### DIFF
--- a/src/components/settings/DataManagementPanel.tsx
+++ b/src/components/settings/DataManagementPanel.tsx
@@ -850,9 +850,12 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
     }
 
     const releaseIds = new Set(releases.map(r => r.id));
-    const staleReadReleases = Array.from(readReleases).filter(
-      id => !releaseIds.has(id)
-    ).length;
+    let staleReadReleases = 0;
+    for (const id of readReleases) {
+      if (!releaseIds.has(id)) {
+        staleReadReleases++;
+      }
+    }
     if (staleReadReleases > 0) {
       suggestions.push({
         key: 'readReleases',
@@ -880,9 +883,12 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
             new Date(r.published_at).getTime() >= ninetyDaysAgo
           );
           const remainingIds = new Set(filteredReleases.map(r => r.id));
-          const cleanedReadReleases = new Set(
-            Array.from(readReleases).filter(id => remainingIds.has(id))
-          );
+          const cleanedReadReleases = new Set<number>();
+          for (const id of readReleases) {
+            if (remainingIds.has(id)) {
+              cleanedReadReleases.add(id);
+            }
+          }
           useAppStore.setState({ releases: filteredReleases, readReleases: cleanedReadReleases });
           break;
         }
@@ -891,9 +897,12 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
           return;
         case 'readReleases': {
           const validReleaseIds = new Set(releases.map(r => r.id));
-          const cleanedReadReleases = new Set(
-            Array.from(readReleases).filter(id => validReleaseIds.has(id))
-          );
+          const cleanedReadReleases = new Set<number>();
+          for (const id of readReleases) {
+            if (validReleaseIds.has(id)) {
+              cleanedReadReleases.add(id);
+            }
+          }
           useAppStore.setState({ readReleases: cleanedReadReleases });
           break;
         }

--- a/src/components/settings/DataManagementPanel.tsx
+++ b/src/components/settings/DataManagementPanel.tsx
@@ -849,15 +849,18 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
       });
     }
 
-    const oldReadReleases = readReleases.size;
-    if (oldReadReleases > 50) {
+    const releaseIds = new Set(releases.map(r => r.id));
+    const staleReadReleases = Array.from(readReleases).filter(
+      id => !releaseIds.has(id)
+    ).length;
+    if (staleReadReleases > 0) {
       suggestions.push({
         key: 'readReleases',
         label: '已读Release标记',
         labelEn: 'Read Release Marks',
-        description: '已读Release的标记记录',
-        descriptionEn: 'Records of read releases',
-        count: oldReadReleases,
+        description: '已不存在的Release的已读标记，可安全清理',
+        descriptionEn: 'Read markers for releases that no longer exist, safe to clean',
+        count: staleReadReleases,
         icon: <Eye className="w-4 h-4" />,
         color: 'text-gray-700 dark:text-text-secondary',
         bgColor: 'bg-light-surface dark:bg-white/[0.04]'
@@ -873,18 +876,27 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
         case 'oldReleases': {
           const now = Date.now();
           const ninetyDaysAgo = now - 90 * 24 * 60 * 60 * 1000;
-          const filteredReleases = releases.filter(r => 
+          const filteredReleases = releases.filter(r =>
             new Date(r.published_at).getTime() >= ninetyDaysAgo
           );
-          setReleases(filteredReleases);
+          const remainingIds = new Set(filteredReleases.map(r => r.id));
+          const cleanedReadReleases = new Set(
+            Array.from(readReleases).filter(id => remainingIds.has(id))
+          );
+          useAppStore.setState({ releases: filteredReleases, readReleases: cleanedReadReleases });
           break;
         }
         case 'discoveryCache':
           await deleteDiscoveryData();
           return;
-        case 'readReleases':
-          useAppStore.setState({ readReleases: new Set<number>() });
+        case 'readReleases': {
+          const validReleaseIds = new Set(releases.map(r => r.id));
+          const cleanedReadReleases = new Set(
+            Array.from(readReleases).filter(id => validReleaseIds.has(id))
+          );
+          useAppStore.setState({ readReleases: cleanedReadReleases });
           break;
+        }
         case 'unanalyzedRepos':
           showSuccess(t('未分析仓库无法直接清理，请通过 AI 分析功能处理', 'Unanalyzed repos cannot be cleaned directly. Use AI analysis to process them.'));
           return;
@@ -895,7 +907,7 @@ export const DataManagementPanel: React.FC<DataManagementPanelProps> = ({ t }) =
       addLog(t('清理数据', 'Cleanup data'), false, String(error));
       showError(t('清理失败，请重试', 'Cleanup failed, please try again'));
     }
-  }, [releases, setReleases, deleteDiscoveryData, addLog, showSuccess, showError, t]);
+  }, [releases, readReleases, deleteDiscoveryData, addLog, showSuccess, showError, t]);
 
   const deleteAllData = async () => {
     try {


### PR DESCRIPTION
## Problem

In Settings → Data Management → Data Cleanup Suggestions, executing the "已读Release标记" (Read Release Marks) cleanup was resetting the entire `readReleases` Set to empty, causing **all releases to appear as unread** — even those the user had previously marked as read.

Additionally, the "过期Release记录" (Outdated Release Records) cleanup removed old releases from the array but did not clean up the corresponding `readReleases` entries, leaving orphaned IDs to accumulate.

## Root Cause

`DataManagementPanel.tsx` line 886:
```typescript
case 'readReleases':
  useAppStore.setState({ readReleases: new Set<number>() }); // ← destroys ALL read state
  break;
```

## Fix

1. **`readReleases` cleanup** — now filters `readReleases` to only keep IDs that still exist in `releases`, removing only orphaned entries
2. **`oldReleases` cleanup** — now also cleans up `readReleases` after removing old releases (same pattern as `removeReleasesByRepoId` in the store)
3. **Cleanup suggestion** — only appears when there are actual stale/orphaned markers (not just `size > 50`), with clarified description
4. **Performance** — stale count calculation uses a `Set` for O(N+M) lookup instead of O(N×M)

## Files Changed

- `src/components/settings/DataManagementPanel.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cleanup suggestions now accurately count and describe only stale read markers that no longer correspond to current releases.
  * Cleanup operations more safely remove old releases and prune obsolete read markers while preserving valid read markers tied to remaining releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->