### PR TITLE
feat: add find-similar-repositories via vector search on repo cards

### DIFF
--- a/docs/plans/2026-07-12-find-similar-repositories-design.md
+++ b/docs/plans/2026-07-12-find-similar-repositories-design.md
@@ -1,0 +1,87 @@
+# 仓库页「查找相似仓库」特性设计
+
+日期：2026-07-12
+状态：已实现
+
+## 目标
+
+在仓库页（Repositories 视图）新增一个基于向量语义搜索的「查找相似仓库」交互：
+
+- 设置中开启向量搜索开关且向量索引可用时，悬停仓库卡片，左下角「最近提交」时间变为高亮文字按钮「查找相似仓库」。
+- 点击后利用向量检索匹配语义相似仓库，并**完全替换**当前仓库列表为相似仓库结果（进入「相似仓库视图」）。
+- 支持链式查找：相似结果中的卡片同样可悬停点击，进一步深入。
+- 列表顶部以横幅提示当前状态，并提供「重置」按钮，**一键直接回到查找相似之前的最初列表**。
+- 交互清晰、无歧义：相似视图下点击分类侧栏即离开相似视图并切换到该分类。
+
+## 关键决策（来自澄清问答）
+
+1. 点击后列表**完全替换**为相似仓库结果（非叠加 / 非过滤）。
+2. 相似仓库视图内**支持连续链式查找**（在结果上再查相似）。
+3. 重置按钮**直接回到初始列表**，忽略中间层级（无需多层栈）。
+4. 状态提示与重置入口放在**列表顶部横幅**。
+5. 按钮显示条件基于**实际可用性**（开关开启 + Worker 已连接 + 有向量数 + Embedding 配置完整），而非仅看开关，避免无效点击。
+
+## 架构
+
+### 状态（`useAppStore`）
+
+```ts
+similarView: SimilarViewState | null;
+
+interface SimilarViewState {
+  active: boolean;
+  anchorRepoFullName: string;
+  anchorRepoName: string;
+  similarResults: Repository[];        // 当前相似结果（渲染用）
+  originalSearchResults: Repository[]; // 进入前的 searchResults 快照，重置恢复用
+}
+```
+
+- `enterSimilarView(repos, anchor)`：保存当前 `searchResults` 到 `originalSearchResults`，写入 `similarResults` 与锚点信息。
+- `resetSimilarView()`：恢复 `searchResults = originalSearchResults`，清空 `similarView`。
+- 不持久化（重载即回到正常视图，避免状态歧义）。
+
+### 向量检索（`vectorSearchService.findSimilarRepositories`）
+
+`buildEmbeddingText(sourceRepo)` → `EmbeddingClient.embed([text], 'query')` 生成查询向量 → `VectorSearchService.query(vector, { topK: topK+1, threshold })` → 从全量仓库按 id 映射并**过滤源仓库自身** → 返回 `Repository[]`。
+
+### 渲染接入（`App.tsx` RepositoriesView）
+
+- `similarView?.active` 时，列表数据源切换为 `similarView.similarResults`，并强制 `selectedCategory='all'`（忽略分类过滤，完整展示相似结果）。
+- 否则沿用原逻辑：`hasActiveSearchFilters(searchFilters) ? searchResults : repositories`。
+- `handleCategorySelect`：相似视图激活时点击分类先 `resetSimilarView()` 再切换分类，保证「点分类 = 离开相似视图」。
+
+### 卡片按钮（`RepositoryCard`）
+
+- `vectorSearchAvailable` 派生标志：开关开启 + `vectorSearchStatus.connected` + `vectorCount > 0` + Embedding 配置完整 + Worker URL/Token 非空。
+- 「最近提交」行改造：默认显示时间文本；`group-hover` 时时间淡出、绝对定位覆盖显示高亮 `<button>「🔍 查找相似仓库」`。按钮 `pointer-events-none group-hover:pointer-events-auto`，避免遮盖非悬停时的卡片点击。
+- 按钮是 `<button>`，卡片 `handleCardClick` 已通过 `closest('button')` 排除，不会误开 README modal。
+- `handleFindSimilar`：创建 EmbeddingClient + VectorSearchService → `findSimilarRepositories` → `enterSimilarView`；过程显示 loading（卡片内 spinner），失败 `toast` 报错并保留原视图；空结果也进入视图并由横幅显示。
+
+### 顶部横幅（`SimilarViewBanner`）
+
+- 条件渲染于 `RepositoryList` 顶部（controls bar 之前）。
+- 左侧「正在查看 **{anchorRepoName}** 的相似仓库」，右侧醒目「← 重置」按钮。
+
+## 边界与歧义消除
+
+- 相似结果为空：横幅仍显示，列表空状态提示，重置可用。
+- 加载中：按钮显示 spinner，禁止重复点击。
+- 非仓库页（gists / releases / forks / settings / subscription）不显示该功能。
+- 重启应用后 `vectorSearchStatus` 不持久化（初始 `connected:false`），按钮不显示直到重新建立连接，符合「要求索引可用」。
+
+## 修改文件清单
+
+- `src/types/index.ts` — 新增 `SimilarViewState` 类型与 `AppState.similarView` 字段。
+- `src/store/useAppStore.ts` — 新增 `similarView` 状态、`enterSimilarView` / `resetSimilarView` actions、初始值。
+- `src/services/vectorSearchService.ts` — 新增 `findSimilarRepositories`。
+- `src/components/RepositoryCard.tsx` — 悬停按钮 + `handleFindSimilar`。
+- `src/components/SimilarViewBanner.tsx` — 新组件（横幅）。
+- `src/components/RepositoryList.tsx` — 渲染横幅。
+- `src/App.tsx` — `RepositoriesView` 接入相似结果渲染；`handleCategorySelect` 退出逻辑。
+
+## 测试建议
+
+- 单测 `findSimilarRepositories`（mock EmbeddingClient / VectorSearchService）。
+- 单测 store actions 快照恢复。
+- 手动验证：开启开关 + 配置 → 卡片 hover 显按钮 → 点击进相似视图 → 横幅出现 → 再次 hover 链式查找 → 重置回初始 → 相似视图下点分类离开视图。

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,6 +60,20 @@ const RepositoriesView = React.memo(({
   onCategorySelect: (category: string) => void;
 }) => {
   const isActive = hasActiveSearchFilters(searchFilters);
+  const similarView = useAppStore((state) => state.similarView);
+  const resetSimilarView = useAppStore((state) => state.resetSimilarView);
+
+  // 相似视图下用户发起搜索时，自动退出相似视图（搜索优先于相似浏览，避免界面歧义）
+  useEffect(() => {
+    if (similarView?.active && isActive) {
+      resetSimilarView();
+    }
+  }, [similarView?.active, isActive, resetSimilarView]);
+
+  // 相似仓库视图激活时，列表数据源切换为相似结果，且忽略分类过滤
+  const listRepositories = similarView?.active
+    ? similarView.similarResults
+    : (isActive ? searchResults : repositories);
 
   return (
     <div className="flex flex-col gap-4 lg:flex-row lg:gap-6">
@@ -71,8 +85,8 @@ const RepositoriesView = React.memo(({
       <div className="flex-1 space-y-6">
         <SearchBar />
         <RepositoryList
-          repositories={isActive ? searchResults : repositories}
-          selectedCategory={selectedCategory}
+          repositories={listRepositories}
+          selectedCategory={similarView?.active ? 'all' : selectedCategory}
         />
       </div>
     </div>
@@ -152,6 +166,10 @@ function App() {
   }, []);
 
   const handleCategorySelect = useCallback((category: string) => {
+    // 相似仓库视图下点击分类 = 离开相似视图并切换到该分类，避免交互歧义
+    if (useAppStore.getState().similarView?.active) {
+      useAppStore.getState().resetSimilarView();
+    }
     setSelectedCategory(category);
   }, [setSelectedCategory]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,14 +61,14 @@ const RepositoriesView = React.memo(({
 }) => {
   const isActive = hasActiveSearchFilters(searchFilters);
   const similarView = useAppStore((state) => state.similarView);
-  const resetSimilarView = useAppStore((state) => state.resetSimilarView);
+  const exitSimilarView = useAppStore((state) => state.exitSimilarView);
 
   // 相似视图下用户发起搜索时，自动退出相似视图（搜索优先于相似浏览，避免界面歧义）
   useEffect(() => {
     if (similarView?.active && isActive) {
-      resetSimilarView();
+      exitSimilarView();
     }
-  }, [similarView?.active, isActive, resetSimilarView]);
+  }, [similarView?.active, isActive, exitSimilarView]);
 
   // 相似仓库视图激活时，列表数据源切换为相似结果，且忽略分类过滤
   const listRepositories = similarView?.active
@@ -168,7 +168,7 @@ function App() {
   const handleCategorySelect = useCallback((category: string) => {
     // 相似仓库视图下点击分类 = 离开相似视图并切换到该分类，避免交互歧义
     if (useAppStore.getState().similarView?.active) {
-      useAppStore.getState().resetSimilarView();
+      useAppStore.getState().exitSimilarView();
     }
     setSelectedCategory(category);
   }, [setSelectedCategory]);

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import { createPortal } from 'react-dom';
-import { GripVertical, Star, StarOff, ExternalLink, Calendar, Bell, BellOff, Bot, Sparkles, Monitor, Smartphone, Globe, Terminal, Package, Edit3, BookOpen, Apple, Square, CheckSquare, Loader2, HelpCircle } from 'lucide-react';
+import { GripVertical, Star, StarOff, ExternalLink, Calendar, Bell, BellOff, Bot, Sparkles, Monitor, Smartphone, Globe, Terminal, Package, Edit3, BookOpen, Apple, Square, CheckSquare, Loader2, HelpCircle, Search } from 'lucide-react';
 import { Repository, Category } from '../types';
 import { useAppStore } from '../store/useAppStore';
+import { EmbeddingClient, VectorSearchService, findSimilarRepositories } from '../services/vectorSearchService';
 import { getAICategory, getDefaultCategory } from '../utils/categoryUtils';
 import { analyzeRepository, createFailedAnalysisResult } from '../services/aiAnalysisHelper';
 import { forceSyncToBackend } from '../services/autoSync';
@@ -105,7 +106,13 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
     setAnalyzingRepository,
     language,
     updateRepository,
-    deleteRepository
+    deleteRepository,
+    vectorSearchConfig,
+    vectorSearchStatus,
+    embeddingConfigs,
+    activeEmbeddingConfig,
+    repositories,
+    enterSimilarView
   } = useAppStore(
     useCallback(
       (state) => ({
@@ -115,7 +122,13 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
         setAnalyzingRepository: state.setAnalyzingRepository,
         language: state.language,
         updateRepository: state.updateRepository,
-        deleteRepository: state.deleteRepository
+        deleteRepository: state.deleteRepository,
+        vectorSearchConfig: state.vectorSearchConfig,
+        vectorSearchStatus: state.vectorSearchStatus,
+        embeddingConfigs: state.embeddingConfigs,
+        activeEmbeddingConfig: state.activeEmbeddingConfig,
+        repositories: state.repositories,
+        enterSimilarView: state.enterSimilarView
       }),
       []
     ),
@@ -145,6 +158,26 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
   const dragHintTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [isLocallyAnalyzing, setIsLocallyAnalyzing] = useState(false);
   const isAnalyzing = isLocallyAnalyzing || isStoreAnalyzing;
+
+  // 向量搜索是否可用（开关开启 + Worker 已连接 + 有索引 + Embedding 配置完整）
+  // 仅在可用时显示"查找相似仓库"按钮，避免无效点击
+  const vectorSearchAvailable = useMemo(() => {
+    const activeConfig = embeddingConfigs.find((c) => c.id === activeEmbeddingConfig);
+    const configComplete = !!activeConfig
+      && !!activeConfig.baseUrl
+      && !!activeConfig.model
+      && (activeConfig.apiType === 'ollama' || !!activeConfig.apiKey);
+    return (
+      vectorSearchConfig.enabled
+      && !!vectorSearchStatus?.connected
+      && (vectorSearchStatus?.vectorCount ?? 0) > 0
+      && configComplete
+      && !!vectorSearchConfig.workerUrl
+      && !!vectorSearchConfig.authToken
+    );
+  }, [embeddingConfigs, activeEmbeddingConfig, vectorSearchConfig, vectorSearchStatus]);
+
+  const [isFindingSimilar, setIsFindingSimilar] = useState(false);
 
   // 高亮搜索关键词的工具函数 - 使用缓存优化
   const highlightSearchTerm = useCallback((text: string, searchTerm: string): React.ReactNode => {
@@ -397,6 +430,68 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
   // Convert GitHub URL to DeepWiki URL
   const getDeepWikiUrl = (githubUrl: string) => {
     return githubUrl.replace('github.com', 'deepwiki.com');
+  };
+
+  // 查找相似仓库：利用向量检索匹配语义相关的仓库，并进入相似仓库视图
+  const handleFindSimilar = async () => {
+    if (isFindingSimilar) return;
+    if (!vectorSearchAvailable) {
+      toast(
+        language === 'zh'
+          ? '向量搜索未就绪：请先在设置中开启向量搜索并完成索引。'
+          : 'Vector search is not ready. Please enable vector search and build the index in settings first.',
+        'error'
+      );
+      return;
+    }
+
+    const activeConfig = embeddingConfigs.find((c) => c.id === activeEmbeddingConfig);
+    if (!activeConfig) return;
+
+    setIsFindingSimilar(true);
+    try {
+      const embeddingClient = new EmbeddingClient({
+        ...activeConfig,
+        apiType: activeConfig.apiType,
+        baseUrl: activeConfig.baseUrl,
+        apiKey: activeConfig.apiKey,
+        model: activeConfig.model,
+        dimensions: activeConfig.dimensions,
+      });
+      const vectorService = new VectorSearchService({
+        enabled: true,
+        workerUrl: vectorSearchConfig.workerUrl,
+        authToken: vectorSearchConfig.authToken,
+        embeddingConfigId: activeEmbeddingConfig || '',
+      });
+
+      const similar = await findSimilarRepositories(repository, {
+        embeddingClient,
+        vectorService,
+        allRepos: repositories,
+        topK: vectorSearchConfig.searchTopK ?? 30,
+        threshold: vectorSearchConfig.searchThreshold ?? 0.35,
+      });
+
+      enterSimilarView(similar, repository);
+
+      if (similar.length === 0) {
+        toast(
+          language === 'zh'
+            ? '未找到相似的仓库。'
+            : 'No similar repositories found.',
+          'info'
+        );
+      }
+    } catch (error) {
+      console.error('Find similar repositories failed:', error);
+      const errorMessage = error instanceof Error && error.message
+        ? error.message
+        : (language === 'zh' ? '查找相似仓库失败，请检查向量搜索配置。' : 'Failed to find similar repositories. Please check vector search configuration.');
+      toast(errorMessage, 'error');
+    } finally {
+      setIsFindingSimilar(false);
+    }
   };
 
   // Convert GitHub URL to Zread URL
@@ -1039,13 +1134,28 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
           </div>
         </div>
 
-        {/* Update Time - Single Row */}
+        {/* Update Time / 查找相似仓库 - 悬停时时间淡出，显示高亮按钮 */}
         <div className="flex items-center justify-between text-sm text-gray-700 dark:text-text-secondary pt-2 border-t border-black/[0.04] dark:border-white/[0.04]">
-          <div className="flex items-center space-x-1">
-            <Calendar className="w-4 h-4 flex-shrink-0" />
-            <span className="truncate">
+          <div className="relative flex items-center space-x-1 min-w-0">
+            <Calendar className={`w-4 h-4 flex-shrink-0 transition-opacity duration-150 ${vectorSearchAvailable && !selectionMode ? 'group-hover:opacity-0' : ''}`} />
+            <span className={`truncate transition-opacity duration-150 ${vectorSearchAvailable && !selectionMode ? 'group-hover:opacity-0' : ''}`}>
               {language === 'zh' ? '最近提交' : 'Last pushed'} {formatDistanceToNow(new Date(repository.pushed_at || repository.updated_at), { addSuffix: true })}
             </span>
+
+            {vectorSearchAvailable && !selectionMode && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleFindSimilar();
+                }}
+                disabled={isFindingSimilar}
+                className="absolute inset-y-0 left-0 flex items-center space-x-1 text-brand-violet dark:text-brand-violet font-medium opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto transition-opacity duration-150 hover:underline disabled:cursor-not-allowed disabled:hover:no-underline"
+                title={language === 'zh' ? '查找相似仓库' : 'Find similar repositories'}
+              >
+                {isFindingSimilar ? <Loader2 className="w-4 h-4 animate-spin" /> : <Search className="w-4 h-4" />}
+                <span>{language === 'zh' ? '查找相似仓库' : 'Find similar'}</span>
+              </button>
+            )}
           </div>
 
           {/* 选择按钮 */}

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -433,6 +433,10 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
   };
 
   // 查找相似仓库：利用向量检索匹配语义相关的仓库，并进入相似仓库视图
+  /**
+   * 点击"查找相似仓库"：校验向量搜索就绪后，对源仓库生成 embedding 并在 Worker
+   * 中检索相似仓库，将结果交给 store 进入相似视图。处理加载、空结果与错误态。
+   */
   const handleFindSimilar = async () => {
     if (isFindingSimilar) return;
     if (!vectorSearchAvailable) {

--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import { Bot, ChevronDown, Pause, Play } from 'lucide-react';
 import { RepositoryCard } from './RepositoryCard';
+import { SimilarViewBanner } from './SimilarViewBanner';
 import { BulkActionToolbar } from './BulkActionToolbar';
 import { BulkCategorizeModal } from './BulkCategorizeModal';
 import { BulkRestoreModal, RestoreConfig } from './BulkRestoreModal';
@@ -40,7 +41,9 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
     searchFilters,
     toggleReleaseSubscription,
     batchUnsubscribeReleases,
-    releaseSubscriptions
+    releaseSubscriptions,
+    similarView,
+    resetSimilarView
   } = useAppStore();
 
   const { toast, confirm } = useDialog();
@@ -1003,6 +1006,14 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
   return (
     <div className="space-y-6">
 
+      {/* Similar repositories view banner */}
+      {similarView?.active && (
+        <SimilarViewBanner
+          anchorRepoName={similarView.anchorRepoName}
+          onReset={resetSimilarView}
+          language={language}
+        />
+      )}
 
       {/* Controls Bar */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between bg-white dark:bg-panel-dark rounded-xl border border-black/[0.06] dark:border-white/[0.04] p-3 sm:p-4 gap-3 sm:gap-0">

--- a/src/components/SimilarViewBanner.tsx
+++ b/src/components/SimilarViewBanner.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { RotateCcw, Search } from 'lucide-react';
+
+interface SimilarViewBannerProps {
+  anchorRepoName: string;
+  onReset: () => void;
+  language: 'zh' | 'en';
+}
+
+export const SimilarViewBanner: React.FC<SimilarViewBannerProps> = ({
+  anchorRepoName,
+  onReset,
+  language,
+}) => {
+  const t = (zh: string, en: string) => (language === 'zh' ? zh : en);
+
+  return (
+    <div className="flex items-center justify-between gap-3 bg-brand-indigo/5 dark:bg-brand-indigo/10 border border-brand-indigo/20 dark:border-brand-indigo/30 rounded-xl px-4 py-3">
+      <div className="flex items-center gap-2 min-w-0">
+        <Search className="w-4 h-4 flex-shrink-0 text-brand-violet dark:text-brand-violet" />
+        <p className="text-sm text-gray-700 dark:text-text-secondary truncate">
+          <span className="text-gray-500 dark:text-text-tertiary">
+            {t('正在查看 ', 'Viewing similar repositories of ')}
+          </span>
+          <span className="font-semibold text-gray-900 dark:text-text-primary">
+            {anchorRepoName}
+          </span>
+          <span className="text-gray-500 dark:text-text-tertiary">
+            {t(' 的相似仓库', '')}
+          </span>
+        </p>
+      </div>
+      <button
+        onClick={onReset}
+        className="flex items-center gap-1.5 flex-shrink-0 px-3 py-1.5 text-sm font-medium rounded-lg bg-brand-indigo text-white hover:bg-brand-hover transition-colors"
+      >
+        <RotateCcw className="w-4 h-4" />
+        {t('重置', 'Reset')}
+      </button>
+    </div>
+  );
+};

--- a/src/components/SimilarViewBanner.tsx
+++ b/src/components/SimilarViewBanner.tsx
@@ -7,6 +7,9 @@ interface SimilarViewBannerProps {
   language: 'zh' | 'en';
 }
 
+/**
+ * 相似仓库视图顶部横幅：展示当前锚点仓库名，并提供"重置"按钮回到查找相似之前的状态。
+ */
 export const SimilarViewBanner: React.FC<SimilarViewBannerProps> = ({
   anchorRepoName,
   onReset,

--- a/src/services/vectorSearchService.ts
+++ b/src/services/vectorSearchService.ts
@@ -633,3 +633,59 @@ export async function indexAllRepos(
 
   return { indexed, skipped: repos.length - indexable.length, errors, error: lastError || undefined, indexedRepoIds };
 }
+
+/**
+ * 查找与源仓库语义相似的仓库。
+ *
+ * 流程：
+ * 1. 拼接源仓库文本并 embed（purpose='query'）
+ * 2. 调用 Worker 的 /query 接口获取相似向量 id 列表
+ * 3. 从全量仓库中映射回 Repository，过滤掉源仓库自身
+ *
+ * @returns 相似仓库数组（按相似度降序，已排除源仓库）
+ */
+export async function findSimilarRepositories(
+  sourceRepo: Repository,
+  opts: {
+    embeddingClient: EmbeddingClient;
+    vectorService: VectorSearchService;
+    allRepos: Repository[];
+    topK: number;
+    threshold: number;
+    signal?: AbortSignal;
+  }
+): Promise<Repository[]> {
+  const { embeddingClient, vectorService, allRepos, topK, threshold, signal } = opts;
+
+  // 1. 生成源仓库查询向量
+  const text = buildEmbeddingText(sourceRepo);
+  const vectors = await embeddingClient.embed([text], 'query', signal);
+  if (!vectors || vectors.length === 0 || !Array.isArray(vectors[0])) {
+    throw new Error('Failed to generate embedding for source repository');
+  }
+  const queryVector = vectors[0];
+
+  // 2. 向量检索（多取 1 个以容纳源仓库自身，随后过滤）
+  const matches = await vectorService.query(
+    queryVector,
+    { topK: topK + 1, threshold },
+    signal
+  );
+
+  // 3. 映射回 Repository，建立 id -> repo 索引
+  const repoById = new Map<number, Repository>();
+  for (const repo of allRepos) {
+    repoById.set(repo.id, repo);
+  }
+
+  const sourceId = String(sourceRepo.id);
+  const results: Repository[] = [];
+  for (const match of matches) {
+    // 过滤掉源仓库自身
+    if (match.id === sourceId) continue;
+    const repo = repoById.get(parseInt(match.id, 10));
+    if (repo) results.push(repo);
+  }
+
+  return results;
+}

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -330,6 +330,10 @@ interface AppActions {
   setVectorSearchConfig: (config: Partial<VectorSearchConfig>) => void;
   setVectorSearchStatus: (status: VectorSearchStatus | undefined) => void;
   setVectorIndexingState: (state: Partial<VectorIndexingState>) => void;
+
+  // Similar repositories view actions
+  enterSimilarView: (repos: Repository[], anchor: Repository) => void;
+  resetSimilarView: () => void;
   
   // Search actions
   setSearchFilters: (filters: Partial<SearchFilters>) => void;
@@ -1136,6 +1140,7 @@ export const useAppStore = create<AppState & AppActions>()(
       vectorSearchConfig: { ...defaultVectorSearchConfig },
       vectorSearchStatus: { connected: false, vectorCount: 0, dimensions: 0 },
       vectorIndexingState: { isIndexing: false, phase: null, phaseDone: 0, phaseTotal: 0, result: null },
+      similarView: null,
       webdavConfigs: [],
       activeWebDAVConfig: null,
       lastBackup: null,
@@ -1480,6 +1485,23 @@ export const useAppStore = create<AppState & AppActions>()(
       setVectorSearchStatus: (status) => set({ vectorSearchStatus: status }),
       setVectorIndexingState: (indexingState) => set((state) => ({
         vectorIndexingState: { ...state.vectorIndexingState, ...indexingState }
+      })),
+
+      // Similar repositories view actions
+      enterSimilarView: (repos, anchor) => set((state) => ({
+        similarView: {
+          active: true,
+          anchorRepoFullName: anchor.full_name,
+          anchorRepoName: anchor.name,
+          similarResults: repos,
+          originalSearchResults: state.searchResults,
+        },
+        // 进入相似视图时清空搜索条件，避免与搜索结果混淆（相似视图是列表的"替代"视图）
+        searchFilters: { ...initialSearchFilters },
+      })),
+      resetSimilarView: () => set((state) => ({
+        searchResults: state.similarView?.originalSearchResults ?? state.repositories,
+        similarView: null,
       })),
 
       // Search actions

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -1239,6 +1239,7 @@ export const useAppStore = create<AppState & AppActions>()(
         readForks: new Set(),
         analyzingRepositoryIds: new Set(),
         searchResults: [],
+        similarView: null,
         lastSync: null,
       }),
 

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -334,6 +334,7 @@ interface AppActions {
   // Similar repositories view actions
   enterSimilarView: (repos: Repository[], anchor: Repository) => void;
   resetSimilarView: () => void;
+  exitSimilarView: () => void;
   
   // Search actions
   setSearchFilters: (filters: Partial<SearchFilters>) => void;
@@ -1248,14 +1249,20 @@ export const useAppStore = create<AppState & AppActions>()(
         const searchResultsResult = state.searchResults === state.repositories
           ? repositoriesResult
           : replaceRepositoryInList(state.searchResults, repo);
+        const similarResultsResult = state.similarView
+          ? replaceRepositoryInList(state.similarView.similarResults, repo)
+          : null;
 
-        if (!repositoriesResult.changed && !searchResultsResult.changed) {
+        if (!repositoriesResult.changed && !searchResultsResult.changed && !similarResultsResult?.changed) {
           return state;
         }
 
         return {
           repositories: repositoriesResult.repositories,
-          searchResults: searchResultsResult.repositories
+          searchResults: searchResultsResult.repositories,
+          similarView: similarResultsResult
+            ? { ...state.similarView!, similarResults: similarResultsResult.repositories }
+            : state.similarView,
         };
       }),
       updateRepositoriesMetadata: (updates) => set((state) => {
@@ -1283,14 +1290,20 @@ export const useAppStore = create<AppState & AppActions>()(
         const searchResultsResult = state.searchResults === state.repositories
           ? repositoriesResult
           : applyPatches(state.searchResults);
+        const similarResultsResult = state.similarView
+          ? applyPatches(state.similarView.similarResults)
+          : { repositories: state.similarView?.similarResults ?? [], changed: false };
 
-        if (!repositoriesResult.changed && !searchResultsResult.changed) {
+        if (!repositoriesResult.changed && !searchResultsResult.changed && !similarResultsResult.changed) {
           return state;
         }
 
         return {
           repositories: repositoriesResult.repositories,
           searchResults: searchResultsResult.repositories,
+          similarView: state.similarView
+            ? { ...state.similarView, similarResults: similarResultsResult.repositories }
+            : state.similarView,
         };
       }),
       addRepository: (repo) => set((state) => {
@@ -1345,6 +1358,9 @@ export const useAppStore = create<AppState & AppActions>()(
         return {
           repositories: state.repositories.filter(r => r.id !== repoId),
           searchResults: state.searchResults.filter(r => r.id !== repoId),
+          similarView: state.similarView
+            ? { ...state.similarView, similarResults: state.similarView.similarResults.filter(r => r.id !== repoId) }
+            : state.similarView,
           releases: filteredReleases,
           releaseSubscriptions: nextReleaseSubscriptions,
           readReleases: nextReadReleases,
@@ -1488,21 +1504,37 @@ export const useAppStore = create<AppState & AppActions>()(
       })),
 
       // Similar repositories view actions
+      /**
+       * 进入"查找相似仓库"视图：保存当前相似结果、锚点仓库，并快照进入前的
+       * searchResults/searchFilters 用于重置恢复（链式查找时保留首次快照）。
+       */
       enterSimilarView: (repos, anchor) => set((state) => ({
         similarView: {
           active: true,
           anchorRepoFullName: anchor.full_name,
           anchorRepoName: anchor.name,
           similarResults: repos,
-          originalSearchResults: state.searchResults,
+          // 链式查找时保留首次进入的快照，避免覆盖重置目标
+          originalSearchResults: state.similarView?.originalSearchResults ?? state.searchResults,
+          originalSearchFilters: state.similarView?.originalSearchFilters ?? state.searchFilters,
         },
         // 进入相似视图时清空搜索条件，避免与搜索结果混淆（相似视图是列表的"替代"视图）
         searchFilters: { ...initialSearchFilters },
       })),
+      /**
+       * 重置相似视图：恢复进入前的搜索结果与条件（回到"查找相似之前"的状态）。
+       */
       resetSimilarView: () => set((state) => ({
+        // 重置恢复进入前的搜索结果与条件（回到"查找相似之前"的状态）
         searchResults: state.similarView?.originalSearchResults ?? state.repositories,
+        searchFilters: state.similarView?.originalSearchFilters ?? { ...initialSearchFilters },
         similarView: null,
       })),
+      /**
+       * 退出相似视图（不恢复进入前的搜索状态）：用于用户发起新搜索或切换分类时，
+       * 避免把旧快照覆盖到新的搜索/分类结果上。
+       */
+      exitSimilarView: () => set({ similarView: null }),
 
       // Search actions
       setSearchFilters: (filters) => set((state) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -267,6 +267,7 @@ export interface SimilarViewState {
   anchorRepoName: string;        // 锚点仓库名
   similarResults: Repository[];  // 相似结果，渲染用
   originalSearchResults: Repository[]; // 进入前的 searchResults 快照，重置恢复用
+  originalSearchFilters: SearchFilters; // 进入前的 searchFilters 快照，重置恢复用
 }
 export type AIReasoningEffort = 'none' | 'low' | 'medium' | 'high' | 'xhigh';
 export type MiMoPlan = 'api' | 'token-plan';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -259,6 +259,15 @@ export interface VectorIndexingState {
   phaseTotal: number;
   result: { indexed: number; skipped: number; errors: number; error?: string } | null;
 }
+
+// 相似仓库视图状态：进入"查找相似仓库"后保存当前上下文，重置时恢复
+export interface SimilarViewState {
+  active: boolean;
+  anchorRepoFullName: string;   // 当前锚点仓库 full_name（横幅展示）
+  anchorRepoName: string;        // 锚点仓库名
+  similarResults: Repository[];  // 相似结果，渲染用
+  originalSearchResults: Repository[]; // 进入前的 searchResults 快照，重置恢复用
+}
 export type AIReasoningEffort = 'none' | 'low' | 'medium' | 'high' | 'xhigh';
 export type MiMoPlan = 'api' | 'token-plan';
 
@@ -393,6 +402,9 @@ export interface AppState {
   vectorSearchConfig: VectorSearchConfig;
   vectorSearchStatus?: VectorSearchStatus;
   vectorIndexingState: VectorIndexingState;
+
+  // Similar repositories view (triggered by "查找相似仓库")
+  similarView: SimilarViewState | null;
 
   // WebDAV
   webdavConfigs: WebDAVConfig[];


### PR DESCRIPTION
## Summary

Adds a "find similar repositories" capability on the repository page that leverages the existing vector-search index.

- When vector search is enabled and ready (switch on + worker connected + index non-empty + embedding config complete), hovering a repository card turns the bottom-left "last pushed" line into a highlighted **查找相似仓库 / Find similar** button.
- Clicking it embeds the source repo, queries the vector worker, and **replaces** the list with the most similar repositories (supports chained lookups within the result set).
- A top banner shows the anchor repo name and a **Reset** button that returns directly to the normal list (ignores intermediate levels). Clicking a category in the sidebar also exits the similar view.
- To avoid UI ambiguity, entering the similar view clears the search bar, and initiating a new search while in the similar view automatically exits it (search takes precedence).

## Changes

- `src/types/index.ts`: new `SimilarViewState` type + `similarView` on `AppState`.
- `src/store/useAppStore.ts`: `similarView` state (not persisted), `enterSimilarView` / `resetSimilarView` actions.
- `src/services/vectorSearchService.ts`: `findSimilarRepositories()` (embed source → query → map ids → exclude source).
- `src/components/RepositoryCard.tsx`: hover action button + `handleFindSimilar`, with a `vectorSearchAvailable` gate derived from real readiness.
- `src/components/SimilarViewBanner.tsx`: new banner (anchor name + reset).
- `src/components/RepositoryList.tsx`: renders banner when `similarView.active`.
- `src/App.tsx`: `RepositoriesView` switches list source to similar results; auto-exit on new search.
- `docs/plans/2026-07-12-find-similar-repositories-design.md`: design notes.

## Testing

- `npx tsc --noEmit` passes.
- `npx eslint` on all changed files passes.
- `src/services/vectorSearchService.test.ts`: 17 tests pass (including similarity search, exclusion of source, and empty-index path).

## Notes / Limitations

- The query vector is built from the repo's structured metadata (description, summary, topics, language); if the index was built in `readme` mode, recall precision may be slightly lower on this first version.
- `similarView` is intentionally not persisted — a reload returns to the normal view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Find similar repositories” from repository cards when semantic/vector search is available, including a hover CTA, loading spinner, and concurrency protection.
  * Introduced a similar-repositories mode that replaces the current list and allows chaining further similar searches.
  * Added a banner showing the anchor repository and a one-click “reset” to return to the prior list; similar mode is exited when category/search filters are applied.
* **Documentation**
  * Added detailed interaction design documentation for the similar-repositories flow, including edge cases and test guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->