### PR TITLE
fix: preserve embeddingFormatVersion across store hydration (Fixes #234)

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { Search, X, SlidersHorizontal, Monitor, Smartphone, Globe, Terminal, Package, CheckCircle, Bell, BellOff, Apple, Bot, Edit3, Lock, Unlock, AlertCircle, ChevronDown, RefreshCw, Clock } from 'lucide-react';
 import { useAppStore, getAllCategories } from '../store/useAppStore';
 import { AIService } from '../services/aiService';
+import { EmbeddingClient, VectorSearchService } from '../services/vectorSearchService';
 import { GitHubApiService } from '../services/githubApi';
 import { forceSyncToBackend } from '../services/autoSync';
 import { Repository } from '../types';
@@ -538,7 +539,6 @@ export const SearchBar: React.FC = () => {
 
       if (vsConfig?.enabled && vsConfig?.workerUrl && activeEmbConfig) {
         try {
-          const { VectorSearchService, EmbeddingClient } = await import('../services/vectorSearchService');
           const embeddingClient = new EmbeddingClient(activeEmbConfig);
           const vectorService = new VectorSearchService(vsConfig);
 
@@ -550,7 +550,6 @@ export const SearchBar: React.FC = () => {
             let hydeTimer: ReturnType<typeof setTimeout> | null = null;
             try {
               setSearchPhase(t('AI 分析查询...', 'AI analyzing query...'));
-              const { AIService } = await import('../services/aiService');
               const hydeService = new AIService(hydeConfig, language);
               embeddingQuery = await Promise.race([
                 hydeService.generateHyDEQuery(searchQuery, hydeAbort.signal).catch(() => searchQuery),
@@ -616,7 +615,6 @@ export const SearchBar: React.FC = () => {
                 if (rerankConfig && vsConfig.enableReranking !== false) {
                   try {
                     setSearchPhase(t('AI 语义重排序...', 'AI semantic reranking...'));
-                    const { AIService } = await import('../services/aiService');
                     const rerankService = new AIService(rerankConfig, language);
                     reranked = await rerankService.searchRepositoriesWithSemanticReranking(scoredRepos, searchQuery);
                     rerankSucceeded = true;

--- a/src/components/settings/VectorSearchSettings.tsx
+++ b/src/components/settings/VectorSearchSettings.tsx
@@ -156,7 +156,6 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
       searchTopK: formSearchTopK,
       enableHyDE: formEnableHyDE,
       enableReranking: formEnableReranking,
-      embeddingFormatVersion: EMBEDDING_FORMAT_VERSION,
     });
     setWorkerSaved(true);
     setTimeout(() => setWorkerSaved(false), 2000);
@@ -231,9 +230,11 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
       .pop() || '';
     return contentTime > r.vector_indexed_at;
   }).length;
+  const indexableCount = repositories.filter((r) => r.analyzed_at && !r.analysis_failed).length;
 
   // 嵌入文本格式版本升级时，即使无内容更新也需要触发增量索引来重建所有向量
   const formatVersionNeedsReindex = (vectorSearchConfig.embeddingFormatVersion ?? 1) < EMBEDDING_FORMAT_VERSION;
+  const incrementalTargetCount = formatVersionNeedsReindex ? indexableCount : unindexedCount;
 
   const createClients = useCallback(() => {
     if (!activeConfig) return null;
@@ -347,8 +348,10 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
     setVectorIndexingState({ isIndexing: true, phase: null, phaseDone: 0, phaseTotal: 0, result: null });
 
     try {
-      // 每次点击时读取最新的 repositories，避免闭包捕获过期数据
-      const currentRepos = useAppStore.getState().repositories;
+      // 每次点击时读取最新的 repositories / vectorSearchConfig，避免闭包捕获过期数据
+      const currentState = useAppStore.getState();
+      const currentRepos = currentState.repositories;
+      const currentEmbeddingFormatVersion = currentState.vectorSearchConfig.embeddingFormatVersion;
 
       // 记录索引前无 vector_indexed_at 的 repo，用于精确计算新增数量
       const newlyIndexedRepoIds = new Set(
@@ -368,7 +371,7 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
         indexMode: formIndexMode,
         readmeMaxChars: formReadmeMaxChars,
         incremental: true,
-        formatVersion: vectorSearchConfig.embeddingFormatVersion,
+        formatVersion: currentEmbeddingFormatVersion,
         currentFormatVersion: EMBEDDING_FORMAT_VERSION,
         onRepoIndexed: (repoId) => {
           stampedRepoIds.push(repoId);
@@ -427,7 +430,7 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
     } finally {
       setAbortController(null);
     }
-  }, [createClients, formIndexMode, formReadmeMaxChars, formDimensions, updateRepositoriesMetadata, setVectorSearchStatus, setVectorIndexingState, vectorSearchConfig.embeddingFormatVersion, setVectorSearchConfig]);
+  }, [createClients, formIndexMode, formReadmeMaxChars, formDimensions, updateRepositoriesMetadata, setVectorSearchStatus, setVectorIndexingState, setVectorSearchConfig]);
 
   const handleAbortIndexing = useCallback(() => {
     abortController?.abort();
@@ -885,14 +888,14 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
           </button>
           <button
             onClick={handleIncrementalIndex}
-            disabled={isIndexing || !isConfigComplete || (unindexedCount === 0 && !formatVersionNeedsReindex)}
+            disabled={isIndexing || !isConfigComplete || incrementalTargetCount === 0}
             className="flex items-center gap-2 px-4 py-2 text-sm bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isIndexing ? <Loader2 className="w-4 h-4 animate-spin" /> : <RefreshCw className="w-4 h-4" />}
             {t('增量索引', 'Incremental Index')}
-            {unindexedCount > 0 && (
+            {incrementalTargetCount > 0 && (
               <span className="ml-1 px-2 py-0.5 text-xs bg-brand-indigo text-white rounded-full">
-                {unindexedCount}
+                {incrementalTargetCount}
               </span>
             )}
           </button>

--- a/src/components/settings/VectorSearchSettings.tsx
+++ b/src/components/settings/VectorSearchSettings.tsx
@@ -12,7 +12,11 @@ import {
   ChevronRight,
   Zap,
 } from 'lucide-react';
-import { useAppStore } from '../../store/useAppStore';
+import {
+  LEGACY_EMBEDDING_FORMAT_VERSION,
+  isKnownEmbeddingFormatVersion,
+  useAppStore,
+} from '../../store/useAppStore';
 import {
   EmbeddingClient,
   VectorSearchService,
@@ -233,7 +237,10 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
   const indexableCount = repositories.filter((r) => r.analyzed_at && !r.analysis_failed).length;
 
   // 嵌入文本格式版本升级时，即使无内容更新也需要触发增量索引来重建所有向量
-  const formatVersionNeedsReindex = (vectorSearchConfig.embeddingFormatVersion ?? 1) < EMBEDDING_FORMAT_VERSION;
+  const storedEmbeddingFormatVersion = isKnownEmbeddingFormatVersion(vectorSearchConfig.embeddingFormatVersion)
+    ? vectorSearchConfig.embeddingFormatVersion
+    : LEGACY_EMBEDDING_FORMAT_VERSION;
+  const formatVersionNeedsReindex = storedEmbeddingFormatVersion < EMBEDDING_FORMAT_VERSION;
   const incrementalTargetCount = formatVersionNeedsReindex ? indexableCount : unindexedCount;
 
   const createClients = useCallback(() => {
@@ -351,7 +358,9 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
       // 每次点击时读取最新的 repositories / vectorSearchConfig，避免闭包捕获过期数据
       const currentState = useAppStore.getState();
       const currentRepos = currentState.repositories;
-      const currentEmbeddingFormatVersion = currentState.vectorSearchConfig.embeddingFormatVersion;
+      const currentEmbeddingFormatVersion = isKnownEmbeddingFormatVersion(currentState.vectorSearchConfig.embeddingFormatVersion)
+        ? currentState.vectorSearchConfig.embeddingFormatVersion
+        : LEGACY_EMBEDDING_FORMAT_VERSION;
 
       // 记录索引前无 vector_indexed_at 的 repo，用于精确计算新增数量
       const newlyIndexedRepoIds = new Set(

--- a/src/services/vectorSearchService.test.ts
+++ b/src/services/vectorSearchService.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
+import { Repository } from '../types';
 import {
   looksLikeLengthError,
   truncateForRetry,
   embedWithFallback,
+  indexAllRepos,
+  EMBEDDING_FORMAT_VERSION,
 } from './vectorSearchService';
 
 // Minimal mock: only the `.embed` method is used by embedWithFallback.
@@ -12,6 +15,37 @@ const makeClient = (
 ) => ({ embed: vi.fn(embedImpl) }) as unknown as Parameters<typeof embedWithFallback>[1];
 
 const vec = (n: number) => [n, n + 1, n + 2];
+
+const makeRepository = (id: number, overrides: Partial<Repository> = {}): Repository => ({
+  id,
+  name: `repo-${id}`,
+  full_name: `owner/repo-${id}`,
+  description: `Repository ${id}`,
+  html_url: `https://github.com/owner/repo-${id}`,
+  stargazers_count: 10,
+  forks_count: 1,
+  forks: 1,
+  language: 'TypeScript',
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-02T00:00:00.000Z',
+  pushed_at: '2026-01-03T00:00:00.000Z',
+  owner: {
+    login: 'owner',
+    avatar_url: 'https://github.com/avatar.png',
+  },
+  topics: ['test'],
+  analyzed_at: '2026-01-04T00:00:00.000Z',
+  vector_indexed_at: '2026-01-05T00:00:00.000Z',
+  ...overrides,
+});
+
+const makeIndexClient = () => ({
+  embed: vi.fn(async (texts: string[]) => texts.map((_, i) => vec(i))),
+}) as unknown as Parameters<typeof indexAllRepos>[1];
+
+const makeVectorService = () => ({
+  upsert: vi.fn(async (vectors: Array<{ id: string }>) => ({ upserted: vectors.length })),
+}) as unknown as Parameters<typeof indexAllRepos>[2];
 
 // 硅基流动真实的长度超限 payload（code 20015）
 const LENGTH_ERROR = () =>
@@ -64,6 +98,68 @@ describe('truncateForRetry', () => {
     const long = 'x'.repeat(10000);
     const result = truncateForRetry(long, 256);
     expect(result.length).toBe(256);
+  });
+});
+
+describe('indexAllRepos incremental filtering', () => {
+  it('skips already indexed unchanged repos when format version is current', async () => {
+    const client = makeIndexClient();
+    const vectorService = makeVectorService();
+    const repos = [
+      makeRepository(1),
+      makeRepository(2, { vector_indexed_at: undefined }),
+      makeRepository(3, {
+        vector_indexed_at: '2026-01-05T00:00:00.000Z',
+        last_edited: '2026-01-06T00:00:00.000Z',
+      }),
+      makeRepository(4, { analyzed_at: undefined, vector_indexed_at: undefined }),
+      makeRepository(5, { analysis_failed: true, vector_indexed_at: undefined }),
+    ];
+
+    const indexedIds: number[] = [];
+    const result = await indexAllRepos(repos, client, vectorService, {
+      incremental: true,
+      formatVersion: EMBEDDING_FORMAT_VERSION,
+      currentFormatVersion: EMBEDDING_FORMAT_VERSION,
+      indexMode: 'description',
+      onRepoIndexed: (repoId) => indexedIds.push(repoId),
+    });
+
+    expect(client.embed).toHaveBeenCalledTimes(1);
+    expect(vectorService.upsert).toHaveBeenCalledTimes(1);
+    expect(indexedIds).toEqual([2, 3]);
+    expect(result.indexedRepoIds).toEqual([2, 3]);
+    expect(result.indexed).toBe(2);
+  });
+
+  it('reindexes all indexable repos when format version is old', async () => {
+    const client = makeIndexClient();
+    const vectorService = makeVectorService();
+    const repos = [
+      makeRepository(1),
+      makeRepository(2, { vector_indexed_at: undefined }),
+      makeRepository(3, {
+        vector_indexed_at: '2026-01-05T00:00:00.000Z',
+        last_edited: '2026-01-06T00:00:00.000Z',
+      }),
+      makeRepository(4, { analyzed_at: undefined, vector_indexed_at: undefined }),
+      makeRepository(5, { analysis_failed: true, vector_indexed_at: undefined }),
+    ];
+
+    const indexedIds: number[] = [];
+    const result = await indexAllRepos(repos, client, vectorService, {
+      incremental: true,
+      formatVersion: EMBEDDING_FORMAT_VERSION - 1,
+      currentFormatVersion: EMBEDDING_FORMAT_VERSION,
+      indexMode: 'description',
+      onRepoIndexed: (repoId) => indexedIds.push(repoId),
+    });
+
+    expect(client.embed).toHaveBeenCalledTimes(1);
+    expect(vectorService.upsert).toHaveBeenCalledTimes(1);
+    expect(indexedIds).toEqual([1, 2, 3]);
+    expect(result.indexedRepoIds).toEqual([1, 2, 3]);
+    expect(result.indexed).toBe(3);
   });
 });
 

--- a/src/services/vectorSearchService.test.ts
+++ b/src/services/vectorSearchService.test.ts
@@ -101,25 +101,30 @@ describe('truncateForRetry', () => {
   });
 });
 
+const incrementalFilteringRepos = () => [
+  makeRepository(1),
+  makeRepository(2, { vector_indexed_at: undefined }),
+  makeRepository(3, {
+    vector_indexed_at: '2026-01-05T00:00:00.000Z',
+    last_edited: '2026-01-06T00:00:00.000Z',
+  }),
+  makeRepository(4, { analyzed_at: undefined, vector_indexed_at: undefined }),
+  makeRepository(5, { analysis_failed: true, vector_indexed_at: undefined }),
+];
+
 describe('indexAllRepos incremental filtering', () => {
-  it('skips already indexed unchanged repos when format version is current', async () => {
+  // formatVersion / expected：当前版本只索引新增/更新；旧版本或缺省（#234 回归路径）触发全量重建
+  it.each([
+    { formatVersion: EMBEDDING_FORMAT_VERSION, expected: [2, 3], expectation: 'current format version skips indexed unchanged repos' },
+    { formatVersion: EMBEDDING_FORMAT_VERSION - 1, expected: [1, 2, 3], expectation: 'old format version reindexes all indexable repos' },
+    { formatVersion: undefined, expected: [1, 2, 3], expectation: 'missing format version is treated as legacy and reindexes all indexable repos' },
+  ])('$expectation', async ({ formatVersion, expected }) => {
     const client = makeIndexClient();
     const vectorService = makeVectorService();
-    const repos = [
-      makeRepository(1),
-      makeRepository(2, { vector_indexed_at: undefined }),
-      makeRepository(3, {
-        vector_indexed_at: '2026-01-05T00:00:00.000Z',
-        last_edited: '2026-01-06T00:00:00.000Z',
-      }),
-      makeRepository(4, { analyzed_at: undefined, vector_indexed_at: undefined }),
-      makeRepository(5, { analysis_failed: true, vector_indexed_at: undefined }),
-    ];
-
     const indexedIds: number[] = [];
-    const result = await indexAllRepos(repos, client, vectorService, {
+    const result = await indexAllRepos(incrementalFilteringRepos(), client, vectorService, {
       incremental: true,
-      formatVersion: EMBEDDING_FORMAT_VERSION,
+      formatVersion,
       currentFormatVersion: EMBEDDING_FORMAT_VERSION,
       indexMode: 'description',
       onRepoIndexed: (repoId) => indexedIds.push(repoId),
@@ -127,39 +132,9 @@ describe('indexAllRepos incremental filtering', () => {
 
     expect(client.embed).toHaveBeenCalledTimes(1);
     expect(vectorService.upsert).toHaveBeenCalledTimes(1);
-    expect(indexedIds).toEqual([2, 3]);
-    expect(result.indexedRepoIds).toEqual([2, 3]);
-    expect(result.indexed).toBe(2);
-  });
-
-  it('reindexes all indexable repos when format version is old', async () => {
-    const client = makeIndexClient();
-    const vectorService = makeVectorService();
-    const repos = [
-      makeRepository(1),
-      makeRepository(2, { vector_indexed_at: undefined }),
-      makeRepository(3, {
-        vector_indexed_at: '2026-01-05T00:00:00.000Z',
-        last_edited: '2026-01-06T00:00:00.000Z',
-      }),
-      makeRepository(4, { analyzed_at: undefined, vector_indexed_at: undefined }),
-      makeRepository(5, { analysis_failed: true, vector_indexed_at: undefined }),
-    ];
-
-    const indexedIds: number[] = [];
-    const result = await indexAllRepos(repos, client, vectorService, {
-      incremental: true,
-      formatVersion: EMBEDDING_FORMAT_VERSION - 1,
-      currentFormatVersion: EMBEDDING_FORMAT_VERSION,
-      indexMode: 'description',
-      onRepoIndexed: (repoId) => indexedIds.push(repoId),
-    });
-
-    expect(client.embed).toHaveBeenCalledTimes(1);
-    expect(vectorService.upsert).toHaveBeenCalledTimes(1);
-    expect(indexedIds).toEqual([1, 2, 3]);
-    expect(result.indexedRepoIds).toEqual([1, 2, 3]);
-    expect(result.indexed).toBe(3);
+    expect(indexedIds).toEqual(expected);
+    expect(result.indexedRepoIds).toEqual(expected);
+    expect(result.indexed).toBe(expected.length);
   });
 });
 

--- a/src/store/useAppStore.test.ts
+++ b/src/store/useAppStore.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { EmbeddingConfig, Repository, defaultReleaseSourceSettings } from '../types';
+import { EMBEDDING_FORMAT_VERSION } from '../services/vectorSearchService';
 import { CUSTOM_RELEASE_SOURCE_ID, createCustomReleaseRepository } from '../utils/releaseSources';
 
 let useAppStore: typeof import('./useAppStore').useAppStore;
@@ -139,6 +140,15 @@ describe('useAppStore vector search config normalization', () => {
       enableReranking: true,
       embeddingFormatVersion: 1,
     });
+  });
+
+  it('uses the latest format version for a fresh/reset config so new users are not forced into a full reindex', () => {
+    const normalized = normalizePersistedState(
+      { embeddingConfigs: [embeddingConfig] },
+      useAppStore.getState()
+    );
+
+    expect(normalized.vectorSearchConfig?.embeddingFormatVersion).toBe(EMBEDDING_FORMAT_VERSION);
   });
 });
 

--- a/src/store/useAppStore.test.ts
+++ b/src/store/useAppStore.test.ts
@@ -1,14 +1,15 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { Repository, defaultReleaseSourceSettings } from '../types';
+import { EmbeddingConfig, Repository, defaultReleaseSourceSettings } from '../types';
 import { CUSTOM_RELEASE_SOURCE_ID, createCustomReleaseRepository } from '../utils/releaseSources';
 
 let useAppStore: typeof import('./useAppStore').useAppStore;
+let normalizePersistedState: typeof import('./useAppStore').normalizePersistedState;
 
 beforeAll(async () => {
   const { indexedDBStorage } = await vi.importActual<typeof import('../services/indexedDbStorage')>('../services/indexedDbStorage');
   window.localStorage?.removeItem?.('github-stars-manager');
   await indexedDBStorage.removeItem('github-stars-manager');
-  ({ useAppStore } = await vi.importActual<typeof import('./useAppStore')>('./useAppStore'));
+  ({ useAppStore, normalizePersistedState } = await vi.importActual<typeof import('./useAppStore')>('./useAppStore'));
 });
 
 const createRepository = (id: number, overrides: Partial<Repository> = {}): Repository => ({
@@ -63,6 +64,81 @@ describe('useAppStore release source settings', () => {
     useAppStore.getState().removeReleaseSourceRepository(CUSTOM_RELEASE_SOURCE_ID, 'OWNER/repo');
 
     expect(useAppStore.getState().releaseSourceSettings.customReleaseRepos).toHaveLength(0);
+  });
+});
+
+describe('useAppStore vector search config normalization', () => {
+  const embeddingConfig: EmbeddingConfig = {
+    id: 'emb-1',
+    name: 'Test Embedding',
+    apiType: 'openai-compatible',
+    baseUrl: 'https://example.com/v1',
+    apiKey: 'test-key',
+    model: 'test-model',
+    dimensions: 1024,
+    isActive: true,
+  };
+
+  it('preserves full vectorSearchConfig during persisted-state hydration', () => {
+    const normalized = normalizePersistedState({
+      embeddingConfigs: [embeddingConfig],
+      activeEmbeddingConfig: embeddingConfig.id,
+      vectorSearchConfig: {
+        enabled: true,
+        workerUrl: 'https://worker.example.com',
+        authToken: 'worker-token',
+        embeddingConfigId: embeddingConfig.id,
+        indexMode: 'description',
+        readmeMaxChars: 4096,
+        searchThreshold: 0,
+        searchTopK: 12,
+        enableHyDE: false,
+        enableReranking: false,
+        embeddingFormatVersion: 2,
+      },
+    }, useAppStore.getState());
+
+    expect(normalized.vectorSearchConfig).toEqual({
+      enabled: true,
+      workerUrl: 'https://worker.example.com',
+      authToken: 'worker-token',
+      embeddingConfigId: embeddingConfig.id,
+      indexMode: 'description',
+      readmeMaxChars: 4096,
+      searchThreshold: 0,
+      searchTopK: 12,
+      enableHyDE: false,
+      enableReranking: false,
+      embeddingFormatVersion: 2,
+    });
+  });
+
+  it('defaults missing vectorSearchConfig fields for old persisted state', () => {
+    const normalized = normalizePersistedState({
+      embeddingConfigs: [embeddingConfig],
+      vectorSearchConfig: {
+        enabled: true,
+        workerUrl: 'https://worker.example.com',
+        authToken: 'worker-token',
+        embeddingConfigId: embeddingConfig.id,
+        indexMode: 'readme',
+        readmeMaxChars: 6000,
+      },
+    }, useAppStore.getState());
+
+    expect(normalized.vectorSearchConfig).toMatchObject({
+      enabled: true,
+      workerUrl: 'https://worker.example.com',
+      authToken: 'worker-token',
+      embeddingConfigId: embeddingConfig.id,
+      indexMode: 'readme',
+      readmeMaxChars: 6000,
+      searchThreshold: 0.35,
+      searchTopK: 30,
+      enableHyDE: true,
+      enableReranking: true,
+      embeddingFormatVersion: 1,
+    });
   });
 });
 

--- a/src/store/useAppStore.test.ts
+++ b/src/store/useAppStore.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { EmbeddingConfig, Repository, defaultReleaseSourceSettings } from '../types';
-import { EMBEDDING_FORMAT_VERSION } from '../services/vectorSearchService';
+import { EmbeddingConfig, Repository, VectorSearchConfig, defaultReleaseSourceSettings } from '../types';
+import { EMBEDDING_FORMAT_VERSION, indexAllRepos } from '../services/vectorSearchService';
 import { CUSTOM_RELEASE_SOURCE_ID, createCustomReleaseRepository } from '../utils/releaseSources';
 
 let useAppStore: typeof import('./useAppStore').useAppStore;
@@ -149,6 +149,94 @@ describe('useAppStore vector search config normalization', () => {
     );
 
     expect(normalized.vectorSearchConfig?.embeddingFormatVersion).toBe(EMBEDDING_FORMAT_VERSION);
+  });
+
+  const baseVectorSearchConfig: VectorSearchConfig = {
+    enabled: true,
+    workerUrl: 'https://worker.example.com',
+    authToken: 'worker-token',
+    embeddingConfigId: embeddingConfig.id,
+    indexMode: 'readme',
+    readmeMaxChars: 6000,
+    searchThreshold: 0.35,
+    searchTopK: 30,
+    enableHyDE: true,
+    enableReranking: true,
+    embeddingFormatVersion: EMBEDDING_FORMAT_VERSION,
+  };
+
+  beforeEach(() => {
+    useAppStore.setState({
+      embeddingConfigs: [embeddingConfig],
+      vectorSearchConfig: { ...baseVectorSearchConfig },
+    });
+  });
+
+  it('does not downgrade embeddingFormatVersion from stale runtime config updates', () => {
+    useAppStore.getState().setVectorSearchConfig({ embeddingFormatVersion: 1 });
+
+    expect(useAppStore.getState().vectorSearchConfig.embeddingFormatVersion).toBe(EMBEDDING_FORMAT_VERSION);
+  });
+
+  it('merges ordinary stale backend fields while preserving current embeddingFormatVersion', () => {
+    useAppStore.getState().setVectorSearchConfig({
+      workerUrl: 'https://stale-backend.example.com',
+      authToken: 'stale-token',
+      embeddingFormatVersion: 1,
+    });
+
+    expect(useAppStore.getState().vectorSearchConfig).toMatchObject({
+      workerUrl: 'https://stale-backend.example.com',
+      authToken: 'stale-token',
+      embeddingFormatVersion: EMBEDDING_FORMAT_VERSION,
+    });
+  });
+
+  it('allows runtime upgrades from legacy to the latest embeddingFormatVersion', () => {
+    useAppStore.setState({
+      vectorSearchConfig: { ...baseVectorSearchConfig, embeddingFormatVersion: 1 },
+    });
+
+    useAppStore.getState().setVectorSearchConfig({ embeddingFormatVersion: EMBEDDING_FORMAT_VERSION });
+
+    expect(useAppStore.getState().vectorSearchConfig.embeddingFormatVersion).toBe(EMBEDDING_FORMAT_VERSION);
+  });
+
+  it('ignores invalid runtime embeddingFormatVersion updates', () => {
+    useAppStore.getState().setVectorSearchConfig({
+      embeddingFormatVersion: EMBEDDING_FORMAT_VERSION + 1,
+    });
+
+    expect(useAppStore.getState().vectorSearchConfig.embeddingFormatVersion).toBe(EMBEDDING_FORMAT_VERSION);
+  });
+
+  it('keeps incremental indexing scoped to newly analyzed repos after a stale backend config sync', async () => {
+    useAppStore.getState().setVectorSearchConfig({ embeddingFormatVersion: 1 });
+    expect(useAppStore.getState().vectorSearchConfig.embeddingFormatVersion).toBe(EMBEDDING_FORMAT_VERSION);
+
+    const indexedIds: number[] = [];
+    const client = {
+      embed: vi.fn(async (texts: string[]) => texts.map((_, i) => [i, i + 1, i + 2])),
+    } as unknown as Parameters<typeof indexAllRepos>[1];
+    const vectorService = {
+      upsert: vi.fn(async (vectors: Array<{ id: string }>) => ({ upserted: vectors.length })),
+    } as unknown as Parameters<typeof indexAllRepos>[2];
+
+    const result = await indexAllRepos([
+      createRepository(1, { analyzed_at: '2026-01-04T00:00:00.000Z', vector_indexed_at: '2026-01-05T00:00:00.000Z' }),
+      createRepository(2, { analyzed_at: '2026-01-04T00:00:00.000Z', vector_indexed_at: '2026-01-05T00:00:00.000Z' }),
+      createRepository(3, { analyzed_at: '2026-01-06T00:00:00.000Z', vector_indexed_at: undefined }),
+      createRepository(4, { analyzed_at: undefined, vector_indexed_at: undefined }),
+    ], client, vectorService, {
+      incremental: true,
+      formatVersion: useAppStore.getState().vectorSearchConfig.embeddingFormatVersion,
+      currentFormatVersion: EMBEDDING_FORMAT_VERSION,
+      indexMode: 'description',
+      onRepoIndexed: (repoId) => indexedIds.push(repoId),
+    });
+
+    expect(indexedIds).toEqual([3]);
+    expect(result.indexedRepoIds).toEqual([3]);
   });
 });
 

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -560,6 +560,7 @@ const normalizeNumberSet = (value: unknown): Set<number> => {
   return new Set<number>();
 };
 
+// 新安装/重置配置的默认：已是最新格式版本，避免首次增量索引被误判为需要全量重建
 const defaultVectorSearchConfig: VectorSearchConfig = {
   enabled: false,
   workerUrl: '',
@@ -571,8 +572,11 @@ const defaultVectorSearchConfig: VectorSearchConfig = {
   searchTopK: 30,
   enableHyDE: true,
   enableReranking: true,
-  embeddingFormatVersion: 1,
+  embeddingFormatVersion: EMBEDDING_FORMAT_VERSION,
 };
+
+// 持久化历史配置缺失 embeddingFormatVersion 时的回退版本：旧值为 1，确保旧用户触发一次重建
+const LEGACY_EMBEDDING_FORMAT_VERSION = 1;
 
 const normalizeVectorSearchConfig = (
   raw: unknown,
@@ -584,7 +588,7 @@ const normalizeVectorSearchConfig = (
 
   const config = raw as Record<string, unknown>;
   const configId = typeof config.embeddingConfigId === 'string' ? config.embeddingConfigId : '';
-  // 仅在确实存在 embeddingConfigId 时才构建 embedding id 集合，避免每次 hydration 都遍历 embeddingConfigs
+  // 仅在确实存在 embeddingConfigId 时才查找 embedding 配置，避免每次 hydration 都遍历 embeddingConfigs
   const hasValidConfig = configId
     ? (Array.isArray(embeddingConfigs)
         ? embeddingConfigs.some((cfg) => cfg && typeof cfg === 'object' && (cfg as { id?: unknown }).id === configId)
@@ -596,12 +600,15 @@ const normalizeVectorSearchConfig = (
   const searchTopK = typeof config.searchTopK === 'number' && Number.isInteger(config.searchTopK) && config.searchTopK >= 5 && config.searchTopK <= 50
     ? config.searchTopK
     : defaultVectorSearchConfig.searchTopK;
-  const embeddingFormatVersion = typeof config.embeddingFormatVersion === 'number'
+  // 持久化的 embeddingFormatVersion 缺失或越界时一律回落到 legacy 版本 1，触发一次全量重建；
+  // 不使用 defaultVectorSearchConfig.embeddingFormatVersion（= 最新版），否则旧用户会跳过重建
+  const hasFormatVersion = typeof config.embeddingFormatVersion === 'number'
     && Number.isInteger(config.embeddingFormatVersion)
     && config.embeddingFormatVersion >= 1
-    && config.embeddingFormatVersion <= EMBEDDING_FORMAT_VERSION
-      ? config.embeddingFormatVersion
-      : defaultVectorSearchConfig.embeddingFormatVersion;
+    && config.embeddingFormatVersion <= EMBEDDING_FORMAT_VERSION;
+  const embeddingFormatVersion = hasFormatVersion
+    ? (config.embeddingFormatVersion as number)
+    : LEGACY_EMBEDDING_FORMAT_VERSION;
 
   return {
     ...defaultVectorSearchConfig,

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -578,6 +578,13 @@ const defaultVectorSearchConfig: VectorSearchConfig = {
 // 持久化历史配置缺失 embeddingFormatVersion 时的回退版本：旧值为 1，确保旧用户触发一次重建
 const LEGACY_EMBEDDING_FORMAT_VERSION = 1;
 
+const isKnownEmbeddingFormatVersion = (value: unknown): value is number => (
+  typeof value === 'number'
+  && Number.isInteger(value)
+  && value >= LEGACY_EMBEDDING_FORMAT_VERSION
+  && value <= EMBEDDING_FORMAT_VERSION
+);
+
 const normalizeVectorSearchConfig = (
   raw: unknown,
   embeddingConfigs: unknown
@@ -602,12 +609,8 @@ const normalizeVectorSearchConfig = (
     : defaultVectorSearchConfig.searchTopK;
   // 持久化的 embeddingFormatVersion 缺失或越界时一律回落到 legacy 版本 1，触发一次全量重建；
   // 不使用 defaultVectorSearchConfig.embeddingFormatVersion（= 最新版），否则旧用户会跳过重建
-  const hasFormatVersion = typeof config.embeddingFormatVersion === 'number'
-    && Number.isInteger(config.embeddingFormatVersion)
-    && config.embeddingFormatVersion >= 1
-    && config.embeddingFormatVersion <= EMBEDDING_FORMAT_VERSION;
-  const embeddingFormatVersion = hasFormatVersion
-    ? (config.embeddingFormatVersion as number)
+  const embeddingFormatVersion = isKnownEmbeddingFormatVersion(config.embeddingFormatVersion)
+    ? config.embeddingFormatVersion
     : LEGACY_EMBEDDING_FORMAT_VERSION;
 
   return {
@@ -628,6 +631,25 @@ const normalizeVectorSearchConfig = (
     enableReranking: typeof config.enableReranking === 'boolean'
       ? config.enableReranking
       : defaultVectorSearchConfig.enableReranking,
+    embeddingFormatVersion,
+  };
+};
+
+const mergeVectorSearchConfig = (
+  current: VectorSearchConfig,
+  patch: Partial<VectorSearchConfig>
+): VectorSearchConfig => {
+  const currentVersion = isKnownEmbeddingFormatVersion(current.embeddingFormatVersion)
+    ? current.embeddingFormatVersion
+    : defaultVectorSearchConfig.embeddingFormatVersion;
+  const patchVersion = patch.embeddingFormatVersion;
+  const embeddingFormatVersion = isKnownEmbeddingFormatVersion(patchVersion)
+    ? Math.max(currentVersion, patchVersion)
+    : currentVersion;
+
+  return {
+    ...current,
+    ...patch,
     embeddingFormatVersion,
   };
 };
@@ -1453,7 +1475,7 @@ export const useAppStore = create<AppState & AppActions>()(
 
       // Vector Search actions
       setVectorSearchConfig: (config) => set((state) => ({
-        vectorSearchConfig: { ...state.vectorSearchConfig, ...config }
+        vectorSearchConfig: mergeVectorSearchConfig(state.vectorSearchConfig, config)
       })),
       setVectorSearchStatus: (status) => set({ vectorSearchStatus: status }),
       setVectorIndexingState: (indexingState) => set((state) => ({

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -576,9 +576,9 @@ const defaultVectorSearchConfig: VectorSearchConfig = {
 };
 
 // 持久化历史配置缺失 embeddingFormatVersion 时的回退版本：旧值为 1，确保旧用户触发一次重建
-const LEGACY_EMBEDDING_FORMAT_VERSION = 1;
+export const LEGACY_EMBEDDING_FORMAT_VERSION = 1;
 
-const isKnownEmbeddingFormatVersion = (value: unknown): value is number => (
+export const isKnownEmbeddingFormatVersion = (value: unknown): value is number => (
   typeof value === 'number'
   && Number.isInteger(value)
   && value >= LEGACY_EMBEDDING_FORMAT_VERSION

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -42,6 +42,7 @@ import {
   defaultHeaderMenuConfig,
 } from '../types';
 import { indexedDBStorage } from '../services/indexedDbStorage';
+import { EMBEDDING_FORMAT_VERSION } from '../services/vectorSearchService';
 import {
   WATCH_CUSTOM_RELEASE_SOURCE_ID,
   normalizeReleaseSourceSettings,
@@ -559,7 +560,72 @@ const normalizeNumberSet = (value: unknown): Set<number> => {
   return new Set<number>();
 };
 
-const normalizePersistedState = (
+const defaultVectorSearchConfig: VectorSearchConfig = {
+  enabled: false,
+  workerUrl: '',
+  authToken: '',
+  embeddingConfigId: '',
+  indexMode: 'readme',
+  readmeMaxChars: 6000,
+  searchThreshold: 0.35,
+  searchTopK: 30,
+  enableHyDE: true,
+  enableReranking: true,
+  embeddingFormatVersion: 1,
+};
+
+const normalizeVectorSearchConfig = (
+  raw: unknown,
+  embeddingConfigs: unknown
+): VectorSearchConfig => {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ...defaultVectorSearchConfig };
+  }
+
+  const config = raw as Record<string, unknown>;
+  const configId = typeof config.embeddingConfigId === 'string' ? config.embeddingConfigId : '';
+  // 仅在确实存在 embeddingConfigId 时才构建 embedding id 集合，避免每次 hydration 都遍历 embeddingConfigs
+  const hasValidConfig = configId
+    ? (Array.isArray(embeddingConfigs)
+        ? embeddingConfigs.some((cfg) => cfg && typeof cfg === 'object' && (cfg as { id?: unknown }).id === configId)
+        : false)
+    : false;
+  const searchThreshold = typeof config.searchThreshold === 'number' && Number.isFinite(config.searchThreshold) && config.searchThreshold >= 0 && config.searchThreshold <= 1
+    ? config.searchThreshold
+    : defaultVectorSearchConfig.searchThreshold;
+  const searchTopK = typeof config.searchTopK === 'number' && Number.isInteger(config.searchTopK) && config.searchTopK >= 5 && config.searchTopK <= 50
+    ? config.searchTopK
+    : defaultVectorSearchConfig.searchTopK;
+  const embeddingFormatVersion = typeof config.embeddingFormatVersion === 'number'
+    && Number.isInteger(config.embeddingFormatVersion)
+    && config.embeddingFormatVersion >= 1
+    && config.embeddingFormatVersion <= EMBEDDING_FORMAT_VERSION
+      ? config.embeddingFormatVersion
+      : defaultVectorSearchConfig.embeddingFormatVersion;
+
+  return {
+    ...defaultVectorSearchConfig,
+    enabled: config.enabled === true && hasValidConfig,
+    workerUrl: typeof config.workerUrl === 'string' ? config.workerUrl : defaultVectorSearchConfig.workerUrl,
+    authToken: typeof config.authToken === 'string' ? config.authToken : defaultVectorSearchConfig.authToken,
+    embeddingConfigId: hasValidConfig ? configId : defaultVectorSearchConfig.embeddingConfigId,
+    indexMode: config.indexMode === 'description' ? 'description' : 'readme',
+    readmeMaxChars: typeof config.readmeMaxChars === 'number' && config.readmeMaxChars > 0
+      ? config.readmeMaxChars
+      : defaultVectorSearchConfig.readmeMaxChars,
+    searchThreshold,
+    searchTopK,
+    enableHyDE: typeof config.enableHyDE === 'boolean'
+      ? config.enableHyDE
+      : defaultVectorSearchConfig.enableHyDE,
+    enableReranking: typeof config.enableReranking === 'boolean'
+      ? config.enableReranking
+      : defaultVectorSearchConfig.enableReranking,
+    embeddingFormatVersion,
+  };
+};
+
+export const normalizePersistedState = (
   persisted: PersistedAppState | undefined,
   currentState: AppState & AppActions
 ): Partial<AppState & AppActions> => {
@@ -639,23 +705,10 @@ const normalizePersistedState = (
     webdavConfigs: Array.isArray(safePersisted.webdavConfigs) ? safePersisted.webdavConfigs : [],
     embeddingConfigs: Array.isArray(safePersisted.embeddingConfigs) ? safePersisted.embeddingConfigs : [],
     activeEmbeddingConfig: typeof safePersisted.activeEmbeddingConfig === 'string' ? safePersisted.activeEmbeddingConfig : null,
-    vectorSearchConfig: (() => {
-      const raw = safePersisted.vectorSearchConfig;
-      const embCfgs = Array.isArray(safePersisted.embeddingConfigs) ? safePersisted.embeddingConfigs : [];
-      const embIds = new Set(embCfgs.map((c: { id: string }) => c.id));
-      if (raw && typeof raw === 'object') {
-        const configId = typeof raw.embeddingConfigId === 'string' ? raw.embeddingConfigId : '';
-        return {
-          enabled: !!raw.enabled && embIds.has(configId),
-          workerUrl: typeof raw.workerUrl === 'string' ? raw.workerUrl : '',
-          authToken: typeof raw.authToken === 'string' ? raw.authToken : '',
-          embeddingConfigId: embIds.has(configId) ? configId : '',
-          indexMode: raw.indexMode === 'description' ? 'description' as const : 'readme' as const,
-          readmeMaxChars: typeof raw.readmeMaxChars === 'number' && raw.readmeMaxChars > 0 ? raw.readmeMaxChars : 6000,
-        };
-      }
-      return { enabled: false, workerUrl: '', authToken: '', embeddingConfigId: '', indexMode: 'readme' as const, readmeMaxChars: 6000 };
-    })(),
+    vectorSearchConfig: normalizeVectorSearchConfig(
+      safePersisted.vectorSearchConfig,
+      safePersisted.embeddingConfigs
+    ),
     customCategories: Array.isArray(safePersisted.customCategories) ? safePersisted.customCategories : [],
     hiddenDefaultCategoryIds: (() => {
       const persistedIds = (safePersisted as Record<string, unknown>).hiddenDefaultCategoryIds;
@@ -1051,7 +1104,7 @@ export const useAppStore = create<AppState & AppActions>()(
       activeAIConfig: null,
       embeddingConfigs: [],
       activeEmbeddingConfig: null,
-      vectorSearchConfig: { enabled: false, workerUrl: '', authToken: '', embeddingConfigId: '', indexMode: 'readme', readmeMaxChars: 6000 },
+      vectorSearchConfig: { ...defaultVectorSearchConfig },
       vectorSearchStatus: { connected: false, vectorCount: 0, dimensions: 0 },
       vectorIndexingState: { isIndexing: false, phase: null, phaseDone: 0, phaseTotal: 0, result: null },
       webdavConfigs: [],
@@ -2310,22 +2363,13 @@ export const useAppStore = create<AppState & AppActions>()(
     (state as Record<string, unknown>).activeEmbeddingConfig = null;
   }
 
-  // 初始化 vectorSearchConfig
-  if (state && !(state as Record<string, unknown>).vectorSearchConfig) {
-    (state as Record<string, unknown>).vectorSearchConfig = { enabled: false, workerUrl: '', authToken: '', embeddingConfigId: '', indexMode: 'readme', readmeMaxChars: 6000 };
-  }
-  // 迁移：为旧配置添加缺失字段
+  // 初始化/迁移 vectorSearchConfig
   if (state) {
-    const vsc = (state as Record<string, unknown>).vectorSearchConfig as Record<string, unknown> | undefined;
-    if (vsc && typeof vsc === 'object') {
-      if (vsc.indexMode !== 'description' && vsc.indexMode !== 'readme') vsc.indexMode = 'readme';
-      if (typeof vsc.readmeMaxChars !== 'number' || vsc.readmeMaxChars <= 0) vsc.readmeMaxChars = 6000;
-      if (typeof vsc.searchThreshold !== 'number') vsc.searchThreshold = 0.35;
-      if (typeof vsc.searchTopK !== 'number') vsc.searchTopK = 30;
-      if (typeof vsc.enableHyDE !== 'boolean') vsc.enableHyDE = true;
-      if (typeof vsc.enableReranking !== 'boolean') vsc.enableReranking = true;
-      if (typeof vsc.embeddingFormatVersion !== 'number') vsc.embeddingFormatVersion = 1;
-    }
+    const stateRecord = state as Record<string, unknown>;
+    stateRecord.vectorSearchConfig = normalizeVectorSearchConfig(
+      stateRecord.vectorSearchConfig,
+      stateRecord.embeddingConfigs
+    );
   }
 
         return state as PersistedAppState;


### PR DESCRIPTION
## Summary

Fixes #234. The incremental-index button reindexed from the beginning after every reload.

## Root cause

`normalizePersistedState` in `src/store/useAppStore.ts` reconstructed `vectorSearchConfig` from a fixed allow-list that dropped `embeddingFormatVersion` (along with `searchThreshold`/`searchTopK`/`enableHyDE`/`enableReranking`). After hydration, `embeddingFormatVersion` became `undefined`, so:

1. `formatVersionNeedsReindex = (undefined ?? 1) < EMBEDDING_FORMAT_VERSION` → `true`
2. `indexAllRepos` treated the format as legacy and intentionally reindexed every indexable repo on each incremental run

The button wiring and `indexAllRepos` behavior were correct — the bug was in persistence normalization losing the saved format version.

## Changes

- Centralize `vectorSearchConfig` defaults in `defaultVectorSearchConfig` and a single `normalizeVectorSearchConfig` used by both hydration and `migrate`, eliminating the duplicated in-place backfill that drifted from hydration.
- Preserve and **clamp** persisted fields to safe ranges so corrupted/synced values cannot reach the worker or suppress reindexing:
  - `embeddingFormatVersion` → `[1, EMBEDDING_FORMAT_VERSION]` (future/corrupt versions can't skip required reindexing)
  - `searchThreshold` → `[0, 1]`
  - `searchTopK` → `[5, 50]` (integer, matches the settings UI)
- Only build the embedding-config id lookup when `embeddingConfigId` is actually present (avoids scanning `embeddingConfigs` on every hydration).
- Leave `indexAllRepos` migration logic intact: missing/old format version still triggers one safe reindex.

## Tests

- `useAppStore.test.ts`: hydration preserves a full `vectorSearchConfig` (incl. `embeddingFormatVersion: 2` and `false` booleans); legacy persisted state without the newer fields defaults to `embeddingFormatVersion: 1`.
- `vectorSearchService.test.ts`: with current format version, incremental indexing only embeds never-indexed / content-updated repos; with an old format version, it reindexes all analyzed, non-failed repos.

## Verification

- [x] `npm run test:run -- src/store/useAppStore.test.ts src/services/vectorSearchService.test.ts` → 24 passed
- [x] `npm run test:run` → 103 passed (11 files)
- [x] `npm run lint` → clean
- [x] `npm run build` → success

## Notes

Backend config routes (`server/src/routes/configs.ts`, `server/src/db/schema.ts`) also omit `embeddingFormatVersion`, but #234's reported path is local/frontend persistence. Kept this fix focused; backend config sync can be a follow-up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restoration and validation of Vector Search settings by normalizing persisted config, applying safe defaults, and clamping thresholds and limits to valid ranges.
  * Added robust handling for embedding format version (including legacy and invalid cases) to ensure configuration stays forward-only and consistent.
  * Refined incremental indexing so only the correct repositories are reprocessed based on current vs older/missing embedding format versions.
* **User Interface**
  * Updated Incremental Index controls to show the correct remaining target count and disable the action when there’s nothing left to index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->