### PR TITLE
feat: 在 Release 卡片新增 AI「总结」按钮

### DIFF
--- a/src/components/ReleaseCard.tsx
+++ b/src/components/ReleaseCard.tsx
@@ -1,11 +1,18 @@
 import React, { memo, useCallback, useRef, useState } from 'react';
-import { ExternalLink, GitBranch, Calendar, Download, ChevronDown, ChevronUp, BookOpen, ArrowUpRight, FolderOpen, Folder, BellOff, FileArchive, Code2, Loader2, CheckCircle2 } from 'lucide-react';
+import { ExternalLink, GitBranch, Calendar, Download, ChevronDown, ChevronUp, BookOpen, ArrowUpRight, FolderOpen, Folder, BellOff, FileArchive, Code2, Loader2, CheckCircle2, Sparkles } from 'lucide-react';
 import { Release } from '../types';
 import { formatDistanceToNow } from 'date-fns';
 import MarkdownRenderer from './MarkdownRenderer';
 import { useAppStore } from '../store/useAppStore';
 import { useDialog } from '../hooks/useDialog';
 import { sendToRpcDownload } from '../services/rpcDownloadService';
+import { AIService } from '../services/aiService';
+
+type SummaryState = {
+  status: 'idle' | 'loading' | 'done' | 'error';
+  content?: string;
+  error?: string;
+};
 
 interface DownloadLink {
   name: string;
@@ -55,7 +62,12 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
   const t = useCallback((zh: string, en: string) => language === 'zh' ? zh : en, [language]);
 
   // RPC download support — use refs to avoid stale closure in async handler
-  const { rpcDownloadConfig, backendApiSecret } = useAppStore();
+  const { rpcDownloadConfig, backendApiSecret, aiConfigs, activeAIConfig } = useAppStore();
+  const activeConfig = aiConfigs.find((config) => config.id === activeAIConfig);
+
+  // AI 总结的本地状态（展开态与结果均内聚在卡片内，不持久化）
+  const [isSummaryExpanded, setIsSummaryExpanded] = useState(false);
+  const [summary, setSummary] = useState<SummaryState>({ status: 'idle' });
   const { toast } = useDialog();
   const downloadingRef = useRef<Record<string, boolean>>({});
   const downloadedRef = useRef<Record<string, boolean>>({});
@@ -89,7 +101,64 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
   }, [backendApiSecret, toast, t]);
 
   // 判断是否有任何内容展开
-  const isAnyExpanded = isAssetsExpanded || isReleaseNotesExpanded;
+  const isAnyExpanded = isAssetsExpanded || isReleaseNotesExpanded || isSummaryExpanded;
+
+  const runSummaryAnalysis = useCallback(async () => {
+    if (!activeConfig) {
+      toast(
+        language === 'zh' ? '请先在设置中配置 AI 服务。' : 'Please configure AI service in settings first.',
+        'error'
+      );
+      return;
+    }
+
+    const config = activeConfig;
+    setSummary({ status: 'loading' });
+    try {
+      const aiService = new AIService(config, language);
+      const content = await aiService.analyzeReleaseSummary(
+        release.body || '',
+        {
+          repoName: release.repository.full_name,
+          tagName: release.tag_name,
+          releaseName: release.name && release.name !== release.tag_name ? release.name : undefined,
+        }
+      );
+      setSummary({ status: 'done', content });
+      setIsSummaryExpanded(true);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setSummary({ status: 'error', error: message });
+      setIsSummaryExpanded(true);
+      toast(
+        language === 'zh' ? `总结生成失败：${message}` : `Summary failed: ${message}`,
+        'error'
+      );
+    }
+  }, [activeConfig, language, release, toast]);
+
+  const handleToggleSummary = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation();
+
+    // 已展开时：出错态点击重试，否则收起
+    if (isSummaryExpanded) {
+      if (summary.status === 'error') {
+        await runSummaryAnalysis();
+        return;
+      }
+      setIsSummaryExpanded(false);
+      return;
+    }
+
+    // 已有结论且未展开 → 直接展开（不重复分析）
+    if (summary.status === 'done' && summary.content) {
+      setIsSummaryExpanded(true);
+      return;
+    }
+
+    // 未分析或上次失败 → 触发 AI 分析（按钮转圈，完成后自动展开）
+    await runSummaryAnalysis();
+  }, [isSummaryExpanded, summary, runSummaryAnalysis]);
 
   return (
     <div
@@ -190,6 +259,29 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
               </button>
             )}
 
+            {release.body && (
+              <button
+                onClick={handleToggleSummary}
+                disabled={summary.status === 'loading'}
+                className={`flex items-center space-x-0.5 px-1.5 py-1 rounded transition-all duration-200 whitespace-nowrap disabled:opacity-70 ${
+                  isSummaryExpanded
+                    ? 'bg-gray-100 dark:bg-white/[0.08] text-gray-700 dark:text-text-secondary'
+                    : 'bg-light-surface text-gray-700 dark:bg-white/[0.04] dark:text-text-tertiary hover:bg-gray-200 dark:hover:bg-white/[0.08]'
+                }`}
+                title={isSummaryExpanded ? t('隐藏 AI 总结', 'Hide AI Summary') : t('AI 总结本次更新', 'AI Summary of this update')}
+                aria-label={isSummaryExpanded ? t('隐藏 AI 总结', 'Hide AI Summary') : t('AI 总结本次更新', 'AI Summary of this update')}
+                aria-expanded={isSummaryExpanded}
+              >
+                {summary.status === 'loading' ? (
+                  <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                ) : (
+                  <Sparkles className="w-3.5 h-3.5" />
+                )}
+                <span className="text-xs font-medium">{t('总结', 'Summary')}</span>
+                {summary.status !== 'loading' && (isSummaryExpanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />)}
+              </button>
+            )}
+
             <button
               onClick={(e) => {
                 e.stopPropagation();
@@ -223,7 +315,7 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
       {/* 可展开内容区域 */}
       <div
         className="grid transition-[grid-template-rows] duration-300 ease-in-out"
-        style={{ gridTemplateRows: (isAssetsExpanded || isReleaseNotesExpanded) ? '1fr' : '0fr' }}
+        style={{ gridTemplateRows: (isAssetsExpanded || isReleaseNotesExpanded || isSummaryExpanded) ? '1fr' : '0fr' }}
       >
         <div className="overflow-hidden min-h-0">
           <div className="px-3 sm:px-4 pb-3 sm:pb-4 pt-3 sm:pt-4 border-t border-black/[0.06] dark:border-white/[0.04]">
@@ -360,6 +452,33 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
                       <ArrowUpRight className="w-3.5 h-3.5" />
                       <span>{t('GitHub', 'GitHub')}</span>
                     </a>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+          {isSummaryExpanded && release.body && (
+            <div className="py-2">
+              <div className="flex items-center space-x-2 mb-3">
+                <Sparkles className="w-3.5 h-3.5 text-gray-700 dark:text-text-secondary" />
+                <span className="text-xs font-medium text-gray-900 dark:text-text-secondary">
+                  {t('AI 总结', 'AI Summary')}
+                </span>
+              </div>
+
+              <div className="relative">
+                {summary.status === 'loading' && (
+                  <div className="flex items-center justify-center space-x-2 py-6 text-xs text-gray-500 dark:text-text-tertiary">
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    <span>{t('正在分析更新内容…', 'Analyzing update…')}</span>
+                  </div>
+                )}
+                {summary.status === 'done' && summary.content && (
+                  <MarkdownRenderer content={summary.content} shouldRender={true} />
+                )}
+                {summary.status === 'error' && (
+                  <div className="py-3 text-xs text-red-500 dark:text-red-400">
+                    {t('总结生成失败，请重试。', 'Failed to generate summary. Please try again.')}
                   </div>
                 )}
               </div>

--- a/src/components/ReleaseCard.tsx
+++ b/src/components/ReleaseCard.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useRef, useState } from 'react';
+import React, { memo, useCallback, useRef, useState, useEffect } from 'react';
 import { ExternalLink, GitBranch, Calendar, Download, ChevronDown, ChevronUp, BookOpen, ArrowUpRight, FolderOpen, Folder, BellOff, FileArchive, Code2, Loader2, CheckCircle2, Sparkles } from 'lucide-react';
 import { Release } from '../types';
 import { formatDistanceToNow } from 'date-fns';
@@ -69,6 +69,14 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
   const [isSummaryExpanded, setIsSummaryExpanded] = useState(false);
   const [summary, setSummary] = useState<SummaryState>({ status: 'idle' });
   const { toast } = useDialog();
+  // 管理进行中的 AI 请求，组件卸载或重新发起时取消，避免内存泄漏与无效网络开销
+  const summaryAbortRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    return () => {
+      summaryAbortRef.current?.abort();
+    };
+  }, []);
   const downloadingRef = useRef<Record<string, boolean>>({});
   const downloadedRef = useRef<Record<string, boolean>>({});
   const [, forceUpdate] = useState(0);
@@ -112,6 +120,11 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
       return;
     }
 
+    // 取消上一次未完成的请求
+    summaryAbortRef.current?.abort();
+    const controller = new AbortController();
+    summaryAbortRef.current = controller;
+
     const config = activeConfig;
     setSummary({ status: 'loading' });
     try {
@@ -122,11 +135,16 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
           repoName: release.repository.full_name,
           tagName: release.tag_name,
           releaseName: release.name && release.name !== release.tag_name ? release.name : undefined,
-        }
+        },
+        controller.signal
       );
       setSummary({ status: 'done', content });
       setIsSummaryExpanded(true);
     } catch (error) {
+      // 主动取消（卸载/重新发起）时静默处理，不更新状态、不弹错误
+      if (error instanceof Error && error.name === 'AbortError') {
+        return;
+      }
       const message = error instanceof Error ? error.message : String(error);
       setSummary({ status: 'error', error: message });
       setIsSummaryExpanded(true);
@@ -134,18 +152,18 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
         language === 'zh' ? `总结生成失败：${message}` : `Summary failed: ${message}`,
         'error'
       );
+    } finally {
+      if (summaryAbortRef.current === controller) {
+        summaryAbortRef.current = null;
+      }
     }
   }, [activeConfig, language, release, toast]);
 
   const handleToggleSummary = useCallback(async (e: React.MouseEvent) => {
     e.stopPropagation();
 
-    // 已展开时：出错态点击重试，否则收起
+    // 已展开时：一律收起（出错态也先收起，再次点击已收起的错误态才会重试）
     if (isSummaryExpanded) {
-      if (summary.status === 'error') {
-        await runSummaryAnalysis();
-        return;
-      }
       setIsSummaryExpanded(false);
       return;
     }

--- a/src/components/ReleaseCard.tsx
+++ b/src/components/ReleaseCard.tsx
@@ -286,8 +286,8 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
                     ? 'bg-gray-100 dark:bg-white/[0.08] text-gray-700 dark:text-text-secondary'
                     : 'bg-light-surface text-gray-700 dark:bg-white/[0.04] dark:text-text-tertiary hover:bg-gray-200 dark:hover:bg-white/[0.08]'
                 }`}
-                title={isSummaryExpanded ? t('隐藏 AI 总结', 'Hide AI Summary') : t('AI 总结本次更新', 'AI Summary of this update')}
-                aria-label={isSummaryExpanded ? t('隐藏 AI 总结', 'Hide AI Summary') : t('AI 总结本次更新', 'AI Summary of this update')}
+                title={isSummaryExpanded ? t('隐藏 AI 总结', 'Hide AI Summary') : (summary.status === 'error' ? t('重试 AI 总结', 'Retry AI summary') : t('AI 总结本次更新', 'AI Summary of this update'))}
+                aria-label={isSummaryExpanded ? t('隐藏 AI 总结', 'Hide AI Summary') : (summary.status === 'error' ? t('重试 AI 总结', 'Retry AI summary') : t('AI 总结本次更新', 'AI Summary of this update'))}
                 aria-expanded={isSummaryExpanded}
               >
                 {summary.status === 'loading' ? (

--- a/src/components/ReleaseCard.tsx
+++ b/src/components/ReleaseCard.tsx
@@ -277,7 +277,7 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
               </button>
             )}
 
-            {release.body && (
+            {release.body?.trim() && (
               <button
                 onClick={handleToggleSummary}
                 disabled={summary.status === 'loading'}
@@ -475,7 +475,7 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
               </div>
             </div>
           )}
-          {isSummaryExpanded && release.body && (
+          {isSummaryExpanded && release.body?.trim() && (
             <div className="py-2">
               <div className="flex items-center space-x-2 mb-3">
                 <Sparkles className="w-3.5 h-3.5 text-gray-700 dark:text-text-secondary" />

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -602,6 +602,62 @@ ${this.sanitizeForPrompt(contentPreview).slice(0, 6000)}
     });
   }
 
+  /**
+   * 分析单个 release 的更新日志，输出通俗易懂、按重要程度排序的 Markdown 总结。
+   * 用于 Release 列表项的「总结」按钮。直接返回 Markdown 文本，调用方负责渲染。
+   * @param releaseBody release 的正文（Markdown 更新说明）
+   * @param meta release 的元信息
+   * @param signal 可选 AbortSignal
+   */
+  async analyzeReleaseSummary(
+    releaseBody: string,
+    meta: { repoName: string; tagName: string; releaseName?: string },
+    signal?: AbortSignal
+  ): Promise<string> {
+    const body = this.sanitizeForPrompt(releaseBody || '').slice(0, 12000);
+    if (!body.trim()) {
+      throw new Error(this.language === 'zh' ? 'Release 内容为空，无法分析。' : 'Release body is empty, cannot analyze.');
+    }
+
+    const system = this.language === 'zh'
+      ? '你是一个专业的 GitHub Release 更新日志分析助手。请用简体中文，以通俗易懂的语言总结本次更新。直接输出 Markdown，不要输出任何额外解释、代码块标记或“以下是总结”之类的开场白。排版需易读，使用列表形式，并按重要程度从高到低排序。'
+      : 'You are a professional GitHub Release changelog analysis assistant. Summarize this update in plain, easy-to-understand English. Output Markdown directly, without any extra explanation, code fences, or opening remarks such as "Here is the summary". Use a readable layout with lists, ordered from most to least important.';
+
+    const user = this.language === 'zh'
+      ? `
+以下是 GitHub 仓库 "${meta.repoName}" 的 Release（标签：${meta.tagName}${meta.releaseName ? `，名称：${meta.releaseName}` : ''}）的更新说明。
+
+请完成以下要求：
+1. 用通俗易懂的语言，面向普通用户总结本次更新的要点。
+2. 尽量区分「新功能 / 特性」与「Bug 修复」两类内容（无对应内容时可省略该分类）。
+3. 使用列表形式（可用子列表），按重要程度从高到低排序，最重要的写在最前面。
+4. 只输出 Markdown 内容，不要加额外说明。
+
+更新说明原文：
+${body}
+      `.trim()
+      : `
+Below is the changelog of a GitHub Release for "${meta.repoName}" (tag: ${meta.tagName}${meta.releaseName ? `, name: ${meta.releaseName}` : ''}).
+
+Requirements:
+1. Summarize the update in plain language for general users.
+2. Separate "New Features" from "Bug Fixes" where applicable (omit a section if empty).
+3. Use lists (nested lists are fine), ordered from most to least important.
+4. Output only Markdown content, no extra commentary.
+
+Changelog:
+${body}
+      `.trim();
+
+    return this.requestText({
+      system,
+      user,
+      temperature: 0.3,
+      maxTokens: 4096,
+      signal,
+    });
+  }
+
   async searchGistsWithReranking(gists: Gist[], query: string): Promise<Gist[]> {
     if (gists.length === 0) return [];
 

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -623,9 +623,13 @@ ${this.sanitizeForPrompt(contentPreview).slice(0, 6000)}
       ? '你是一个专业的 GitHub Release 更新日志分析助手。请用简体中文，以通俗易懂的语言总结本次更新。直接输出 Markdown，不要输出任何额外解释、代码块标记或“以下是总结”之类的开场白。排版需易读，使用列表形式，并按重要程度从高到低排序。'
       : 'You are a professional GitHub Release changelog analysis assistant. Summarize this update in plain, easy-to-understand English. Output Markdown directly, without any extra explanation, code fences, or opening remarks such as "Here is the summary". Use a readable layout with lists, ordered from most to least important.';
 
+    const repoName = this.sanitizeForPrompt(meta.repoName);
+    const tagName = this.sanitizeForPrompt(meta.tagName);
+    const releaseName = meta.releaseName ? this.sanitizeForPrompt(meta.releaseName) : '';
+
     const user = this.language === 'zh'
       ? `
-以下是 GitHub 仓库 "${meta.repoName}" 的 Release（标签：${meta.tagName}${meta.releaseName ? `，名称：${meta.releaseName}` : ''}）的更新说明。
+以下是 GitHub 仓库 "${repoName}" 的 Release（标签：${tagName}${releaseName ? `，名称：${releaseName}` : ''}）的更新说明。
 
 请完成以下要求：
 1. 用通俗易懂的语言，面向普通用户总结本次更新的要点。
@@ -637,7 +641,7 @@ ${this.sanitizeForPrompt(contentPreview).slice(0, 6000)}
 ${body}
       `.trim()
       : `
-Below is the changelog of a GitHub Release for "${meta.repoName}" (tag: ${meta.tagName}${meta.releaseName ? `, name: ${meta.releaseName}` : ''}).
+Below is the changelog of a GitHub Release for "${repoName}" (tag: ${tagName}${releaseName ? `, name: ${releaseName}` : ''}).
 
 Requirements:
 1. Summarize the update in plain language for general users.
@@ -649,13 +653,20 @@ Changelog:
 ${body}
       `.trim();
 
-    return this.requestText({
+    const response = await this.requestText({
       system,
       user,
       temperature: 0.3,
       maxTokens: 4096,
       signal,
     });
+
+    // 防御性处理：部分模型仍会用 ```markdown 或 ``` 包裹返回内容，
+    // 剥离首尾代码块标记，避免 MarkdownRenderer 将其渲染成代码块。
+    return response
+      .replace(/^```(?:markdown)?[ \t]*\n?/i, '')
+      .replace(/\n?[ \t]*```\s*$/i, '')
+      .trim();
   }
 
   async searchGistsWithReranking(gists: Gist[], query: string): Promise<Gist[]> {


### PR DESCRIPTION
## 概述
在 Release 列表项的「日志」与「取消订阅」铃铛之间，新增一个与「资产」「日志」样式一致的「总结」切换按钮。点击后调用已配置的 AI 服务分析该 release 的更新日志，以界面语言（设置中的 zh/en）输出通俗易懂、按重要程度排序、列表化排版的 Markdown 总结（新特性 / Bug 修复等）。

## 行为
- 点击「总结」→ 按钮立即显示旋转加载图标（面板保持收起），后台调用 AI。
- AI 输出完成后自动展开结果面板（沿用与「资产」「日志」相同的折叠动画 `grid-template-rows`）。
- 再次点击 → 收起；已有结论时点击只切换展开/收起，不重复分析。
- 分析失败 → 弹出错误提示并在面板内显示错误，点击按钮可重试。
- 未配置 AI 服务时点击给出提示。

## 改动文件
- `src/services/aiService.ts`：新增 `analyzeReleaseSummary()`，直接返回 Markdown 文本（参照 `analyzeGist` 模式），按配置语言要求以 Markdown 列表、按重要度排序输出。
- `src/components/ReleaseCard.tsx`：新增「总结」按钮与展开面板、本地分析状态（展开态与结果内聚在卡片内，不持久化，与现有 `expandedAssets`/`expandedReleaseNotes` 的本地 UI 态惯例一致），两处渲染点（时间线视图 / 仓库分类视图）无需新增 props。

## 验证
- `npm run lint` 通过
- `npm run build` 通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional “AI 总结” panel and header button on release cards to generate a Markdown summary from the release description.
  * Supports expand/collapse with a loading state, successful Markdown rendering, and an inline error display.
  * Automatically re-runs summary generation after failures.
* **Bug Fixes**
  * Cancels in-progress generation when you re-run or leave the card to prevent stale results, and shows a toast only for genuine errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->