### PR TITLE
fix: stabilize real-time search during IME input

### DIFF
--- a/src/components/ForkTimeline.test.tsx
+++ b/src/components/ForkTimeline.test.tsx
@@ -132,8 +132,10 @@ describe('ForkTimeline owner filtering', () => {
     } as unknown as GitHubApiService));
   });
 
-  it('shows only personal-account forks by default', () => {
+  it('shows only personal-account forks by default', async () => {
     render(<ForkTimeline />);
+
+    await screen.findByLabelText('选择 Fork 拥有者');
 
     expect(screen.getByText('personal-fork')).toBeInTheDocument();
     expect(screen.queryByText('org-fork')).not.toBeInTheDocument();

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -848,16 +848,12 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = memo(({
         }
       );
 
-      if (hasImagesOnly) {
-        return (
-          <div className="text-gray-900 dark:text-text-secondary mb-2 leading-relaxed flex flex-wrap items-center justify-center gap-3">
-            {children}
-          </div>
-        );
-      }
-
       return (
-        <p className="text-gray-900 dark:text-text-secondary mb-2 leading-relaxed">
+        <p className={`text-gray-900 dark:text-text-secondary mb-2 leading-relaxed ${
+          hasImagesOnly
+            ? 'flex flex-wrap items-center justify-center gap-3'
+            : ''
+        }`}>
           {children}
         </p>
       );

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -476,7 +476,7 @@ const MarkdownImage: React.FC<{ src?: string; alt?: string; baseUrl?: string }> 
 
   if (hasError) {
     return (
-      <div className="my-2 px-3 py-2 bg-gray-100 dark:bg-white/[0.04] rounded border border-black/[0.06] dark:border-white/[0.04] flex items-center gap-2 text-xs">
+      <span className="my-2 px-3 py-2 bg-gray-100 dark:bg-white/[0.04] rounded border border-black/[0.06] dark:border-white/[0.04] flex items-center gap-2 text-xs">
         <svg className="w-4 h-4 text-gray-500 dark:text-text-tertiary flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
         </svg>
@@ -490,7 +490,7 @@ const MarkdownImage: React.FC<{ src?: string; alt?: string; baseUrl?: string }> 
         >
           {language === 'zh' ? '重试' : 'Retry'}
         </button>
-      </div>
+      </span>
     );
   }
 
@@ -527,17 +527,17 @@ const MarkdownImage: React.FC<{ src?: string; alt?: string; baseUrl?: string }> 
           </span>
         </span>
       ) : (
-        <div className="my-4 flex flex-col items-center group/img">
+        <span className="my-4 flex flex-col items-center group/img">
           {isLoading && (
-            <div className="w-full max-w-md h-16 bg-light-surface dark:bg-panel-dark rounded-lg flex items-center justify-center animate-pulse gap-2">
+            <span className="w-full max-w-md h-16 bg-light-surface dark:bg-panel-dark rounded-lg flex items-center justify-center animate-pulse gap-2">
               <svg className="w-5 h-5 text-gray-300 dark:text-text-tertiary" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" />
               </svg>
               <span className="text-xs text-gray-400 dark:text-text-quaternary">{language === 'zh' ? '加载中...' : 'Loading...'}</span>
-            </div>
+            </span>
           )}
 
-          <div className={`relative inline-block rounded-xl overflow-hidden shadow-sm hover:shadow-lg transition-shadow duration-300 ${isLoading ? 'hidden' : ''}`}>
+          <span className={`relative inline-block rounded-xl overflow-hidden shadow-sm hover:shadow-lg transition-shadow duration-300 ${isLoading ? 'hidden' : ''}`}>
             <img
               ref={imgRef}
               src={imageUrl}
@@ -559,11 +559,11 @@ const MarkdownImage: React.FC<{ src?: string; alt?: string; baseUrl?: string }> 
               onError={handleImageError}
               onClick={handleImageClick}
             />
-            <div className="absolute inset-0 rounded-xl ring-1 ring-inset ring-black/5 dark:ring-white/5 pointer-events-none" />
-          </div>
+            <span className="absolute inset-0 rounded-xl ring-1 ring-inset ring-black/5 dark:ring-white/5 pointer-events-none" />
+          </span>
 
           {!isLoading && !hasError && (
-            <div data-translate="false" className="text-center mt-2 text-xs text-gray-400 dark:text-text-tertiary opacity-0 group-hover/img:opacity-100 transition-opacity duration-200 flex items-center gap-3">
+            <span data-translate="false" className="text-center mt-2 text-xs text-gray-400 dark:text-text-tertiary opacity-0 group-hover/img:opacity-100 transition-opacity duration-200 flex items-center gap-3">
               <span>
                 {isInsideLink
                   ? (language === 'zh' ? '单击放大 · Ctrl+点击打开链接' : 'Click to zoom · Ctrl+Click to open link')
@@ -576,11 +576,11 @@ const MarkdownImage: React.FC<{ src?: string; alt?: string; baseUrl?: string }> 
               {naturalWidth > 0 && (
                 <span>{naturalWidth} × {naturalHeight}</span>
               )}
-            </div>
+            </span>
           )}
 
           {!isLoading && !hasError && isInsideLink && parentLinkHref && (
-            <div
+            <span
               data-translate="false"
               className="text-center mt-1 text-xs text-brand-violet dark:text-brand-violet opacity-0 group-hover/img:opacity-100 transition-opacity flex items-center justify-center gap-1 cursor-pointer"
               onClick={(e) => {
@@ -595,9 +595,9 @@ const MarkdownImage: React.FC<{ src?: string; alt?: string; baseUrl?: string }> 
               <span className="truncate max-w-[200px]" title={parentLinkHref}>
                 {truncateUrl(parentLinkHref)}
               </span>
-            </div>
+            </span>
           )}
-        </div>
+        </span>
       )}
 
       {isZoomed && createPortal(
@@ -847,12 +847,17 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = memo(({
           return false;
         }
       );
+
+      if (hasImagesOnly) {
+        return (
+          <div className="text-gray-900 dark:text-text-secondary mb-2 leading-relaxed flex flex-wrap items-center justify-center gap-3">
+            {children}
+          </div>
+        );
+      }
+
       return (
-        <p className={`text-gray-900 dark:text-text-secondary mb-2 leading-relaxed ${
-          hasImagesOnly
-            ? 'flex flex-wrap items-center justify-center gap-3'
-            : ''
-        }`}>
+        <p className="text-gray-900 dark:text-text-secondary mb-2 leading-relaxed">
           {children}
         </p>
       );

--- a/src/components/SearchBar.test.tsx
+++ b/src/components/SearchBar.test.tsx
@@ -1,8 +1,8 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SearchBar } from './SearchBar';
 import { useAppStore } from '../store/useAppStore';
-import type { SearchFilters } from '../types';
+import type { Repository, SearchFilters } from '../types';
 
 vi.mock('../store/useAppStore', () => ({
   useAppStore: vi.fn(),
@@ -51,6 +51,27 @@ const defaultSearchFilters: SearchFilters = {
   sortBy: 'stars',
   sortOrder: 'desc',
 };
+
+const createRepository = (overrides: Partial<Repository>): Repository => ({
+  id: 1,
+  name: 'react',
+  full_name: 'facebook/react',
+  description: null,
+  html_url: 'https://github.com/facebook/react',
+  stargazers_count: 1000,
+  forks_count: 100,
+  forks: 100,
+  language: 'TypeScript',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-02T00:00:00Z',
+  pushed_at: '2024-01-03T00:00:00Z',
+  owner: {
+    login: 'facebook',
+    avatar_url: 'https://example.com/avatar.png',
+  },
+  topics: [],
+  ...overrides,
+});
 
 const createStoreState = (overrides: Partial<ReturnType<typeof baseStoreState>> = {}) => ({
   ...baseStoreState(),
@@ -140,5 +161,80 @@ describe('SearchBar', () => {
     });
     expect(setSearchFilters).toHaveBeenCalledWith({ query: '' });
     expect(setSearchFilters).toHaveBeenCalledWith({ sortOrder: 'asc' });
+  });
+
+  it('pauses real-time search for IME preedit text and resumes after composition ends', () => {
+    vi.useFakeTimers();
+    const setSearchResults = vi.fn();
+    currentState = createStoreState({
+      repositories: [
+        createRepository({ id: 1, name: 'nested-rain', full_name: 'owner/nested-rain' }),
+        createRepository({ id: 2, name: 'vector-search', full_name: 'owner/vector-search' }),
+      ],
+      setSearchResults,
+    });
+    mockUseAppStore.mockReturnValue(currentState as ReturnType<typeof useAppStore>);
+
+    try {
+      render(<SearchBar />);
+      const input = screen.getByRole('textbox');
+
+      fireEvent.compositionStart(input);
+      fireEvent.change(input, { target: { value: 'rain' } });
+
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(setSearchResults).not.toHaveBeenCalledWith([
+        expect.objectContaining({ name: 'nested-rain' }),
+      ]);
+
+      fireEvent.compositionEnd(input, { currentTarget: { value: 'rain' } });
+
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(setSearchResults).toHaveBeenLastCalledWith([
+        expect.objectContaining({ name: 'nested-rain' }),
+      ]);
+      expect(screen.getByText('实时搜索模式 - 匹配仓库名称')).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('resets stale real-time results when the input becomes whitespace-only', () => {
+    vi.useFakeTimers();
+    const repositories = [
+      createRepository({ id: 1, name: 'nested-rain', full_name: 'owner/nested-rain' }),
+      createRepository({ id: 2, name: 'vector-search', full_name: 'owner/vector-search' }),
+    ];
+    const setSearchResults = vi.fn();
+    currentState = createStoreState({
+      repositories,
+      setSearchResults,
+    });
+    mockUseAppStore.mockReturnValue(currentState as ReturnType<typeof useAppStore>);
+
+    try {
+      render(<SearchBar />);
+      const input = screen.getByRole('textbox');
+
+      fireEvent.change(input, { target: { value: 'rain' } });
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(setSearchResults).toHaveBeenLastCalledWith([
+        expect.objectContaining({ name: 'nested-rain' }),
+      ]);
+
+      fireEvent.change(input, { target: { value: '   ' } });
+
+      expect(setSearchResults).toHaveBeenLastCalledWith(repositories);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/components/SearchBar.test.tsx
+++ b/src/components/SearchBar.test.tsx
@@ -190,7 +190,7 @@ describe('SearchBar', () => {
         expect.objectContaining({ name: 'nested-rain' }),
       ]);
 
-      fireEvent.compositionEnd(input, { currentTarget: { value: 'rain' } });
+      fireEvent.compositionEnd(input);
 
       act(() => {
         vi.advanceTimersByTime(300);

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -107,6 +107,7 @@ export const SearchBar: React.FC = () => {
   const [availableTags, setAvailableTags] = useState<string[]>([]);
   const [availablePlatforms, setAvailablePlatforms] = useState<string[]>([]);
   const [isRealTimeSearch, setIsRealTimeSearch] = useState(false);
+  const [isComposing, setIsComposing] = useState(false);
   
   const allCategories = useMemo(() => 
     getAllCategories(customCategories, language, hiddenDefaultCategoryIds, defaultCategoryOverrides),
@@ -251,33 +252,35 @@ export const SearchBar: React.FC = () => {
 
   // Real-time search effect for repository name matching
   useEffect(() => {
-    if (searchQuery && isRealTimeSearch) {
+    if (searchQuery.trim() && isRealTimeSearch && !isComposing) {
       const timeoutId = setTimeout(() => {
         performRealTimeSearch(searchQuery);
       }, 300); // 300ms debounce to avoid too frequent searches
 
       return () => clearTimeout(timeoutId);
-    } else if (!searchQuery) {
-      // Reset to show all repositories when search is empty
+    } else if (!searchQuery.trim()) {
+      // Reset to show all repositories when search is empty or whitespace-only
       performBasicFilter();
     }
     // Search helpers are intentionally kept as local closures; the explicit deps below
     // cover the state they read without causing a search loop on every render.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchQuery, isRealTimeSearch, repositories, allCategories]);
+  }, [searchQuery, isRealTimeSearch, isComposing, repositories, allCategories]);
 
-  // Handle composition events for better IME support (Chinese input)
+  const updateRealTimeSearchState = (value: string) => {
+    setIsRealTimeSearch(Boolean(value.trim()));
+  };
+
+  // Handle composition events for IME input (Chinese/Japanese/Korean).
+  // Track composition separately so the debounce pauses for preedit text without
+  // relying on composition events to re-arm real-time search after typing.
   const handleCompositionStart = () => {
-    // Pause real-time search during IME composition
-    setIsRealTimeSearch(false);
+    setIsComposing(true);
   };
 
   const handleCompositionEnd = (e: React.CompositionEvent<HTMLInputElement>) => {
-    // Resume real-time search after IME composition ends
-    const value = e.currentTarget.value;
-    if (value) {
-      setIsRealTimeSearch(true);
-    }
+    setIsComposing(false);
+    updateRealTimeSearchState(e.currentTarget.value);
   };
 
   const performRealTimeSearch = (query: string) => {
@@ -712,12 +715,9 @@ export const SearchBar: React.FC = () => {
       setSearchFilters({ query: '' });
     }
 
-    // Enable real-time search mode when user starts typing
-    if (value && !isRealTimeSearch) {
-      setIsRealTimeSearch(true);
-    } else if (!value && isRealTimeSearch) {
-      setIsRealTimeSearch(false);
-    }
+    // Keep real-time search armed whenever the input has searchable text.
+    // A separate composing flag pauses debounce while IME preedit text is active.
+    updateRealTimeSearchState(value);
 
     // Show search history when input is focused and empty
     if (!value && searchHistory.length > 0) {

--- a/src/components/settings/VectorSearchSettings.tsx
+++ b/src/components/settings/VectorSearchSettings.tsx
@@ -336,7 +336,7 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
     } finally {
       setAbortController(null);
     }
-  }, [createClients, formIndexMode, formReadmeMaxChars, formDimensions, updateRepositoriesMetadata, setVectorSearchStatus, setVectorIndexingState, vectorSearchConfig.embeddingFormatVersion, setVectorSearchConfig]);
+  }, [createClients, formIndexMode, formReadmeMaxChars, formDimensions, updateRepositoriesMetadata, setVectorSearchStatus, setVectorIndexingState, setVectorSearchConfig]);
 
   const handleIncrementalIndex = useCallback(async () => {
     const clients = createClients();


### PR DESCRIPTION
## Summary
- Fix real-time repository-name search so IME composition pauses preedit matching and resumes after composition ends
- Reset stale real-time results when the search input becomes whitespace-only
- Add SearchBar regression tests for IME preedit and whitespace-only input cases
- Clean up existing React warnings in MarkdownRenderer/ForkTimeline tests and VectorSearchSettings hook deps

## Testing
- npm run test:run -- SearchBar.test.tsx
- npm run test:run -- MarkdownRenderer.test.tsx ForkTimeline.test.tsx
- npm run test:run
- npm run lint
- npm run build

## Notes
- Browser-driven verification was intentionally skipped per maintainer instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search now behaves better with IME input, pausing live results while composing text and resuming afterward.
  * Clearing a search back to whitespace now restores the full repository list instead of leaving stale results.

* **Bug Fixes**
  * Improved Markdown image rendering consistency, including loading/error states and zoom/hover presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #232
