### PR TITLE
fix: raise max_tokens for AI analysis to avoid thinking-model truncation

### DIFF
--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -73,6 +73,7 @@ export class AIService {
   private config: AIConfig;
   private language: string;
   private static readonly ANALYSIS_MAX_ATTEMPTS = 3;
+  private static readonly ANALYSIS_MAX_TOKENS = 4096;
 
   constructor(config: AIConfig, language: string = 'zh') {
     this.config = config;
@@ -514,7 +515,7 @@ ${options.user}` : options.user;
             ? prompt
             : this.createAnalysisRetryPrompt(prompt, lastContent, lastInvalidReason),
           temperature: attempt === 1 ? 0.3 : 0.1,
-          maxTokens: 1000,
+          maxTokens: AIService.ANALYSIS_MAX_TOKENS,
           signal,
         });
 
@@ -620,7 +621,7 @@ AI Summary: ${gist.ai_summary || 'None'}`;
       system,
       user: `Query: ${query}\n\nGists:\n${this.sanitizeForPrompt(gistSummaries)}`,
       temperature: 0.1,
-      maxTokens: 1200,
+      maxTokens: AIService.ANALYSIS_MAX_TOKENS,
     });
 
     try {
@@ -682,7 +683,7 @@ AI Summary: ${gist.ai_summary || 'None'}`;
       system,
       user: `Query: ${query}\n\nRepositories:\n${this.sanitizeForPrompt(repoSummaries)}`,
       temperature: 0.1,
-      maxTokens: 800,
+      maxTokens: AIService.ANALYSIS_MAX_TOKENS,
       signal,
     });
 

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -74,6 +74,7 @@ export class AIService {
   private language: string;
   private static readonly ANALYSIS_MAX_ATTEMPTS = 3;
   private static readonly ANALYSIS_MAX_TOKENS = 4096;
+  private static readonly RERANKING_MAX_TOKENS = 4096;
 
   constructor(config: AIConfig, language: string = 'zh') {
     this.config = config;
@@ -621,7 +622,7 @@ AI Summary: ${gist.ai_summary || 'None'}`;
       system,
       user: `Query: ${query}\n\nGists:\n${this.sanitizeForPrompt(gistSummaries)}`,
       temperature: 0.1,
-      maxTokens: AIService.ANALYSIS_MAX_TOKENS,
+      maxTokens: AIService.RERANKING_MAX_TOKENS,
     });
 
     try {
@@ -683,7 +684,7 @@ AI Summary: ${gist.ai_summary || 'None'}`;
       system,
       user: `Query: ${query}\n\nRepositories:\n${this.sanitizeForPrompt(repoSummaries)}`,
       temperature: 0.1,
-      maxTokens: AIService.ANALYSIS_MAX_TOKENS,
+      maxTokens: AIService.RERANKING_MAX_TOKENS,
       signal,
     });
 


### PR DESCRIPTION
## Summary
- Reasoning models (e.g. `agnes-2.0-flash`) enable thinking by default and emit `reasoning_content`. With the previous 1000/1200/800 token caps, the thinking chain consumed the entire budget and hit `finish_reason:"length"` before the final JSON was written to `content`, causing repository AI analysis to fail (empty content → "No content received from AI service").
- Raise the analysis and semantic-reranking token budgets to a shared `ANALYSIS_MAX_TOKENS = 4096` so the model can finish thinking and emit the answer.

## Why this approach
- `max_tokens` is a standard OpenAI-compatible parameter accepted by any endpoint — no risk of 400s from unknown/vendor-specific fields, and no model/provider database to maintain.
- This is the conservative fix: it does not try to disable thinking (which requires vendor-specific params like `chat_template_kwargs`/`enable_thinking`/`thinking.type` that vary per provider and can error on strict relays). It simply gives the token budget enough room for thinking + final JSON.

## Changes
`src/services/aiService.ts`:
- Add `private static readonly ANALYSIS_MAX_TOKENS = 4096;`
- `analyzeRepository`: `maxTokens` 1000 → 4096
- `searchGistsWithReranking`: `maxTokens` 1200 → 4096
- `searchRepositoriesWithSemanticReranking`: `maxTokens` 800 → 4096

## Test plan
- [ ] Configure an OpenAI-compatible channel using a thinking model (e.g. agnes-2.0-flash) with reasoning effort "none".
- [ ] Run AI analysis on a repository; confirm `finish_reason:"stop"`, `content` contains valid JSON, and analysis succeeds.
- [ ] `tsc --noEmit` and `eslint` pass (verified locally).

🤖 Generated with OpenCode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Increased and standardized the maximum response size for repository and gist analysis and reranking to allow more complete, higher-quality semantic search results.
  * Reranking now uses a consistent token budget across gist and repository flows, improving result coverage and relevance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->