### PR TITLE
fix(backup): WebDAV 恢复后保留铃铛订阅、Watch 来源与已读状态

### DIFF
--- a/src/components/settings/BackupPanel.tsx
+++ b/src/components/settings/BackupPanel.tsx
@@ -155,16 +155,18 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
         }
 
         // 恢复 Release 订阅、来源(Watch/自定义)与已读状态。
-        // 旧版 1.0 备份无这些字段 —— setter 内部经 normalizeReleaseSourceSettings 对 null/缺字段安全回退为默认空，保持向后兼容。
+        // 旧版 1.0 备份无这些字段 —— 仅在字段存在时回填，且对数组元素做数字过滤，与 store 的 normalizeNumberSet 行为一致，防止损坏/被篡改的备份混入非数字类型污染 Set<number>。
         try {
           if (Array.isArray(backupData.releaseSubscriptions)) {
-            useAppStore.setState({ releaseSubscriptions: new Set<number>(backupData.releaseSubscriptions) });
+            const validSubscriptions = backupData.releaseSubscriptions.filter((id: unknown): id is number => typeof id === 'number');
+            useAppStore.setState({ releaseSubscriptions: new Set<number>(validSubscriptions) });
           }
-          if (backupData.releaseSourceSettings !== undefined) {
-            setReleaseSourceSettings(backupData.releaseSourceSettings ?? null);
+          if (backupData.releaseSourceSettings) {
+            setReleaseSourceSettings(backupData.releaseSourceSettings);
           }
           if (Array.isArray(backupData.readReleases)) {
-            useAppStore.setState({ readReleases: new Set<number>(backupData.readReleases) });
+            const validReads = backupData.readReleases.filter((id: unknown): id is number => typeof id === 'number');
+            useAppStore.setState({ readReleases: new Set<number>(validReads) });
           }
         } catch (e) {
           console.warn('恢复 Release 订阅与已读状态时发生问题：', e);

--- a/src/components/settings/BackupPanel.tsx
+++ b/src/components/settings/BackupPanel.tsx
@@ -40,6 +40,7 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
     setProxyConfig,
     setRpcDownloadConfig,
     setBackendApiSecret,
+    setReleaseSourceSettings,
   } = useAppStore();
 
   const { toast, confirm } = useDialog();
@@ -81,9 +82,15 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
           secret: includeKeysInBackup ? rpcDownloadConfig.secret : (rpcDownloadConfig.secret ? '***' : ''),
         },
         backendApiSecret: includeKeysInBackup ? backendApiSecret : (backendApiSecret ? '***' : null),
+
+        // Release 订阅、来源(Watch/自定义)与已读状态 —— 此前遗漏，导致 WebDAV 恢复后铃铛订阅与 Watch 仓库丢失
+        releaseSubscriptions: Array.from(useAppStore.getState().releaseSubscriptions),
+        releaseSourceSettings: useAppStore.getState().releaseSourceSettings,
+        readReleases: Array.from(useAppStore.getState().readReleases),
+
         includeKeysInBackup,
         exportedAt: new Date().toISOString(),
-        version: '1.0'
+        version: '1.1'
       };
 
       const filename = `github-stars-backup-${new Date().toISOString().split('T')[0]}.json`;
@@ -145,6 +152,22 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
         }
         if (Array.isArray(backupData.releases)) {
           setReleases(backupData.releases);
+        }
+
+        // 恢复 Release 订阅、来源(Watch/自定义)与已读状态。
+        // 旧版 1.0 备份无这些字段 —— setter 内部经 normalizeReleaseSourceSettings 对 null/缺字段安全回退为默认空，保持向后兼容。
+        try {
+          if (Array.isArray(backupData.releaseSubscriptions)) {
+            useAppStore.setState({ releaseSubscriptions: new Set<number>(backupData.releaseSubscriptions) });
+          }
+          if (backupData.releaseSourceSettings !== undefined) {
+            setReleaseSourceSettings(backupData.releaseSourceSettings ?? null);
+          }
+          if (Array.isArray(backupData.readReleases)) {
+            useAppStore.setState({ readReleases: new Set<number>(backupData.readReleases) });
+          }
+        } catch (e) {
+          console.warn('恢复 Release 订阅与已读状态时发生问题：', e);
         }
 
         try {
@@ -415,6 +438,7 @@ export const BackupPanel: React.FC<BackupPanelProps> = ({ t }) => {
           <li>• {t('自定义分类', 'Custom categories')}</li>
           <li>• {t('AI 服务配置', 'AI service configurations')}</li>
           <li>• {t('WebDAV 配置', 'WebDAV configurations')}</li>
+          <li>• {t('Release 订阅、来源与已读状态', 'Release subscriptions, sources & read state')}</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## 问题

备份到 WebDAV → 恢复备份后，以下 release 相关数据全部丢失：
- 仓库卡片上铃铛图标订阅的仓库（`releaseSubscriptions`）
- Release 来源设置中的「Watch 仓库」与「自定义订阅」（`releaseSourceSettings.watchCustomReleaseRepos` / `customReleaseRepos`）
- 发布已读标记（`readReleases`）

## 根因

WebDAV 备份/恢复（`src/components/settings/BackupPanel.tsx`）自行手工拼装 JSON 负载，遗漏了这三项**仅存于前端 Zustand store（持久化到 IndexedDB）**的状态，且无对应服务端表；`handleRestore` 也从不回填它们。铃铛 UI 凭 `releaseSubscriptions.has(repoId)` 判定亮灭（`RepositoryCard.tsx`），恢复后该集合为 `new Set()` → 所有铃铛全灭，丢失静默。

`repositories` 里的每行 `subscribed_to_releases` 布尔列虽存活，但 UI 不读它（`resolveReleaseSources` 用 `releaseSubscriptions.has(repo.id)` 过滤），故不解决丢失。

平行的本地文件导出/导入 `DataManagementPanel.tsx` 本就处理正确，本次按其行为镜像到 WebDAV 链路。

## 改动（仅 `BackupPanel.tsx`）

- **备份**：在 `backupData` 写入 `releaseSubscriptions`、`releaseSourceSettings`、`readReleases`；`version` `1.0` → `1.1`。
- **恢复**：`setReleases` 之后用 `useAppStore.setState` 回填订阅与已读 Set，用 `setReleaseSourceSettings(... ?? null)` 回填来源（setter 内部经 `normalizeReleaseSourceSettings` 对 `null`/缺字段安全回退默认空）。
- **UI**：「备份内容包括」文案新增一行「Release 订阅、来源与已读状态」。

## 向后兼容

旧版 `1.0` 备份无这些字段 —— `Array.isArray` 守卫 + setter 内置 `normalizeReleaseSourceSettings(null)` 回退默认空集合，恢复不报错、行为与升级前一致。

## 验证

- `tsc -p tsconfig.app.json`：BackupPanel 零错误；`eslint`（BackupPanel）：通过。
- `vitest`：11 文件 / 110 测试全通过。
- 端到端手测脚本见计划文件：订阅-备份-清空-恢复-核对铃铛与 Watch 列表；并用删掉 `releaseSourceSettings` 键的旧 `1.0` 备份回归向后兼容。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backups now include release subscriptions, release source settings, and release read-status data.
  * The backup contents list has been updated to reflect the added release information.
* **Bug Fixes**
  * Restoring older backups remains supported; release-related fields are applied only when present and in a compatible format.
  * Restore will safely skip applying release data if it can’t be read, with a warning logged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->