### PR TITLE
feat: true incremental vector index with concurrent README fetching

### DIFF
--- a/cloudflare-worker/src/index.ts
+++ b/cloudflare-worker/src/index.ts
@@ -113,7 +113,7 @@ export default {
         for (let round = 0; round < 10; round++) {
           const result = await env.VECTORIZE.query(zeroVector, {
             topK: 100,
-            returnMetadata: false,
+            returnMetadata: 'none',
           });
           const staleIds = result.matches
             .filter((m) => !keepSet.has(m.id))

--- a/cloudflare-worker/worker.js
+++ b/cloudflare-worker/worker.js
@@ -96,7 +96,7 @@ export default {
         for (let round = 0; round < 10; round++) {
           const result = await env.VECTORIZE.query(zeroVector, {
             topK: 100,
-            returnMetadata: false,
+            returnMetadata: 'none',
           });
           const staleIds = result.matches
             .filter((m) => !keepSet.has(m.id))

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -149,4 +149,5 @@ export function initializeSchema(db: Database.Database): void {
   addColumnIfMissing(db, 'asset_filters', 'sort_order', 'INTEGER DEFAULT 0');
   addColumnIfMissing(db, 'vector_search_configs', 'index_mode', "TEXT NOT NULL DEFAULT 'readme'");
   addColumnIfMissing(db, 'vector_search_configs', 'readme_max_chars', 'INTEGER NOT NULL DEFAULT 6000');
+  addColumnIfMissing(db, 'repositories', 'vector_indexed_at', 'TEXT');
 }

--- a/server/src/routes/repositories.ts
+++ b/server/src/routes/repositories.ts
@@ -118,6 +118,13 @@ router.put('/api/repositories', (req, res) => {
         res.status(400).json({ error: 'Each repository must have a valid non-negative stargazers_count', code: 'INVALID_STARGAZERS_COUNT' });
         return;
       }
+      // 校验 vector_indexed_at：允许 null/undefined 或合法 ISO 8601 字符串
+      if (repo.vector_indexed_at !== null && repo.vector_indexed_at !== undefined && repo.vector_indexed_at !== '') {
+        if (typeof repo.vector_indexed_at !== 'string' || isNaN(Date.parse(repo.vector_indexed_at))) {
+          res.status(400).json({ error: 'vector_indexed_at must be an ISO 8601 string or null', code: 'INVALID_VECTOR_INDEXED_AT' });
+          return;
+        }
+      }
     }
 
     const stmt = db.prepare(`

--- a/server/src/routes/repositories.ts
+++ b/server/src/routes/repositories.ts
@@ -154,7 +154,7 @@ router.put('/api/repositories', (req, res) => {
         category_locked = excluded.category_locked,
         last_edited = CASE WHEN excluded.last_edited IS NOT NULL AND excluded.last_edited != '' THEN excluded.last_edited ELSE repositories.last_edited END,
         subscribed_to_releases = excluded.subscribed_to_releases,
-        vector_indexed_at = CASE WHEN excluded.vector_indexed_at IS NOT NULL AND excluded.vector_indexed_at != '' THEN excluded.vector_indexed_at ELSE repositories.vector_indexed_at END
+        vector_indexed_at = excluded.vector_indexed_at
     `);
 
     const deleteAllReleases = db.prepare('DELETE FROM releases');

--- a/server/src/routes/repositories.ts
+++ b/server/src/routes/repositories.ts
@@ -39,6 +39,7 @@ function transformRepo(row: Record<string, unknown>) {
     category_locked: !!row.category_locked,
     last_edited: row.last_edited,
     subscribed_to_releases: !!row.subscribed_to_releases,
+    vector_indexed_at: row.vector_indexed_at ?? undefined,
   };
 }
 
@@ -126,8 +127,8 @@ router.put('/api/repositories', (req, res) => {
         owner_login, owner_avatar_url, topics,
         ai_summary, ai_tags, ai_platforms, analyzed_at, analysis_failed,
         custom_description, custom_tags, custom_category, category_locked, last_edited,
-        subscribed_to_releases
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        subscribed_to_releases, vector_indexed_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         name = excluded.name,
         full_name = excluded.full_name,
@@ -152,7 +153,8 @@ router.put('/api/repositories', (req, res) => {
         custom_category = excluded.custom_category,
         category_locked = excluded.category_locked,
         last_edited = CASE WHEN excluded.last_edited IS NOT NULL AND excluded.last_edited != '' THEN excluded.last_edited ELSE repositories.last_edited END,
-        subscribed_to_releases = excluded.subscribed_to_releases
+        subscribed_to_releases = excluded.subscribed_to_releases,
+        vector_indexed_at = CASE WHEN excluded.vector_indexed_at IS NOT NULL AND excluded.vector_indexed_at != '' THEN excluded.vector_indexed_at ELSE repositories.vector_indexed_at END
     `);
 
     const deleteAllReleases = db.prepare('DELETE FROM releases');
@@ -198,7 +200,8 @@ router.put('/api/repositories', (req, res) => {
           repo.custom_description ?? null,
           JSON.stringify(Array.isArray(repo.custom_tags) ? repo.custom_tags : []),
           repo.custom_category ?? null, (repo.category_locked === true || repo.category_locked === 1) ? 1 : 0, repo.last_edited ?? null,
-          (repo.subscribed_to_releases === true || repo.subscribed_to_releases === 1) ? 1 : 0
+          (repo.subscribed_to_releases === true || repo.subscribed_to_releases === 1) ? 1 : 0,
+          repo.vector_indexed_at ?? null
         );
         count++;
       }
@@ -232,6 +235,7 @@ router.patch('/api/repositories/:id', (req, res) => {
       category_locked: (v) => (v === true || v === 1) ? 1 : 0,
       last_edited: (v) => v,
       subscribed_to_releases: (v) => (v === true || v === 1) ? 1 : 0,
+      vector_indexed_at: (v) => v,
       description: (v) => v,
       name: (v) => v,
     };

--- a/server/src/routes/repositories.ts
+++ b/server/src/routes/repositories.ts
@@ -235,10 +235,24 @@ router.patch('/api/repositories/:id', (req, res) => {
       category_locked: (v) => (v === true || v === 1) ? 1 : 0,
       last_edited: (v) => v,
       subscribed_to_releases: (v) => (v === true || v === 1) ? 1 : 0,
-      vector_indexed_at: (v) => v,
+      // 规范化：null/undefined/空字符串 → null；仅接受字符串（ISO 时间戳）
+      vector_indexed_at: (v) =>
+        (v === null || v === undefined || v === '') ? null : v,
       description: (v) => v,
       name: (v) => v,
     };
+
+    // 校验 vector_indexed_at 类型：只允许 null 或 ISO 字符串，拒绝数字/布尔/对象
+    if ('vector_indexed_at' in updates) {
+      const v = updates.vector_indexed_at;
+      if (v !== null && v !== undefined && v !== '' && typeof v !== 'string') {
+        res.status(400).json({
+          error: 'vector_indexed_at must be an ISO string or null',
+          code: 'INVALID_VECTOR_INDEXED_AT',
+        });
+        return;
+      }
+    }
 
     const setClauses: string[] = [];
     const values: unknown[] = [];

--- a/server/src/routes/repositories.ts
+++ b/server/src/routes/repositories.ts
@@ -242,10 +242,10 @@ router.patch('/api/repositories/:id', (req, res) => {
       name: (v) => v,
     };
 
-    // 校验 vector_indexed_at 类型：只允许 null 或 ISO 字符串，拒绝数字/布尔/对象
+    // 校验 vector_indexed_at 类型：只允许 null 或 ISO 8601 字符串，拒绝数字/布尔/对象/非日期字符串
     if ('vector_indexed_at' in updates) {
       const v = updates.vector_indexed_at;
-      if (v !== null && v !== undefined && v !== '' && typeof v !== 'string') {
+      if (v !== null && v !== undefined && v !== '' && (typeof v !== 'string' || isNaN(Date.parse(v)))) {
         res.status(400).json({
           error: 'vector_indexed_at must be an ISO string or null',
           code: 'INVALID_VECTOR_INDEXED_AT',

--- a/server/src/routes/sync.ts
+++ b/server/src/routes/sync.ts
@@ -108,8 +108,8 @@ router.post('/api/sync/import', (req, res) => {
             owner_login, owner_avatar_url, topics,
             ai_summary, ai_tags, ai_platforms, analyzed_at, analysis_failed,
             custom_description, custom_tags, custom_category, category_locked, last_edited,
-            subscribed_to_releases
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            subscribed_to_releases, vector_indexed_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `);
         for (const r of repos) {
           // 验证必需的字段
@@ -130,7 +130,8 @@ router.post('/api/sync/import', (req, res) => {
             r.custom_description ?? null,
             typeof r.custom_tags === 'string' ? r.custom_tags : JSON.stringify(r.custom_tags ?? []),
             r.custom_category ?? null, (r.category_locked === true || r.category_locked === 1) ? 1 : 0, r.last_edited ?? null,
-            r.subscribed_to_releases ? 1 : 0
+            r.subscribed_to_releases ? 1 : 0,
+            r.vector_indexed_at ?? null
           );
         }
         counts.repositories = repos.length;

--- a/src/components/SearchBar.test.tsx
+++ b/src/components/SearchBar.test.tsx
@@ -75,25 +75,28 @@ const baseStoreState = () => ({
 });
 
 const mockUseAppStore = vi.mocked(useAppStore);
-// SearchBar also calls useAppStore.getState() directly in effects/handlers.
+// Track the current mock state so getState() returns the same overrides as the hook.
+let currentState = baseStoreState();
 (mockUseAppStore as unknown as { getState: () => ReturnType<typeof baseStoreState> }).getState =
-  () => baseStoreState();
+  () => currentState;
 
 describe('SearchBar', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    currentState = baseStoreState();
   });
 
   it('clears the committed query when the search input is manually emptied', () => {
     const setSearchFilters = vi.fn();
-    mockUseAppStore.mockReturnValue(createStoreState({
+    currentState = createStoreState({
       searchFilters: {
         ...defaultSearchFilters,
         query: 'react',
       },
       setSearchFilters,
-    }) as ReturnType<typeof useAppStore>);
+    });
+    mockUseAppStore.mockReturnValue(currentState as ReturnType<typeof useAppStore>);
 
     render(<SearchBar />);
 
@@ -119,6 +122,7 @@ describe('SearchBar', () => {
     });
     storeState.setSearchFilters = setSearchFilters;
 
+    currentState = storeState;
     mockUseAppStore.mockReturnValue(storeState as ReturnType<typeof useAppStore>);
 
     const { rerender } = render(<SearchBar />);

--- a/src/components/SearchBar.test.tsx
+++ b/src/components/SearchBar.test.tsx
@@ -9,6 +9,13 @@ vi.mock('../store/useAppStore', () => ({
   getAllCategories: vi.fn(() => []),
 }));
 
+vi.mock('../hooks/useDialog', () => ({
+  useDialog: () => ({
+    toast: vi.fn(),
+    confirm: vi.fn(),
+  }),
+}));
+
 const localStorageMock = (() => {
   let store: Record<string, string> = {};
 
@@ -62,9 +69,15 @@ const baseStoreState = () => ({
   customCategories: [],
   hiddenDefaultCategoryIds: [],
   defaultCategoryOverrides: {},
+  vectorSearchConfig: { enabled: false, workerUrl: '', authToken: '', embeddingConfigId: '', indexMode: 'readme' as const, readmeMaxChars: 6000 },
+  vectorSearchStatus: { connected: false, vectorCount: 0, dimensions: 0 },
+  embeddingConfigs: [],
 });
 
 const mockUseAppStore = vi.mocked(useAppStore);
+// SearchBar also calls useAppStore.getState() directly in effects/handlers.
+(mockUseAppStore as unknown as { getState: () => ReturnType<typeof baseStoreState> }).getState =
+  () => baseStoreState();
 
 describe('SearchBar', () => {
   beforeEach(() => {

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -880,27 +880,6 @@ export const SearchBar: React.FC = () => {
         toast(t('同步完成！所有仓库都是最新的。', 'Sync completed! All repositories are up to date.'), 'info');
       }
 
-      // 向量搜索开启时，后台自动索引新仓库
-      const vsCfg = useAppStore.getState().vectorSearchConfig;
-      const embCfgs = useAppStore.getState().embeddingConfigs;
-      const activeEmb = embCfgs.find(c => c.id === vsCfg?.embeddingConfigId);
-      if (vsCfg?.enabled && vsCfg?.workerUrl && activeEmb && newRepoCount > 0) {
-        const { VectorSearchService, EmbeddingClient, indexAllRepos } = await import('../services/vectorSearchService');
-        const embClient = new EmbeddingClient(activeEmb);
-        const vecService = new VectorSearchService(vsCfg);
-        const readmeFetcher = githubToken
-          ? (owner: string, repo: string, signal?: AbortSignal) => new GitHubApiService(githubToken).getRepositoryReadme(owner, repo, signal)
-          : undefined;
-        // 只索引新增仓库，不重复索引已有仓库
-        const newRepos = mergedRepositories.filter(repo => !existingRepoIds.has(repo.id));
-        if (newRepos.length > 0) {
-          indexAllRepos(newRepos, embClient, vecService, {
-            readmeFetcher,
-            indexMode: vsCfg.indexMode,
-            readmeMaxChars: vsCfg.readmeMaxChars,
-          }).catch(() => {});
-        }
-      }
     } catch (error) {
       console.error('Sync failed:', error);
       if (error instanceof Error && error.message.includes('token')) {

--- a/src/components/settings/VectorSearchSettings.tsx
+++ b/src/components/settings/VectorSearchSettings.tsx
@@ -299,7 +299,8 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
       if (err instanceof Error && err.message === 'Aborted') {
         setVectorIndexingState({ isIndexing: false, phase: null, result: null });
       } else {
-        setVectorIndexingState({ isIndexing: false, phase: null, result: { indexed: 0, skipped: 0, errors: repositories.length } });
+        const msg = err instanceof Error ? err.message : String(err);
+        setVectorIndexingState({ isIndexing: false, phase: null, result: { indexed: 0, skipped: 0, errors: repositories.length, error: msg } });
       }
     } finally {
       setAbortController(null);
@@ -342,14 +343,20 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
 
       setVectorIndexingState({ result, isIndexing: false, phase: null });
       // 只计算本次新增索引的 repo（之前无 vector_indexed_at），不包含重新索引的
+      // 用可选链避免 vectorSearchStatus 为 undefined 时抛错（旧版本持久化状态或未测试连接）
       const newlyIndexedCount = result.indexedRepoIds.filter(id => newlyIndexedRepoIds.has(id)).length;
-      const prevCount = useAppStore.getState().vectorSearchStatus.vectorCount || 0;
-      setVectorSearchStatus({
-        connected: true,
-        vectorCount: prevCount + newlyIndexedCount,
-        dimensions: formDimensions,
-        lastSyncAt: new Date().toISOString(),
-      });
+      const prevCount = useAppStore.getState().vectorSearchStatus?.vectorCount ?? 0;
+      try {
+        setVectorSearchStatus({
+          connected: true,
+          vectorCount: prevCount + newlyIndexedCount,
+          dimensions: formDimensions,
+          lastSyncAt: new Date().toISOString(),
+        });
+      } catch (statusErr) {
+        // 状态更新失败不应回滚已成功的索引结果
+        console.warn('Failed to update vector search status:', statusErr);
+      }
     } catch (err) {
       if (err instanceof Error && err.message === 'Aborted') {
         setVectorIndexingState({ isIndexing: false, phase: null, result: null });
@@ -823,12 +830,12 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
           <button
             onClick={handleIncrementalIndex}
             disabled={isIndexing || !isConfigComplete || unindexedCount === 0}
-            className="flex items-center gap-2 px-4 py-2 text-sm bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="flex items-center gap-2 px-4 py-2 text-sm bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isIndexing ? <Loader2 className="w-4 h-4 animate-spin" /> : <RefreshCw className="w-4 h-4" />}
             {t('增量索引', 'Incremental Index')}
             {unindexedCount > 0 && (
-              <span className="ml-1 px-1.5 py-0.5 text-xs bg-purple-500 text-white rounded-full">
+              <span className="ml-1 px-2 py-0.5 text-xs bg-purple-500 text-white rounded-full">
                 {unindexedCount}
               </span>
             )}
@@ -836,7 +843,7 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
           {isIndexing && (
             <button
               onClick={handleAbortIndexing}
-              className="flex items-center gap-2 px-4 py-2 text-sm bg-red-500 text-white rounded-md hover:bg-red-600"
+              className="flex items-center gap-2 px-4 py-2 text-sm bg-red-500 text-white rounded-lg hover:bg-red-600"
             >
               <Square className="w-4 h-4" />
               {t('中止', 'Abort')}

--- a/src/components/settings/VectorSearchSettings.tsx
+++ b/src/components/settings/VectorSearchSettings.tsx
@@ -213,7 +213,10 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
   const unindexedCount = repositories.filter((r) => {
     if (!r.analyzed_at || r.analysis_failed) return false;
     if (!r.vector_indexed_at) return true;
-    const contentTime = r.last_edited || r.analyzed_at || '';
+    const contentTime = [r.last_edited, r.analyzed_at]
+      .filter((t): t is string => !!t)
+      .sort()
+      .pop() || '';
     return contentTime > r.vector_indexed_at;
   }).length;
 

--- a/src/components/settings/VectorSearchSettings.tsx
+++ b/src/components/settings/VectorSearchSettings.tsx
@@ -58,7 +58,7 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
     setVectorIndexingState,
     repositories,
     githubToken,
-    setRepositories,
+    updateRepositoriesMetadata,
   } = useAppStore();
 
   // Local form state for embedding config
@@ -236,11 +236,11 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
       authToken: formAuthToken,
       embeddingConfigId: activeEmbeddingConfig || '',
     });
-    const readmeFetcher = githubToken
-      ? (owner: string, repo: string, signal?: AbortSignal) => {
-          const api = new GitHubApiService(githubToken);
-          return api.getRepositoryReadme(owner, repo, signal);
-        }
+    // 复用单个 GitHubApiService 实例，保留 rate-limit state
+    const githubApi = githubToken ? new GitHubApiService(githubToken) : null;
+    const readmeFetcher = githubApi
+      ? (owner: string, repo: string, signal?: AbortSignal) =>
+          githubApi.getRepositoryReadme(owner, repo, signal)
       : undefined;
     return { embeddingClient, vectorService, readmeFetcher };
   }, [activeConfig, formApiType, formBaseUrl, formApiKey, formModel, formDimensions, formWorkerUrl, formAuthToken, activeEmbeddingConfig, githubToken]);
@@ -255,9 +255,10 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
 
     try {
       // 1. 清除所有 vector_indexed_at（包括之前失败/不可索引的 repo 的残留值）
-      setRepositories(repositories.map(repo =>
-        repo.vector_indexed_at ? { ...repo, vector_indexed_at: undefined } : repo
-      ));
+      //    用 updateRepositoriesMetadata 避免重置当前过滤的 searchResults
+      updateRepositoriesMetadata(
+        repositories.filter(r => r.vector_indexed_at).map(r => ({ id: r.id, patch: { vector_indexed_at: undefined } }))
+      );
 
       // 2. 全量索引
       const now = new Date().toISOString();
@@ -282,11 +283,10 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
         throw cleanupErr;
       }
 
-      // 4. 为成功索引的 repo 设置 vector_indexed_at（批量更新）
-      const indexedSet = new Set(result.indexedRepoIds);
-      setRepositories(useAppStore.getState().repositories.map(repo =>
-        indexedSet.has(repo.id) ? { ...repo, vector_indexed_at: now } : repo
-      ));
+      // 4. 为成功索引的 repo 设置 vector_indexed_at（批量更新，保留 searchResults）
+      updateRepositoriesMetadata(
+        result.indexedRepoIds.map(id => ({ id, patch: { vector_indexed_at: now } }))
+      );
 
       setVectorIndexingState({ result, isIndexing: false, phase: null });
       setVectorSearchStatus({
@@ -305,7 +305,7 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
     } finally {
       setAbortController(null);
     }
-  }, [createClients, repositories, formIndexMode, formReadmeMaxChars, formDimensions, setRepositories, setVectorSearchStatus, setVectorIndexingState]);
+  }, [createClients, repositories, formIndexMode, formReadmeMaxChars, formDimensions, updateRepositoriesMetadata, setVectorSearchStatus, setVectorIndexingState]);
 
   const handleIncrementalIndex = useCallback(async () => {
     const clients = createClients();
@@ -335,11 +335,10 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
         incremental: true,
       });
 
-      // 批量设置 vector_indexed_at（一次性更新，避免逐个 updateRepository）
-      const indexedSet = new Set(result.indexedRepoIds);
-      setRepositories(useAppStore.getState().repositories.map(repo =>
-        indexedSet.has(repo.id) ? { ...repo, vector_indexed_at: now } : repo
-      ));
+      // 批量设置 vector_indexed_at（保留 searchResults 不被重置）
+      updateRepositoriesMetadata(
+        result.indexedRepoIds.map(id => ({ id, patch: { vector_indexed_at: now } }))
+      );
 
       setVectorIndexingState({ result, isIndexing: false, phase: null });
       // 只计算本次新增索引的 repo（之前无 vector_indexed_at），不包含重新索引的
@@ -371,7 +370,7 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
     } finally {
       setAbortController(null);
     }
-  }, [createClients, repositories, formIndexMode, formReadmeMaxChars, formDimensions, setRepositories, setVectorSearchStatus, setVectorIndexingState]);
+  }, [createClients, repositories, formIndexMode, formReadmeMaxChars, formDimensions, updateRepositoriesMetadata, setVectorSearchStatus, setVectorIndexingState]);
 
   const handleAbortIndexing = useCallback(() => {
     abortController?.abort();

--- a/src/components/settings/VectorSearchSettings.tsx
+++ b/src/components/settings/VectorSearchSettings.tsx
@@ -370,12 +370,20 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
       } else {
         const msg = err instanceof Error ? err.message : String(err);
         const currentRepos = useAppStore.getState().repositories;
-        const indexableCount = currentRepos.filter((r) => r.analyzed_at && !r.analysis_failed).length;
-        const skippedCount = currentRepos.length - indexableCount;
+        const attemptedCount = currentRepos.filter((r) => {
+          if (!r.analyzed_at || r.analysis_failed) return false;
+          if (!r.vector_indexed_at) return true;
+          const contentTime = [r.last_edited, r.analyzed_at]
+            .filter((t): t is string => !!t)
+            .sort()
+            .pop() || '';
+          return contentTime > r.vector_indexed_at;
+        }).length;
+        const skippedCount = currentRepos.length - attemptedCount;
         setVectorIndexingState({
           isIndexing: false,
           phase: null,
-          result: { indexed: 0, skipped: skippedCount, errors: indexableCount, error: msg },
+          result: { indexed: 0, skipped: skippedCount, errors: attemptedCount, error: msg },
         });
       }
     } finally {

--- a/src/components/settings/VectorSearchSettings.tsx
+++ b/src/components/settings/VectorSearchSettings.tsx
@@ -58,7 +58,6 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
     setVectorIndexingState,
     repositories,
     githubToken,
-    updateRepository,
     setRepositories,
   } = useAppStore();
 

--- a/src/components/settings/VectorSearchSettings.tsx
+++ b/src/components/settings/VectorSearchSettings.tsx
@@ -278,11 +278,12 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
         incremental: false,
       });
 
-      // 3. cleanup：全量重建后只保留本次成功重建的向量（失败不中断索引结果）
+      // 3. cleanup：全量重建后只保留本次成功重建的向量
       try {
         await clients.vectorService.cleanup(result.indexedRepoIds.map(String), controller.signal);
       } catch (cleanupErr) {
-        console.warn('Vector cleanup failed after rebuild (non-fatal):', cleanupErr);
+        console.warn('Vector cleanup failed after rebuild:', cleanupErr);
+        throw cleanupErr;
       }
 
       // 4. 为成功索引的 repo 设置 vector_indexed_at（批量更新，保留 searchResults）
@@ -302,8 +303,9 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
         setVectorIndexingState({ isIndexing: false, phase: null, result: null });
       } else {
         const msg = err instanceof Error ? err.message : String(err);
-        const repoCount = useAppStore.getState().repositories.length;
-        setVectorIndexingState({ isIndexing: false, phase: null, result: { indexed: 0, skipped: 0, errors: repoCount, error: msg } });
+        const currentRepos = useAppStore.getState().repositories;
+        const indexableCount = currentRepos.filter((r) => r.analyzed_at && !r.analysis_failed).length;
+        setVectorIndexingState({ isIndexing: false, phase: null, result: { indexed: 0, skipped: currentRepos.length - indexableCount, errors: indexableCount, error: msg } });
       }
     } finally {
       setAbortController(null);
@@ -367,11 +369,13 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
         setVectorIndexingState({ isIndexing: false, phase: null, result: null });
       } else {
         const msg = err instanceof Error ? err.message : String(err);
-        const repoCount = useAppStore.getState().repositories.length;
+        const currentRepos = useAppStore.getState().repositories;
+        const indexableCount = currentRepos.filter((r) => r.analyzed_at && !r.analysis_failed).length;
+        const skippedCount = currentRepos.length - indexableCount;
         setVectorIndexingState({
           isIndexing: false,
           phase: null,
-          result: { indexed: 0, skipped: 0, errors: repoCount, error: msg },
+          result: { indexed: 0, skipped: skippedCount, errors: indexableCount, error: msg },
         });
       }
     } finally {

--- a/src/components/settings/VectorSearchSettings.tsx
+++ b/src/components/settings/VectorSearchSettings.tsx
@@ -58,6 +58,7 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
     setVectorIndexingState,
     repositories,
     githubToken,
+    updateRepository,
   } = useAppStore();
 
   // Local form state for embedding config
@@ -208,9 +209,16 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
     }
   }, [formWorkerUrl, formAuthToken, setVectorSearchStatus]);
 
-  const runIndexAll = useCallback(async (withCleanup: boolean) => {
-    if (!activeConfig) return;
+  // 未索引数量（已分析、未失败、未向量索引或内容已更新）
+  const unindexedCount = repositories.filter((r) => {
+    if (!r.analyzed_at || r.analysis_failed) return false;
+    if (!r.vector_indexed_at) return true;
+    const contentTime = r.last_edited || r.analyzed_at || '';
+    return contentTime > r.vector_indexed_at;
+  }).length;
 
+  const createClients = useCallback(() => {
+    if (!activeConfig) return null;
     const embeddingClient = new EmbeddingClient({
       ...activeConfig,
       apiType: formApiType,
@@ -225,40 +233,64 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
       authToken: formAuthToken,
       embeddingConfigId: activeEmbeddingConfig || '',
     });
+    const readmeFetcher = githubToken
+      ? (owner: string, repo: string, signal?: AbortSignal) => {
+          const api = new GitHubApiService(githubToken);
+          return api.getRepositoryReadme(owner, repo, signal);
+        }
+      : undefined;
+    return { embeddingClient, vectorService, readmeFetcher };
+  }, [activeConfig, formApiType, formBaseUrl, formApiKey, formModel, formDimensions, formWorkerUrl, formAuthToken, activeEmbeddingConfig, githubToken]);
+
+  const handleRebuildIndex = useCallback(async () => {
+    const clients = createClients();
+    if (!clients) return;
+
     const controller = new AbortController();
     setAbortController(controller);
     setVectorIndexingState({ isIndexing: true, phase: null, phaseDone: 0, phaseTotal: 0, result: null });
 
     try {
-      if (withCleanup) {
-        const keepIds = repositories.map(r => String(r.id));
-        try {
-          await vectorService.cleanup(keepIds, controller.signal);
-        } catch (cleanupErr) {
-          // Cleanup 失败不阻塞重建，记录警告继续
-          console.warn('Vector cleanup failed, continuing with rebuild:', cleanupErr);
+      // 1. cleanup：删除不在当前仓库列表中的向量
+      const keepIds = repositories.map(r => String(r.id));
+      try {
+        await clients.vectorService.cleanup(keepIds, controller.signal);
+      } catch (cleanupErr) {
+        console.warn('Vector cleanup failed, continuing with rebuild:', cleanupErr);
+      }
+
+      // 2. 清除所有 vector_indexed_at（包括之前失败/不可索引的 repo 的残留值）
+      for (const repo of repositories) {
+        if (repo.vector_indexed_at) {
+          updateRepository({ ...repo, vector_indexed_at: undefined });
         }
       }
 
-      const readmeFetcher = githubToken
-        ? (owner: string, repo: string, signal?: AbortSignal) => {
-            const api = new GitHubApiService(githubToken);
-            return api.getRepositoryReadme(owner, repo, signal);
-          }
-        : undefined;
-
-      const result = await indexAllRepos(repositories, embeddingClient, vectorService, {
+      // 3. 全量索引
+      const now = new Date().toISOString();
+      const result = await indexAllRepos(repositories, clients.embeddingClient, clients.vectorService, {
         onProgress: (progress) => setVectorIndexingState({
           phase: progress.phase,
           phaseDone: progress.done,
           phaseTotal: progress.total,
         }),
         signal: controller.signal,
-        readmeFetcher,
+        readmeFetcher: clients.readmeFetcher,
         indexMode: formIndexMode,
         readmeMaxChars: formReadmeMaxChars,
+        incremental: false,
       });
+
+      // 4. 为成功索引的 repo 设置 vector_indexed_at
+      const indexedSet = new Set(result.indexedRepoIds);
+      for (const repo of useAppStore.getState().repositories) {
+        if (indexedSet.has(repo.id)) {
+          updateRepository({ ...repo, vector_indexed_at: now });
+        }
+      }
+
       setVectorIndexingState({ result, isIndexing: false, phase: null });
+      // Rebuild 替换全部索引，vectorCount = 本次成功数量
       setVectorSearchStatus({
         connected: true,
         vectorCount: result.indexed,
@@ -274,10 +306,56 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
     } finally {
       setAbortController(null);
     }
-  }, [activeConfig, formApiType, formBaseUrl, formApiKey, formModel, formDimensions, formWorkerUrl, formAuthToken, formIndexMode, formReadmeMaxChars, activeEmbeddingConfig, repositories, githubToken, setVectorSearchStatus, setVectorIndexingState]);
+  }, [createClients, repositories, formIndexMode, formReadmeMaxChars, formDimensions, updateRepository, setVectorSearchStatus, setVectorIndexingState]);
 
-  const handleRebuildIndex = useCallback(() => runIndexAll(true), [runIndexAll]);
-  const handleIncrementalIndex = useCallback(() => runIndexAll(false), [runIndexAll]);
+  const handleIncrementalIndex = useCallback(async () => {
+    const clients = createClients();
+    if (!clients) return;
+
+    const controller = new AbortController();
+    setAbortController(controller);
+    setVectorIndexingState({ isIndexing: true, phase: null, phaseDone: 0, phaseTotal: 0, result: null });
+
+    try {
+      const now = new Date().toISOString();
+      const result = await indexAllRepos(repositories, clients.embeddingClient, clients.vectorService, {
+        onProgress: (progress) => setVectorIndexingState({
+          phase: progress.phase,
+          phaseDone: progress.done,
+          phaseTotal: progress.total,
+        }),
+        signal: controller.signal,
+        readmeFetcher: clients.readmeFetcher,
+        indexMode: formIndexMode,
+        readmeMaxChars: formReadmeMaxChars,
+        incremental: true,
+        onRepoIndexed: (repoId) => {
+          // 用 getState() 获取最新 repo 数据，避免 stale closure 覆盖并发编辑
+          const repo = useAppStore.getState().repositories.find(r => r.id === repoId);
+          if (repo) {
+            updateRepository({ ...repo, vector_indexed_at: now });
+          }
+        },
+      });
+
+      setVectorIndexingState({ result, isIndexing: false, phase: null });
+      const prevCount = useAppStore.getState().vectorSearchStatus.vectorCount || 0;
+      setVectorSearchStatus({
+        connected: true,
+        vectorCount: prevCount + result.indexed,
+        dimensions: formDimensions,
+        lastSyncAt: new Date().toISOString(),
+      });
+    } catch (err) {
+      if (err instanceof Error && err.message === 'Aborted') {
+        setVectorIndexingState({ isIndexing: false, phase: null, result: null });
+      } else {
+        setVectorIndexingState({ isIndexing: false, phase: null, result: { indexed: 0, skipped: 0, errors: repositories.length } });
+      }
+    } finally {
+      setAbortController(null);
+    }
+  }, [createClients, repositories, formIndexMode, formReadmeMaxChars, formDimensions, updateRepository, setVectorSearchStatus, setVectorIndexingState]);
 
   const handleAbortIndexing = useCallback(() => {
     abortController?.abort();
@@ -735,11 +813,16 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
           </button>
           <button
             onClick={handleIncrementalIndex}
-            disabled={isIndexing || !isConfigComplete}
+            disabled={isIndexing || !isConfigComplete || unindexedCount === 0}
             className="flex items-center gap-2 px-4 py-2 text-sm bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-md hover:bg-gray-300 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isIndexing ? <Loader2 className="w-4 h-4 animate-spin" /> : <RefreshCw className="w-4 h-4" />}
             {t('增量索引', 'Incremental Index')}
+            {unindexedCount > 0 && (
+              <span className="ml-1 px-1.5 py-0.5 text-xs bg-purple-500 text-white rounded-full">
+                {unindexedCount}
+              </span>
+            )}
           </button>
           {isIndexing && (
             <button

--- a/src/components/settings/VectorSearchSettings.tsx
+++ b/src/components/settings/VectorSearchSettings.tsx
@@ -278,12 +278,11 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
         incremental: false,
       });
 
-      // 3. cleanup：全量重建后只保留本次成功重建的向量
+      // 3. cleanup：全量重建后只保留本次成功重建的向量（失败不中断索引结果）
       try {
         await clients.vectorService.cleanup(result.indexedRepoIds.map(String), controller.signal);
       } catch (cleanupErr) {
-        console.warn('Vector cleanup failed after rebuild:', cleanupErr);
-        throw cleanupErr;
+        console.warn('Vector cleanup failed after rebuild (non-fatal):', cleanupErr);
       }
 
       // 4. 为成功索引的 repo 设置 vector_indexed_at（批量更新，保留 searchResults）
@@ -842,7 +841,7 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
             {isIndexing ? <Loader2 className="w-4 h-4 animate-spin" /> : <RefreshCw className="w-4 h-4" />}
             {t('增量索引', 'Incremental Index')}
             {unindexedCount > 0 && (
-              <span className="ml-1 px-2 py-0.5 text-xs bg-purple-500 text-white rounded-full">
+              <span className="ml-1 px-2 py-0.5 text-xs bg-brand-indigo text-white rounded-full">
                 {unindexedCount}
               </span>
             )}
@@ -874,7 +873,7 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
             </div>
             <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
               <div
-                className="bg-purple-500 h-2 rounded-full transition-all"
+                className="bg-brand-indigo h-2 rounded-full transition-all"
                 style={{ width: `${(phaseDone / phaseTotal) * 100}%` }}
               />
             </div>

--- a/src/components/settings/VectorSearchSettings.tsx
+++ b/src/components/settings/VectorSearchSettings.tsx
@@ -378,7 +378,9 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
     } finally {
       setAbortController(null);
     }
-  }, [createClients, formIndexMode, formReadmeMaxChars, formDimensions, updateRepositoriesMetadata, setVectorSearchStatus, setVectorIndexingState]); = useCallback(() => {
+  }, [createClients, formIndexMode, formReadmeMaxChars, formDimensions, updateRepositoriesMetadata, setVectorSearchStatus, setVectorIndexingState]);
+
+  const handleAbortIndexing = useCallback(() => {
     abortController?.abort();
   }, [abortController]);
 

--- a/src/components/settings/VectorSearchSettings.tsx
+++ b/src/components/settings/VectorSearchSettings.tsx
@@ -59,6 +59,7 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
     repositories,
     githubToken,
     updateRepository,
+    setRepositories,
   } = useAppStore();
 
   // Local form state for embedding config
@@ -251,22 +252,12 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
     setVectorIndexingState({ isIndexing: true, phase: null, phaseDone: 0, phaseTotal: 0, result: null });
 
     try {
-      // 1. cleanup：删除不在当前仓库列表中的向量
-      const keepIds = repositories.map(r => String(r.id));
-      try {
-        await clients.vectorService.cleanup(keepIds, controller.signal);
-      } catch (cleanupErr) {
-        console.warn('Vector cleanup failed, continuing with rebuild:', cleanupErr);
-      }
+      // 1. 清除所有 vector_indexed_at（包括之前失败/不可索引的 repo 的残留值）
+      setRepositories(repositories.map(repo =>
+        repo.vector_indexed_at ? { ...repo, vector_indexed_at: undefined } : repo
+      ));
 
-      // 2. 清除所有 vector_indexed_at（包括之前失败/不可索引的 repo 的残留值）
-      for (const repo of repositories) {
-        if (repo.vector_indexed_at) {
-          updateRepository({ ...repo, vector_indexed_at: undefined });
-        }
-      }
-
-      // 3. 全量索引
+      // 2. 全量索引
       const now = new Date().toISOString();
       const result = await indexAllRepos(repositories, clients.embeddingClient, clients.vectorService, {
         onProgress: (progress) => setVectorIndexingState({
@@ -281,16 +272,20 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
         incremental: false,
       });
 
-      // 4. 为成功索引的 repo 设置 vector_indexed_at
-      const indexedSet = new Set(result.indexedRepoIds);
-      for (const repo of useAppStore.getState().repositories) {
-        if (indexedSet.has(repo.id)) {
-          updateRepository({ ...repo, vector_indexed_at: now });
-        }
+      // 3. cleanup：全量重建后只保留本次成功重建的向量
+      try {
+        await clients.vectorService.cleanup(result.indexedRepoIds.map(String), controller.signal);
+      } catch (cleanupErr) {
+        console.warn('Vector cleanup failed after rebuild:', cleanupErr);
       }
 
+      // 4. 为成功索引的 repo 设置 vector_indexed_at（批量更新）
+      const indexedSet = new Set(result.indexedRepoIds);
+      setRepositories(useAppStore.getState().repositories.map(repo =>
+        indexedSet.has(repo.id) ? { ...repo, vector_indexed_at: now } : repo
+      ));
+
       setVectorIndexingState({ result, isIndexing: false, phase: null });
-      // Rebuild 替换全部索引，vectorCount = 本次成功数量
       setVectorSearchStatus({
         connected: true,
         vectorCount: result.indexed,
@@ -306,7 +301,7 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
     } finally {
       setAbortController(null);
     }
-  }, [createClients, repositories, formIndexMode, formReadmeMaxChars, formDimensions, updateRepository, setVectorSearchStatus, setVectorIndexingState]);
+  }, [createClients, repositories, formIndexMode, formReadmeMaxChars, formDimensions, setRepositories, setVectorSearchStatus, setVectorIndexingState]);
 
   const handleIncrementalIndex = useCallback(async () => {
     const clients = createClients();
@@ -317,6 +312,11 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
     setVectorIndexingState({ isIndexing: true, phase: null, phaseDone: 0, phaseTotal: 0, result: null });
 
     try {
+      // 记录索引前无 vector_indexed_at 的 repo，用于精确计算新增数量
+      const newlyIndexedRepoIds = new Set(
+        repositories.filter(r => !r.vector_indexed_at).map(r => r.id)
+      );
+
       const now = new Date().toISOString();
       const result = await indexAllRepos(repositories, clients.embeddingClient, clients.vectorService, {
         onProgress: (progress) => setVectorIndexingState({
@@ -329,20 +329,21 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
         indexMode: formIndexMode,
         readmeMaxChars: formReadmeMaxChars,
         incremental: true,
-        onRepoIndexed: (repoId) => {
-          // 用 getState() 获取最新 repo 数据，避免 stale closure 覆盖并发编辑
-          const repo = useAppStore.getState().repositories.find(r => r.id === repoId);
-          if (repo) {
-            updateRepository({ ...repo, vector_indexed_at: now });
-          }
-        },
       });
 
+      // 批量设置 vector_indexed_at（一次性更新，避免逐个 updateRepository）
+      const indexedSet = new Set(result.indexedRepoIds);
+      setRepositories(useAppStore.getState().repositories.map(repo =>
+        indexedSet.has(repo.id) ? { ...repo, vector_indexed_at: now } : repo
+      ));
+
       setVectorIndexingState({ result, isIndexing: false, phase: null });
+      // 只计算本次新增索引的 repo（之前无 vector_indexed_at），不包含重新索引的
+      const newlyIndexedCount = result.indexedRepoIds.filter(id => newlyIndexedRepoIds.has(id)).length;
       const prevCount = useAppStore.getState().vectorSearchStatus.vectorCount || 0;
       setVectorSearchStatus({
         connected: true,
-        vectorCount: prevCount + result.indexed,
+        vectorCount: prevCount + newlyIndexedCount,
         dimensions: formDimensions,
         lastSyncAt: new Date().toISOString(),
       });
@@ -355,7 +356,7 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
     } finally {
       setAbortController(null);
     }
-  }, [createClients, repositories, formIndexMode, formReadmeMaxChars, formDimensions, updateRepository, setVectorSearchStatus, setVectorIndexingState]);
+  }, [createClients, repositories, formIndexMode, formReadmeMaxChars, formDimensions, setRepositories, setVectorSearchStatus, setVectorIndexingState]);
 
   const handleAbortIndexing = useCallback(() => {
     abortController?.abort();

--- a/src/components/settings/VectorSearchSettings.tsx
+++ b/src/components/settings/VectorSearchSettings.tsx
@@ -254,15 +254,18 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
     setVectorIndexingState({ isIndexing: true, phase: null, phaseDone: 0, phaseTotal: 0, result: null });
 
     try {
+      // 每次点击时读取最新的 repositories，避免闭包捕获过期数据
+      const currentRepos = useAppStore.getState().repositories;
+
       // 1. 清除所有 vector_indexed_at（包括之前失败/不可索引的 repo 的残留值）
       //    用 updateRepositoriesMetadata 避免重置当前过滤的 searchResults
       updateRepositoriesMetadata(
-        repositories.filter(r => r.vector_indexed_at).map(r => ({ id: r.id, patch: { vector_indexed_at: undefined } }))
+        currentRepos.filter(r => r.vector_indexed_at).map(r => ({ id: r.id, patch: { vector_indexed_at: undefined } }))
       );
 
       // 2. 全量索引
       const now = new Date().toISOString();
-      const result = await indexAllRepos(repositories, clients.embeddingClient, clients.vectorService, {
+      const result = await indexAllRepos(currentRepos, clients.embeddingClient, clients.vectorService, {
         onProgress: (progress) => setVectorIndexingState({
           phase: progress.phase,
           phaseDone: progress.done,
@@ -300,12 +303,13 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
         setVectorIndexingState({ isIndexing: false, phase: null, result: null });
       } else {
         const msg = err instanceof Error ? err.message : String(err);
-        setVectorIndexingState({ isIndexing: false, phase: null, result: { indexed: 0, skipped: 0, errors: repositories.length, error: msg } });
+        const repoCount = useAppStore.getState().repositories.length;
+        setVectorIndexingState({ isIndexing: false, phase: null, result: { indexed: 0, skipped: 0, errors: repoCount, error: msg } });
       }
     } finally {
       setAbortController(null);
     }
-  }, [createClients, repositories, formIndexMode, formReadmeMaxChars, formDimensions, updateRepositoriesMetadata, setVectorSearchStatus, setVectorIndexingState]);
+  }, [createClients, formIndexMode, formReadmeMaxChars, formDimensions, updateRepositoriesMetadata, setVectorSearchStatus, setVectorIndexingState]);
 
   const handleIncrementalIndex = useCallback(async () => {
     const clients = createClients();
@@ -316,13 +320,16 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
     setVectorIndexingState({ isIndexing: true, phase: null, phaseDone: 0, phaseTotal: 0, result: null });
 
     try {
+      // 每次点击时读取最新的 repositories，避免闭包捕获过期数据
+      const currentRepos = useAppStore.getState().repositories;
+
       // 记录索引前无 vector_indexed_at 的 repo，用于精确计算新增数量
       const newlyIndexedRepoIds = new Set(
-        repositories.filter(r => !r.vector_indexed_at).map(r => r.id)
+        currentRepos.filter(r => !r.vector_indexed_at).map(r => r.id)
       );
 
       const now = new Date().toISOString();
-      const result = await indexAllRepos(repositories, clients.embeddingClient, clients.vectorService, {
+      const result = await indexAllRepos(currentRepos, clients.embeddingClient, clients.vectorService, {
         onProgress: (progress) => setVectorIndexingState({
           phase: progress.phase,
           phaseDone: progress.done,
@@ -361,18 +368,17 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
         setVectorIndexingState({ isIndexing: false, phase: null, result: null });
       } else {
         const msg = err instanceof Error ? err.message : String(err);
+        const repoCount = useAppStore.getState().repositories.length;
         setVectorIndexingState({
           isIndexing: false,
           phase: null,
-          result: { indexed: 0, skipped: 0, errors: repositories.length, error: msg },
+          result: { indexed: 0, skipped: 0, errors: repoCount, error: msg },
         });
       }
     } finally {
       setAbortController(null);
     }
-  }, [createClients, repositories, formIndexMode, formReadmeMaxChars, formDimensions, updateRepositoriesMetadata, setVectorSearchStatus, setVectorIndexingState]);
-
-  const handleAbortIndexing = useCallback(() => {
+  }, [createClients, formIndexMode, formReadmeMaxChars, formDimensions, updateRepositoriesMetadata, setVectorSearchStatus, setVectorIndexingState]); = useCallback(() => {
     abortController?.abort();
   }, [abortController]);
 

--- a/src/components/settings/VectorSearchSettings.tsx
+++ b/src/components/settings/VectorSearchSettings.tsx
@@ -276,6 +276,7 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
         await clients.vectorService.cleanup(result.indexedRepoIds.map(String), controller.signal);
       } catch (cleanupErr) {
         console.warn('Vector cleanup failed after rebuild:', cleanupErr);
+        throw cleanupErr;
       }
 
       // 4. 为成功索引的 repo 设置 vector_indexed_at（批量更新）
@@ -350,7 +351,12 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
       if (err instanceof Error && err.message === 'Aborted') {
         setVectorIndexingState({ isIndexing: false, phase: null, result: null });
       } else {
-        setVectorIndexingState({ isIndexing: false, phase: null, result: { indexed: 0, skipped: 0, errors: repositories.length } });
+        const msg = err instanceof Error ? err.message : String(err);
+        setVectorIndexingState({
+          isIndexing: false,
+          phase: null,
+          result: { indexed: 0, skipped: 0, errors: repositories.length, error: msg },
+        });
       }
     } finally {
       setAbortController(null);

--- a/src/components/settings/VectorSearchSettings.tsx
+++ b/src/components/settings/VectorSearchSettings.tsx
@@ -263,8 +263,9 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
         currentRepos.filter(r => r.vector_indexed_at).map(r => ({ id: r.id, patch: { vector_indexed_at: undefined } }))
       );
 
-      // 2. 全量索引
+      // 2. 全量索引，逐批确认后立即 stamp（中断不丢失已确认进度）
       const now = new Date().toISOString();
+      const stampedRepoIds: number[] = [];
       const result = await indexAllRepos(currentRepos, clients.embeddingClient, clients.vectorService, {
         onProgress: (progress) => setVectorIndexingState({
           phase: progress.phase,
@@ -276,7 +277,20 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
         indexMode: formIndexMode,
         readmeMaxChars: formReadmeMaxChars,
         incremental: false,
+        onRepoIndexed: (repoId) => {
+          stampedRepoIds.push(repoId);
+          // 批量 stamp：每 32 个（一个 batch）刷新一次，减少 UI 刷新频率
+          if (stampedRepoIds.length % 32 === 0) {
+            const batch = stampedRepoIds.splice(0, stampedRepoIds.length);
+            updateRepositoriesMetadata(batch.map(id => ({ id, patch: { vector_indexed_at: now } })));
+          }
+        },
       });
+
+      // stamp 剩余未刷新的
+      if (stampedRepoIds.length > 0) {
+        updateRepositoriesMetadata(stampedRepoIds.map(id => ({ id, patch: { vector_indexed_at: now } })));
+      }
 
       // 3. cleanup：全量重建后只保留本次成功重建的向量
       try {
@@ -285,11 +299,6 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
         console.warn('Vector cleanup failed after rebuild:', cleanupErr);
         throw cleanupErr;
       }
-
-      // 4. 为成功索引的 repo 设置 vector_indexed_at（批量更新，保留 searchResults）
-      updateRepositoriesMetadata(
-        result.indexedRepoIds.map(id => ({ id, patch: { vector_indexed_at: now } }))
-      );
 
       setVectorIndexingState({ result, isIndexing: false, phase: null });
       setVectorSearchStatus({
@@ -330,6 +339,7 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
       );
 
       const now = new Date().toISOString();
+      const stampedRepoIds: number[] = [];
       const result = await indexAllRepos(currentRepos, clients.embeddingClient, clients.vectorService, {
         onProgress: (progress) => setVectorIndexingState({
           phase: progress.phase,
@@ -341,12 +351,19 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
         indexMode: formIndexMode,
         readmeMaxChars: formReadmeMaxChars,
         incremental: true,
+        onRepoIndexed: (repoId) => {
+          stampedRepoIds.push(repoId);
+          if (stampedRepoIds.length % 32 === 0) {
+            const batch = stampedRepoIds.splice(0, stampedRepoIds.length);
+            updateRepositoriesMetadata(batch.map(id => ({ id, patch: { vector_indexed_at: now } })));
+          }
+        },
       });
 
-      // 批量设置 vector_indexed_at（保留 searchResults 不被重置）
-      updateRepositoriesMetadata(
-        result.indexedRepoIds.map(id => ({ id, patch: { vector_indexed_at: now } }))
-      );
+      // stamp 剩余未刷新的
+      if (stampedRepoIds.length > 0) {
+        updateRepositoriesMetadata(stampedRepoIds.map(id => ({ id, patch: { vector_indexed_at: now } })));
+      }
 
       setVectorIndexingState({ result, isIndexing: false, phase: null });
       // 只计算本次新增索引的 repo（之前无 vector_indexed_at），不包含重新索引的

--- a/src/services/vectorSearchService.test.ts
+++ b/src/services/vectorSearchService.test.ts
@@ -6,20 +6,33 @@ import {
 } from './vectorSearchService';
 
 // Minimal mock: only the `.embed` method is used by embedWithFallback.
+// Signature mirrors EmbeddingClient.embed; helpers only pass the args they use.
 const makeClient = (
-  embedImpl: (texts: string[], purpose: 'document' | 'query', signal?: AbortSignal) => Promise<number[][]>,
+  embedImpl: (texts: string[]) => Promise<number[][]>,
 ) => ({ embed: vi.fn(embedImpl) }) as unknown as Parameters<typeof embedWithFallback>[1];
 
 const vec = (n: number) => [n, n + 1, n + 2];
 
+// 硅基流动真实的长度超限 payload（code 20015）
+const LENGTH_ERROR = () =>
+  new Error('Embedding API error 400: {"code":20015,"message":"The parameter is invalid.","data":null}');
+
 describe('looksLikeLengthError', () => {
   it('detects SiliconFlow 20015 length errors', () => {
-    expect(looksLikeLengthError(new Error('Embedding API error 400: {"code":20015,"message":"The parameter is invalid."}'))).toBe(true);
+    expect(looksLikeLengthError(LENGTH_ERROR())).toBe(true);
   });
 
-  it('detects generic length phrases', () => {
-    expect(looksLikeLengthError(new Error('input length exceeds maximum token limit'))).toBe(true);
-    expect(looksLikeLengthError(new Error('text too long'))).toBe(true);
+  it('detects explicit length/token phrases', () => {
+    expect(looksLikeLengthError(new Error('input length exceeds the model maximum'))).toBe(true);
+    expect(looksLikeLengthError(new Error('maximum token limit reached'))).toBe(true);
+    expect(looksLikeLengthError(new Error('text too long for model'))).toBe(true);
+  });
+
+  it('does NOT treat generic 400 / "parameter is invalid" as length errors', () => {
+    // 纯 400 状态码不一定是长度问题（可能是配置/参数缺失）
+    expect(looksLikeLengthError(new Error('400 Bad Request'))).toBe(false);
+    // 只有 "parameter is invalid" 而无 20015 也可能是配置错误
+    expect(looksLikeLengthError(new Error('parameter is invalid'))).toBe(false);
   });
 
   it('rejects non-length errors', () => {
@@ -34,7 +47,7 @@ describe('truncateForRetry', () => {
     expect(truncateForRetry('short', 6000)).toBe('short');
   });
 
-  it('halves until under limit', () => {
+  it('leaves text unchanged when shorter than maxChars', () => {
     const long = 'x'.repeat(1000);
     const result = truncateForRetry(long, 6000);
     // 6000 > 1000, so no truncation needed actually
@@ -64,16 +77,16 @@ describe('embedWithFallback', () => {
     expect(result.every((v) => Array.isArray(v))).toBe(true);
   });
 
-  it('isolates single oversized item on length error', async () => {
+  it('isolates single oversized item on 20015 length error', async () => {
     // Batch call throws 20015; per-item: only the long one fails, short ones succeed.
-    const client = makeClient(async (texts, _purpose, _signal) => {
+    const client = makeClient(async (texts) => {
       if (texts.length > 1) {
         // batch path
-        throw new Error('Embedding API error 400: {"code":20015,"message":"The parameter is invalid."}');
+        throw LENGTH_ERROR();
       }
       const t = texts[0];
       if (t.length > 100) {
-        throw new Error('Embedding API error 400: {"code":20015,"message":"The parameter is invalid."}');
+        throw LENGTH_ERROR();
       }
       return [vec(t.length)];
     });
@@ -84,19 +97,27 @@ describe('embedWithFallback', () => {
     expect(result[2]).not.toBeNull();
   });
 
+  it('does NOT fall back to per-item on generic 400 errors', async () => {
+    // 通用 400（非长度类）应整批失败，不降级为逐条
+    const client = makeClient(async () => {
+      throw new Error('400 Bad Request: model not found');
+    });
+    await expect(embedWithFallback(['a', 'b'], client, undefined, 6000)).rejects.toThrow('400');
+  });
+
   it('rescues oversized item via truncation retry', async () => {
     // Per-item: full text fails but truncated version succeeds.
     // Models like bge have ~512 token (~2000 char) limits; truncation ladder
     // goes 6000 → 3000 → 1500, so a text that fails at full length but succeeds
     // when under ~2000 chars is rescuable.
-    const client = makeClient(async (texts, _purpose, _signal) => {
+    const client = makeClient(async (texts) => {
       if (texts.length > 1) {
-        throw new Error('400 parameter is invalid');
+        throw LENGTH_ERROR();
       }
       const t = texts[0];
       // Accept only texts under 2000 chars (simulating a 512-token bge limit)
       if (t.length > 2000) {
-        throw new Error('400 too long');
+        throw new Error('too long: input length exceeds maximum token limit');
       }
       return [vec(t.length)];
     });
@@ -104,7 +125,7 @@ describe('embedWithFallback', () => {
     const longText = 'y'.repeat(10000);
     const result = await embedWithFallback([longText], client, undefined, 6000);
     expect(result[0]).not.toBeNull();
-    // Should have retried with a truncated candidate (<=3000 chars)
+    // Should have retried with a truncated candidate (<=2000 chars)
     expect(client.embed.mock.calls.length).toBeGreaterThan(1);
     // The successful call used a truncated text under 2000 chars
     const lastCallText = client.embed.mock.calls[client.embed.mock.calls.length - 1][0] as string[];

--- a/src/services/vectorSearchService.test.ts
+++ b/src/services/vectorSearchService.test.ts
@@ -54,11 +54,10 @@ describe('truncateForRetry', () => {
     expect(result.length).toBe(1000);
   });
 
-  it('truncates oversized text', () => {
+  it('truncates oversized text to maxChars', () => {
     const long = 'x'.repeat(10000);
     const result = truncateForRetry(long, 6000);
-    expect(result.length).toBeLessThanOrEqual(6000);
-    expect(result.length).toBeGreaterThan(0);
+    expect(result.length).toBe(6000);
   });
 
   it('stops halving at 256 floor', () => {
@@ -107,29 +106,29 @@ describe('embedWithFallback', () => {
 
   it('rescues oversized item via truncation retry', async () => {
     // Per-item: full text fails but truncated version succeeds.
-    // Models like bge have ~512 token (~2000 char) limits; truncation ladder
-    // goes 6000 → 3000 → 1500, so a text that fails at full length but succeeds
-    // when under ~2000 chars is rescuable.
+    // With retryMaxChars=6000 and 10000-char text:
+    //   candidate lengths: [10000, 5000, 2500]
+    // Model accepts < 2000 chars → only the 3rd candidate (2500) fails too → null.
+    // But with retryMaxChars=6000 and 8000-char text:
+    //   candidate lengths: [8000, 4000, 2000] → 3rd succeeds.
     const client = makeClient(async (texts) => {
-      if (texts.length > 1) {
-        throw LENGTH_ERROR();
-      }
+      if (texts.length > 1) throw LENGTH_ERROR();
       const t = texts[0];
-      // Accept only texts under 2000 chars (simulating a 512-token bge limit)
-      if (t.length > 2000) {
-        throw new Error('too long: input length exceeds maximum token limit');
-      }
+      if (t.length > 2000) throw new Error('too long: input length exceeds maximum token limit');
       return [vec(t.length)];
     });
-    // Text longer than retryMaxChars(6000) so truncation actually kicks in
-    const longText = 'y'.repeat(10000);
+    const longText = 'y'.repeat(8000);
     const result = await embedWithFallback([longText], client, undefined, 6000);
     expect(result[0]).not.toBeNull();
-    // Should have retried with a truncated candidate (<=2000 chars)
-    expect(client.embed.mock.calls.length).toBeGreaterThan(1);
-    // The successful call used a truncated text under 2000 chars
-    const lastCallText = client.embed.mock.calls[client.embed.mock.calls.length - 1][0] as string[];
-    expect(lastCallText[0].length).toBeLessThanOrEqual(2000);
+    // 4 calls: 1 batch attempt + 3 per-item candidates [8000, 4000, 2000]
+    expect(client.embed.mock.calls.length).toBe(4);
+    // Verify per-item candidate lengths (calls 1-3, call 0 is the batch)
+    const call1 = client.embed.mock.calls[1][0] as string[];
+    const call2 = client.embed.mock.calls[2][0] as string[];
+    const call3 = client.embed.mock.calls[3][0] as string[];
+    expect(call1[0].length).toBe(8000);  // original
+    expect(call2[0].length).toBe(4000);  // firstLimit = min(6000, 8000/2) = 4000
+    expect(call3[0].length).toBe(2000);  // secondLimit = max(256, 4000/2) = 2000
   });
 
   it('rethrows non-length errors', async () => {

--- a/src/services/vectorSearchService.test.ts
+++ b/src/services/vectorSearchService.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  looksLikeLengthError,
+  truncateForRetry,
+  embedWithFallback,
+} from './vectorSearchService';
+
+// Minimal mock: only the `.embed` method is used by embedWithFallback.
+const makeClient = (
+  embedImpl: (texts: string[], purpose: 'document' | 'query', signal?: AbortSignal) => Promise<number[][]>,
+) => ({ embed: vi.fn(embedImpl) }) as unknown as Parameters<typeof embedWithFallback>[1];
+
+const vec = (n: number) => [n, n + 1, n + 2];
+
+describe('looksLikeLengthError', () => {
+  it('detects SiliconFlow 20015 length errors', () => {
+    expect(looksLikeLengthError(new Error('Embedding API error 400: {"code":20015,"message":"The parameter is invalid."}'))).toBe(true);
+  });
+
+  it('detects generic length phrases', () => {
+    expect(looksLikeLengthError(new Error('input length exceeds maximum token limit'))).toBe(true);
+    expect(looksLikeLengthError(new Error('text too long'))).toBe(true);
+  });
+
+  it('rejects non-length errors', () => {
+    expect(looksLikeLengthError(new Error('Unauthorized'))).toBe(false);
+    expect(looksLikeLengthError(new Error('Internal server error 500'))).toBe(false);
+    expect(looksLikeLengthError(new Error('rate limit 429'))).toBe(false);
+  });
+});
+
+describe('truncateForRetry', () => {
+  it('returns text unchanged when within limit', () => {
+    expect(truncateForRetry('short', 6000)).toBe('short');
+  });
+
+  it('halves until under limit', () => {
+    const long = 'x'.repeat(1000);
+    const result = truncateForRetry(long, 6000);
+    // 6000 > 1000, so no truncation needed actually
+    expect(result.length).toBe(1000);
+  });
+
+  it('truncates oversized text', () => {
+    const long = 'x'.repeat(10000);
+    const result = truncateForRetry(long, 6000);
+    expect(result.length).toBeLessThanOrEqual(6000);
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('stops halving at 256 floor', () => {
+    const long = 'x'.repeat(10000);
+    const result = truncateForRetry(long, 256);
+    expect(result.length).toBe(256);
+  });
+});
+
+describe('embedWithFallback', () => {
+  it('uses fast batch path on success', async () => {
+    const client = makeClient(async (texts) => texts.map((_, i) => vec(i)));
+    const result = await embedWithFallback(['a', 'b', 'c'], client, undefined, 6000);
+    expect(client.embed).toHaveBeenCalledTimes(1);
+    expect(result).toHaveLength(3);
+    expect(result.every((v) => Array.isArray(v))).toBe(true);
+  });
+
+  it('isolates single oversized item on length error', async () => {
+    // Batch call throws 20015; per-item: only the long one fails, short ones succeed.
+    const client = makeClient(async (texts, _purpose, _signal) => {
+      if (texts.length > 1) {
+        // batch path
+        throw new Error('Embedding API error 400: {"code":20015,"message":"The parameter is invalid."}');
+      }
+      const t = texts[0];
+      if (t.length > 100) {
+        throw new Error('Embedding API error 400: {"code":20015,"message":"The parameter is invalid."}');
+      }
+      return [vec(t.length)];
+    });
+    const result = await embedWithFallback(['short', 'x'.repeat(500), 'ok'], client, undefined, 6000);
+    // First item succeeds, second oversized fails (null), third succeeds
+    expect(result[0]).not.toBeNull();
+    expect(result[1]).toBeNull();
+    expect(result[2]).not.toBeNull();
+  });
+
+  it('rescues oversized item via truncation retry', async () => {
+    // Per-item: full text fails but truncated version succeeds.
+    // Models like bge have ~512 token (~2000 char) limits; truncation ladder
+    // goes 6000 → 3000 → 1500, so a text that fails at full length but succeeds
+    // when under ~2000 chars is rescuable.
+    const client = makeClient(async (texts, _purpose, _signal) => {
+      if (texts.length > 1) {
+        throw new Error('400 parameter is invalid');
+      }
+      const t = texts[0];
+      // Accept only texts under 2000 chars (simulating a 512-token bge limit)
+      if (t.length > 2000) {
+        throw new Error('400 too long');
+      }
+      return [vec(t.length)];
+    });
+    // Text longer than retryMaxChars(6000) so truncation actually kicks in
+    const longText = 'y'.repeat(10000);
+    const result = await embedWithFallback([longText], client, undefined, 6000);
+    expect(result[0]).not.toBeNull();
+    // Should have retried with a truncated candidate (<=3000 chars)
+    expect(client.embed.mock.calls.length).toBeGreaterThan(1);
+    // The successful call used a truncated text under 2000 chars
+    const lastCallText = client.embed.mock.calls[client.embed.mock.calls.length - 1][0] as string[];
+    expect(lastCallText[0].length).toBeLessThanOrEqual(2000);
+  });
+
+  it('rethrows non-length errors', async () => {
+    const client = makeClient(async () => {
+      throw new Error('Internal server error 500');
+    });
+    await expect(embedWithFallback(['a', 'b'], client, undefined, 6000)).rejects.toThrow('500');
+  });
+
+  it('propagates abort', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const client = makeClient(async () => [vec(1)]);
+    await expect(embedWithFallback(['a'], client, controller.signal, 6000)).rejects.toThrow('Aborted');
+  });
+});

--- a/src/services/vectorSearchService.ts
+++ b/src/services/vectorSearchService.ts
@@ -361,6 +361,107 @@ export interface IndexProgress {
   total: number;
 }
 
+/**
+ * 判断 embedding 错误是否属于"输入过长"类（如硅基流动 20015）。
+ * 这类错误的特点是：batch 中某一条超 token 限制导致整批失败，
+ * 可以通过降级为逐条 embed 来隔离出真正超限的那条。
+ */
+export function looksLikeLengthError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return (
+    /\b400\b/.test(msg) ||
+    /\b20015\b/.test(msg) ||
+    /parameter is invalid/i.test(msg) ||
+    /input length/i.test(msg) ||
+    /maximum token/i.test(msg) ||
+    /too long/i.test(msg)
+  );
+}
+
+/**
+ * 对最终拼接好的文本做二次截断用于重试。
+ * 逐级折半直到不超过 maxChars。
+ */
+export function truncateForRetry(text: string, maxChars: number): string {
+  // 已经够短，无需截断
+  if (text.length <= maxChars) return text;
+  // 逐级折半 maxChars 直到：要么 text 能放下，要么触达 256 下限
+  let limit = maxChars;
+  while (limit > 256 && text.length > limit) {
+    limit = Math.floor(limit / 2);
+  }
+  return text.slice(0, Math.max(256, limit));
+}
+
+/**
+ * 批量 embed，带单条失败隔离 + 截断重试。
+ * - 正常路径：一次 batch 调用，快。
+ * - 若 batch 抛出"长度类"错误：降级为逐条 embed，只让真正超限的那条失败。
+ * - 非 length 错误（auth/5xx/网络）：直接 rethrow，交由上层整批失败处理。
+ * 返回稀疏数组：成功位置为向量，彻底失败的位置为 null。
+ */
+export async function embedWithFallback(
+  texts: string[],
+  embeddingClient: EmbeddingClient,
+  signal: AbortSignal | undefined,
+  retryMaxChars: number
+): Promise<(number[] | null)[]> {
+  // 快路径：尝试整批
+  try {
+    if (signal?.aborted) throw new Error('Aborted');
+    const vectors = await embeddingClient.embed(texts, 'document', signal);
+    if (Array.isArray(vectors) && vectors.length >= texts.length) {
+      return vectors.slice(0, texts.length);
+    }
+    throw new Error(`Embedding API returned ${vectors?.length ?? 0} vectors for ${texts.length} texts`);
+  } catch (err) {
+    if (signal?.aborted || (err instanceof Error && err.message === 'Aborted')) {
+      throw new Error('Aborted');
+    }
+    // 仅对"长度类"错误降级为逐条；其他错误整批失败
+    if (!looksLikeLengthError(err)) {
+      throw err;
+    }
+  }
+
+  // 慢路径：逐条 embed，单条超限则截断重试
+  const results: (number[] | null)[] = new Array(texts.length).fill(null);
+  for (let i = 0; i < texts.length; i++) {
+    if (signal?.aborted) throw new Error('Aborted');
+    const original = texts[i];
+    // 截断重试阶梯：原始 → 折半 → 再折半
+    const candidates = [
+      original,
+      truncateForRetry(original, retryMaxChars),
+      truncateForRetry(original, Math.floor(retryMaxChars / 2)),
+    ];
+    let succeeded = false;
+    for (const candidate of candidates) {
+      if (!candidate) { succeeded = true; break; } // 空文本直接跳过
+      try {
+        const v = await embeddingClient.embed([candidate], 'document', signal);
+        if (Array.isArray(v) && v.length === 1 && Array.isArray(v[0])) {
+          results[i] = v[0];
+          succeeded = true;
+          break;
+        }
+      } catch (err) {
+        if (signal?.aborted || (err instanceof Error && err.message === 'Aborted')) {
+          throw new Error('Aborted');
+        }
+        // 仍是 length 错误 → 尝试更短的候选；其他错误记录后跳过
+        if (!looksLikeLengthError(err)) {
+          break;
+        }
+      }
+    }
+    if (!succeeded) {
+      results[i] = null;
+    }
+  }
+  return results;
+}
+
 export async function indexAllRepos(
   repos: Repository[],
   embeddingClient: EmbeddingClient,
@@ -376,7 +477,7 @@ export async function indexAllRepos(
     onRepoIndexed?: (repoId: number) => void;
   } = {}
 ): Promise<{ indexed: number; skipped: number; errors: number; error?: string; indexedRepoIds: number[] }> {
-  const { batchSize = 100, onProgress, signal, readmeFetcher, indexMode = 'readme', readmeMaxChars = 6000, incremental, onRepoIndexed } = options;
+  const { batchSize = 32, onProgress, signal, readmeFetcher, indexMode = 'readme', readmeMaxChars = 6000, incremental, onRepoIndexed } = options;
 
   if (!Number.isInteger(batchSize) || batchSize <= 0) {
     throw new Error('batchSize must be a positive integer');
@@ -438,37 +539,47 @@ export async function indexAllRepos(
     const texts = batch.map(repo => buildEmbeddingText(repo, readmeCache.get(repo.full_name), readmeMaxChars));
 
     try {
-      // 1. 调用 Embedding API 生成向量
-      const vectors = await embeddingClient.embed(texts, 'document', signal);
+      // 1. 调用 Embedding API 生成向量（带单条失败隔离 + 截断重试）
+      //    长度类错误（如硅基流动 20015）会降级为逐条 embed，避免整批失败
+      const vectors = await embedWithFallback(texts, embeddingClient, signal, readmeMaxChars);
 
-      // Validate that the embedding API returned the expected number of vectors
-      if (!Array.isArray(vectors) || vectors.length < batch.length) {
-        throw new Error(
-          `Embedding API returned ${vectors?.length ?? 0} vectors for ${batch.length} texts`
-        );
+      // 2. 组装成功项的 Vectorize 格式（跳过 null 的失败项）
+      const vectorizeVectors: VectorizeVector[] = [];
+      let batchErrors = 0;
+      for (let j = 0; j < batch.length; j++) {
+        const vec = vectors[j];
+        if (vec && Array.isArray(vec)) {
+          vectorizeVectors.push({
+            id: String(batch[j].id),
+            values: vec,
+            metadata: {
+              full_name: batch[j].full_name,
+              description: batch[j].description || '',
+              language: batch[j].language || '',
+              stars: batch[j].stargazers_count || 0,
+              tags: batch[j].ai_tags || [],
+            },
+          });
+        } else {
+          batchErrors++;
+        }
       }
 
-      // 2. 组装 Vectorize 格式
-      const vectorizeVectors: VectorizeVector[] = batch.map((repo, j) => ({
-        id: String(repo.id),
-        values: vectors[j],
-        metadata: {
-          full_name: repo.full_name,
-          description: repo.description || '',
-          language: repo.language || '',
-          stars: repo.stargazers_count || 0,
-          tags: repo.ai_tags || [],
-        },
-      }));
-
-      // 3. upsert 到 Worker
+      // 3. upsert 到 Worker（仅当有成功向量时）
       const currentBatch = Math.floor(i / batchSize) + 1;
-      onProgress?.({ phase: 'uploading', done: currentBatch, total: totalBatches });
-      await vectorService.upsert(vectorizeVectors, signal);
-      indexed += batch.length;
-      for (const repo of batch) {
-        indexedRepoIds.push(repo.id);
-        onRepoIndexed?.(repo.id);
+      if (vectorizeVectors.length > 0) {
+        onProgress?.({ phase: 'uploading', done: currentBatch, total: totalBatches });
+        await vectorService.upsert(vectorizeVectors, signal);
+        indexed += vectorizeVectors.length;
+        for (const vec of vectorizeVectors) {
+          const repoId = parseInt(vec.id, 10);
+          indexedRepoIds.push(repoId);
+          onRepoIndexed?.(repoId);
+        }
+      }
+      if (batchErrors > 0) {
+        errors += batchErrors;
+        lastError = `${batchErrors} text(s) failed embedding (likely over token limit)`;
       }
     } catch (err) {
       if (signal?.aborted || (err instanceof Error && err.message === 'Aborted')) {

--- a/src/services/vectorSearchService.ts
+++ b/src/services/vectorSearchService.ts
@@ -351,8 +351,8 @@ export function buildEmbeddingText(repo: Repository, readmeContent?: string, max
 }
 
 /**
- * 全量重建向量索引
- * 遍历所有已分析仓库，分批生成 embedding 并 upsert 到 Worker
+ * 全量/增量重建向量索引
+ * 遍历已分析仓库，分批生成 embedding 并 upsert 到 Worker
  * @param readmeFetcher 可选：获取仓库 README 内容的函数 (owner, repo) => content
  */
 export interface IndexProgress {
@@ -372,37 +372,60 @@ export async function indexAllRepos(
     readmeFetcher?: (owner: string, repo: string, signal?: AbortSignal) => Promise<string>;
     indexMode?: 'description' | 'readme';
     readmeMaxChars?: number;
+    incremental?: boolean;
+    onRepoIndexed?: (repoId: number) => void;
   } = {}
-): Promise<{ indexed: number; skipped: number; errors: number; error?: string }> {
-  const { batchSize = 100, onProgress, signal, readmeFetcher, indexMode = 'readme', readmeMaxChars = 6000 } = options;
+): Promise<{ indexed: number; skipped: number; errors: number; error?: string; indexedRepoIds: number[] }> {
+  const { batchSize = 100, onProgress, signal, readmeFetcher, indexMode = 'readme', readmeMaxChars = 6000, incremental, onRepoIndexed } = options;
 
   if (!Number.isInteger(batchSize) || batchSize <= 0) {
     throw new Error('batchSize must be a positive integer');
   }
 
   // 只索引已分析且未失败的仓库
-  const indexable = repos.filter((r) => r.analyzed_at && !r.analysis_failed);
+  let indexable = repos.filter((r) => r.analyzed_at && !r.analysis_failed);
+  // 增量模式下跳过已索引且内容未更新的仓库
+  if (incremental) {
+    indexable = indexable.filter((r) => {
+      if (!r.vector_indexed_at) return true; // 从未索引
+      // 内容更新后需要重新索引
+      const contentTime = r.last_edited || r.analyzed_at || '';
+      return contentTime > r.vector_indexed_at;
+    });
+  }
   let indexed = 0;
   let errors = 0;
   let lastError = '';
+  const indexedRepoIds: number[] = [];
 
   // 仅在 readme 模式下获取 README 内容
   const shouldFetchReadme = indexMode === 'readme' && readmeFetcher;
   const readmeCache = new Map<string, string>();
   if (shouldFetchReadme) {
-    for (let i = 0; i < indexable.length; i++) {
-      const repo = indexable[i];
+    const CONCURRENCY = 5;
+    let completed = 0;
+
+    for (let i = 0; i < indexable.length; i += CONCURRENCY) {
       if (signal?.aborted) throw new Error('Aborted');
-      onProgress?.({ phase: 'readme', done: i, total: indexable.length });
-      try {
-        const [owner, name] = repo.full_name.split('/');
-        const readme = await readmeFetcher(owner, name, signal);
-        if (readme) readmeCache.set(repo.full_name, readme);
-      } catch {
-        // README 获取失败不影响索引
+
+      const batch = indexable.slice(i, i + CONCURRENCY);
+      const results = await Promise.allSettled(
+        batch.map(async (repo) => {
+          const [owner, name] = repo.full_name.split('/');
+          const readme = await readmeFetcher(owner, name, signal);
+          return { fullName: repo.full_name, readme };
+        })
+      );
+
+      for (const result of results) {
+        if (result.status === 'fulfilled' && result.value.readme) {
+          readmeCache.set(result.value.fullName, result.value.readme);
+        }
       }
+
+      completed = Math.min(completed + batch.length, indexable.length);
+      onProgress?.({ phase: 'readme', done: completed, total: indexable.length });
     }
-    onProgress?.({ phase: 'readme', done: indexable.length, total: indexable.length });
   }
 
   const totalBatches = Math.ceil(indexable.length / batchSize);
@@ -443,6 +466,10 @@ export async function indexAllRepos(
       onProgress?.({ phase: 'uploading', done: currentBatch, total: totalBatches });
       await vectorService.upsert(vectorizeVectors, signal);
       indexed += batch.length;
+      for (const repo of batch) {
+        indexedRepoIds.push(repo.id);
+        onRepoIndexed?.(repo.id);
+      }
     } catch (err) {
       if (signal?.aborted || (err instanceof Error && err.message === 'Aborted')) {
         throw new Error('Aborted');
@@ -456,5 +483,5 @@ export async function indexAllRepos(
     onProgress?.({ phase: 'embedding', done: currentBatch, total: totalBatches });
   }
 
-  return { indexed, skipped: repos.length - indexable.length, errors, error: lastError || undefined };
+  return { indexed, skipped: repos.length - indexable.length, errors, error: lastError || undefined, indexedRepoIds };
 }

--- a/src/services/vectorSearchService.ts
+++ b/src/services/vectorSearchService.ts
@@ -379,18 +379,10 @@ export function looksLikeLengthError(err: unknown): boolean {
 }
 
 /**
- * 对最终拼接好的文本做二次截断用于重试。
- * 逐级折半直到不超过 maxChars。
+ * 对文本做截断，保留下限 256 字符。
  */
 export function truncateForRetry(text: string, maxChars: number): string {
-  // 已经够短，无需截断
-  if (text.length <= maxChars) return text;
-  // 逐级折半 maxChars 直到：要么 text 能放下，要么触达 256 下限
-  let limit = maxChars;
-  while (limit > 256 && text.length > limit) {
-    limit = Math.floor(limit / 2);
-  }
-  return text.slice(0, Math.max(256, limit));
+  return text.slice(0, Math.max(256, Math.min(text.length, maxChars)));
 }
 
 /**
@@ -429,13 +421,13 @@ export async function embedWithFallback(
   for (let i = 0; i < texts.length; i++) {
     if (signal?.aborted) throw new Error('Aborted');
     const original = texts[i];
-    // 截断重试阶梯：每步严格递减，确保不会重复尝试同一长度
-    // step1 = 原文；step2 = min(原文, retryMaxChars)；step3 = 再折半；下限 256
-    const half = Math.floor(retryMaxChars / 2);
+    // 截断重试阶梯：每步严格递减，保留下限 256
+    const firstLimit = Math.max(256, Math.min(retryMaxChars, Math.floor(original.length / 2)));
+    const secondLimit = Math.max(256, Math.floor(firstLimit / 2));
     const candidates = [
       original,
-      truncateForRetry(original, retryMaxChars),
-      truncateForRetry(original, half),
+      truncateForRetry(original, firstLimit),
+      truncateForRetry(original, secondLimit),
     ].filter((c, idx, arr) => idx === 0 || c.length < (arr[idx - 1]?.length ?? Infinity));
     let succeeded = false;
     for (const candidate of candidates) {

--- a/src/services/vectorSearchService.ts
+++ b/src/services/vectorSearchService.ts
@@ -365,15 +365,15 @@ export interface IndexProgress {
  * 判断 embedding 错误是否属于"输入过长"类（如硅基流动 20015）。
  * 这类错误的特点是：batch 中某一条超 token 限制导致整批失败，
  * 可以通过降级为逐条 embed 来隔离出真正超限的那条。
+ * 只匹配明确的长度/token 关键词，避免把通用 400/配置错误误判为可重试。
  */
 export function looksLikeLengthError(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
   return (
-    /\b400\b/.test(msg) ||
     /\b20015\b/.test(msg) ||
-    /parameter is invalid/i.test(msg) ||
     /input length/i.test(msg) ||
     /maximum token/i.test(msg) ||
+    /token limit/i.test(msg) ||
     /too long/i.test(msg)
   );
 }
@@ -449,9 +449,9 @@ export async function embedWithFallback(
         if (signal?.aborted || (err instanceof Error && err.message === 'Aborted')) {
           throw new Error('Aborted');
         }
-        // 仍是 length 错误 → 尝试更短的候选；其他错误记录后跳过
+        // 仍是 length 错误 → 尝试更短的候选；非长度错误（5xx/network/auth）立即抛出
         if (!looksLikeLengthError(err)) {
-          break;
+          throw err;
         }
       }
     }
@@ -489,8 +489,11 @@ export async function indexAllRepos(
   if (incremental) {
     indexable = indexable.filter((r) => {
       if (!r.vector_indexed_at) return true; // 从未索引
-      // 内容更新后需要重新索引
-      const contentTime = r.last_edited || r.analyzed_at || '';
+      // 取 last_edited 与 analyzed_at 中较新者作为内容时间，更新后需要重新索引
+      const contentTime = [r.last_edited, r.analyzed_at]
+        .filter((t): t is string => !!t)
+        .sort()
+        .pop() || '';
       return contentTime > r.vector_indexed_at;
     });
   }

--- a/src/services/vectorSearchService.ts
+++ b/src/services/vectorSearchService.ts
@@ -429,12 +429,14 @@ export async function embedWithFallback(
   for (let i = 0; i < texts.length; i++) {
     if (signal?.aborted) throw new Error('Aborted');
     const original = texts[i];
-    // 截断重试阶梯：原始 → 折半 → 再折半
+    // 截断重试阶梯：每步严格递减，确保不会重复尝试同一长度
+    // step1 = 原文；step2 = min(原文, retryMaxChars)；step3 = 再折半；下限 256
+    const half = Math.floor(retryMaxChars / 2);
     const candidates = [
       original,
       truncateForRetry(original, retryMaxChars),
-      truncateForRetry(original, Math.floor(retryMaxChars / 2)),
-    ];
+      truncateForRetry(original, half),
+    ].filter((c, idx, arr) => idx === 0 || c.length < (arr[idx - 1]?.length ?? Infinity));
     let succeeded = false;
     for (const candidate of candidates) {
       if (!candidate) { succeeded = true; break; } // 空文本直接跳过
@@ -569,15 +571,25 @@ export async function indexAllRepos(
       }
 
       // 3. upsert 到 Worker（仅当有成功向量时）
+      //    Vectorize upsert 是原子的，但用返回的 upserted 数量计数更严谨
       const currentBatch = Math.floor(i / batchSize) + 1;
       if (vectorizeVectors.length > 0) {
         onProgress?.({ phase: 'uploading', done: currentBatch, total: totalBatches });
-        await vectorService.upsert(vectorizeVectors, signal);
-        indexed += vectorizeVectors.length;
-        for (const vec of vectorizeVectors) {
-          const repoId = parseInt(vec.id, 10);
+        const upsertResult = await vectorService.upsert(vectorizeVectors, signal);
+        const upsertedCount = typeof upsertResult?.upserted === 'number'
+          ? Math.min(upsertResult.upserted, vectorizeVectors.length)
+          : vectorizeVectors.length;
+        indexed += upsertedCount;
+        // 仅标记确认 upserted 的 repo（按顺序）
+        for (let j = 0; j < upsertedCount; j++) {
+          const repoId = parseInt(vectorizeVectors[j].id, 10);
           indexedRepoIds.push(repoId);
           onRepoIndexed?.(repoId);
+        }
+        // 若 worker 返回的 upserted 少于发送数，差额计入 errors
+        const notUpserted = vectorizeVectors.length - upsertedCount;
+        if (notUpserted > 0) {
+          batchErrors += notUpserted;
         }
       }
       if (batchErrors > 0) {

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -1050,6 +1050,7 @@ export const useAppStore = create<AppState & AppActions>()(
       embeddingConfigs: [],
       activeEmbeddingConfig: null,
       vectorSearchConfig: { enabled: false, workerUrl: '', authToken: '', embeddingConfigId: '', indexMode: 'readme', readmeMaxChars: 6000 },
+      vectorSearchStatus: { connected: false, vectorCount: 0, dimensions: 0 },
       vectorIndexingState: { isIndexing: false, phase: null, phaseDone: 0, phaseTotal: 0, result: null },
       webdavConfigs: [],
       activeWebDAVConfig: null,

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -284,6 +284,8 @@ interface AppActions {
   // Repository actions
   setRepositories: (repos: Repository[]) => void;
   updateRepository: (repo: Repository) => void;
+  /** 批量更新多个仓库的指定字段，保留当前过滤的 searchResults 不被重置 */
+  updateRepositoriesMetadata: (updates: { id: number; patch: Partial<Repository> }[]) => void;
   addRepository: (repo: Repository) => void;
   setLoading: (loading: boolean) => void;
   setSyncingStars: (syncing: boolean) => void;
@@ -1169,6 +1171,41 @@ export const useAppStore = create<AppState & AppActions>()(
           searchResults: searchResultsResult.repositories
         };
       }),
+      updateRepositoriesMetadata: (updates) => set((state) => {
+        if (!updates.length) return state;
+        const patchMap = new Map(updates.map((u) => [u.id, u.patch]));
+
+        const applyPatches = (list: Repository[]): { repositories: Repository[]; changed: boolean } => {
+          let changed = false;
+          // 用 Map 索引避免多次 findIndex
+          const indexById = new Map(list.map((r, i) => [r.id, i]));
+          const next = list.slice();
+          for (const [id, patch] of patchMap) {
+            const idx = indexById.get(id);
+            if (idx === undefined) continue;
+            const merged = { ...next[idx], ...patch };
+            if (!areRepositoryRecordsEqual(next[idx], merged)) {
+              next[idx] = merged;
+              changed = true;
+            }
+          }
+          return { repositories: next, changed };
+        };
+
+        const repositoriesResult = applyPatches(state.repositories);
+        const searchResultsResult = state.searchResults === state.repositories
+          ? repositoriesResult
+          : applyPatches(state.searchResults);
+
+        if (!repositoriesResult.changed && !searchResultsResult.changed) {
+          return state;
+        }
+
+        return {
+          repositories: repositoriesResult.repositories,
+          searchResults: searchResultsResult.repositories,
+        };
+      }),
       addRepository: (repo) => set((state) => {
         // 检查是否已存在相同 full_name 的仓库
         const existingRepoIndex = state.repositories.findIndex(r => r.full_name === repo.full_name);
@@ -2018,6 +2055,8 @@ export const useAppStore = create<AppState & AppActions>()(
 
         // 持久化向量搜索配置
         vectorSearchConfig: state.vectorSearchConfig,
+        // 持久化向量搜索状态（vectorCount 等，跨重启保留）
+        vectorSearchStatus: state.vectorSearchStatus,
 
         // 持久化WebDAV配置
         webdavConfigs: state.webdavConfigs,
@@ -2137,6 +2176,12 @@ export const useAppStore = create<AppState & AppActions>()(
         if (state && typeof state.defaultCategoryOverrides !== 'object') {
           console.log('Migrating from old version: initializing defaultCategoryOverrides');
           state.defaultCategoryOverrides = {};
+        }
+
+        // 从旧版本升级时，确保 vectorSearchStatus 字段存在（vectorCount 等）
+        if (state && !state.vectorSearchStatus) {
+          console.log('Migrating from old version: initializing vectorSearchStatus');
+          state.vectorSearchStatus = { connected: false, vectorCount: 0, dimensions: 0 };
         }
 
         // 迁移仓库数据中的旧标记

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,7 @@ export interface Repository {
   custom_category?: string;
   category_locked?: boolean;
   last_edited?: string;
+  vector_indexed_at?: string;  // ISO timestamp of last successful vector indexing
   last_release_fetch_time?: string;  // ISO timestamp, for incremental sync
   has_fetched_releases?: boolean;   // whether this repo has been synced for releases
 }

--- a/src/utils/repositoryMerge.ts
+++ b/src/utils/repositoryMerge.ts
@@ -14,6 +14,7 @@ const LOCAL_REPOSITORY_FIELDS: Array<keyof Repository> = [
   'custom_category',
   'category_locked',
   'last_edited',
+  'vector_indexed_at',
 ];
 
 export function mergeRepositoriesPreservingLocalMetadata(


### PR DESCRIPTION
## 改动概览

### 1. 增量索引真正增量 — `vector_indexed_at` 字段
- 全数据流添加 `vector_indexed_at`：Repository 类型 → SQLite schema → backend CRUD → sync import → repositoryMerge
- 增量索引只索引未索引或内容已更新的仓库（比较 `vector_indexed_at` vs `last_edited`/`analyzed_at`）
- 重建索引前清除所有 `vector_indexed_at`，完成后只为成功索引的 repo 设置

### 2. 未索引数量 badge
- 增量索引按钮旁显示待索引仓库数量，为 0 时 disabled

### 3. README 获取并发化
- 串行 `for` 循环 → 并发 5 的 `Promise.allSettled` 批次

### 4. 同步按钮不再触发自动索引
- 移除同步后的自动索引代码块（因新仓库没有 `analyzed_at`，实际是空操作）

### 审计修复
- `onRepoIndexed` 用 `getState()` 获取最新数据，避免 stale closure 覆盖并发编辑
- `vectorCount` 增量时累加，重建时替换全部

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full end-to-end `vector_indexed_at` support: schema migration, repository API responses, bulk upsert, sync import/export, and local merge preservation.
  * Updated vector indexing controls with full rebuild and incremental indexing (including accurate “unindexed” counting and status/progress updates).

* **Bug Fixes**
  * Improved embedding reliability by retrying with progressively truncated per-item text on length/token-limit errors.
  * Added `vector_indexed_at` validation for repository updates.
  * Cleanup query now requests different metadata while keeping deletion behavior unchanged.

* **Chores / Tests**
  * Persisted/restored vector search status across restarts and added/updated unit tests for fallback and truncation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->