### PR TITLE
feat: add Atlas Cloud AI provider

### DIFF
--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -251,7 +251,7 @@ router.post('/api/proxy/ai', async (req, res) => {
       'Accept': 'application/json',
     };
 
-    if (apiType === 'openai' || apiType === 'openai-responses' || apiType === 'openai-compatible' || apiType === 'deepseek' || apiType === 'mimo') {
+    if (apiType === 'openai' || apiType === 'openai-responses' || apiType === 'openai-compatible' || apiType === 'deepseek' || apiType === 'atlascloud' || apiType === 'mimo') {
       // openai-compatible 类型直接使用 baseUrl 作为完整地址
       targetUrl = apiType === 'openai-compatible'
         ? baseUrl.replace(/\/$/, '')
@@ -273,13 +273,16 @@ router.post('/api/proxy/ai', async (req, res) => {
     }
 
     // DeepSeek Reasoner does not support the reasoning parameter
-    const isDeepSeekReasoner = model.trim() === 'deepseek-reasoner';
+    const normalizedModel = model.trim().toLowerCase();
+    const isDeepSeekReasoner = normalizedModel === 'deepseek-reasoner';
+    const isAtlasDeepSeek = apiType === 'atlascloud' && normalizedModel.includes('deepseek');
     const effectiveRequestBody = (
       reasoningEffort
       && !isDeepSeekReasoner
+      && !isAtlasDeepSeek
       && typeof requestBody === 'object'
       && requestBody !== null
-      && (apiType === 'openai' || apiType === 'openai-responses' || apiType === 'openai-compatible' || apiType === 'deepseek' || apiType === 'mimo')
+      && (apiType === 'openai' || apiType === 'openai-responses' || apiType === 'openai-compatible' || apiType === 'deepseek' || apiType === 'atlascloud' || apiType === 'mimo')
       && !('reasoning' in requestBody)
     )
       ? { ...requestBody, reasoning: { effort: reasoningEffort } }

--- a/src/components/settings/AIConfigPanel.tsx
+++ b/src/components/settings/AIConfigPanel.tsx
@@ -35,8 +35,13 @@ const DEFAULT_API_ENDPOINTS: Record<AIApiType, string> = {
   claude: 'https://api.anthropic.com/v1',
   gemini: 'https://generativelanguage.googleapis.com/v1beta',
   deepseek: 'https://api.deepseek.com',
+  atlascloud: 'https://api.atlascloud.ai/v1',
   mimo: MIMO_PLAN_ENDPOINTS.api,
   'openai-compatible': '',
+};
+
+const DEFAULT_API_MODELS: Partial<Record<AIApiType, string>> = {
+  atlascloud: 'deepseek-ai/deepseek-v4-pro',
 };
 
 function getEndpointPlaceholder(apiType: AIApiType, mimoPlan: MiMoPlan): string {
@@ -48,6 +53,8 @@ function getEndpointPlaceholder(apiType: AIApiType, mimoPlan: MiMoPlan): string 
       return 'https://api.anthropic.com/v1';
     case 'deepseek':
       return 'https://api.deepseek.com';
+    case 'atlascloud':
+      return 'https://api.atlascloud.ai/v1';
     case 'mimo':
       return MIMO_PLAN_ENDPOINTS[mimoPlan];
     case 'openai-compatible':
@@ -65,6 +72,8 @@ function getEndpointHelpText(apiType: AIApiType, t: (zh: string, en: string) => 
       return t('只填到 v1beta 即可，路径会自动生成', 'Only include the version prefix v1beta, the path will be generated automatically');
     case 'deepseek':
       return t('填写到域名即可（如 https://api.deepseek.com），路径会自动生成', 'Only include the domain (e.g. https://api.deepseek.com), the path will be generated automatically');
+    case 'atlascloud':
+      return t('填写到 /v1 即可，Chat Completions 路径会自动生成', 'Only include up to /v1; the Chat Completions path will be generated automatically');
     case 'mimo':
       return t('填写到 /v1 即可（如 https://api.xiaomimimo.com/v1），路径会自动生成', 'Only include up to /v1 (e.g. https://api.xiaomimimo.com/v1), the path will be generated automatically');
     default:
@@ -123,23 +132,23 @@ export const AIConfigPanel: React.FC<AIConfigPanelProps> = ({ t }) => {
     mimoPlan: 'api',
   });
 
-  // Auto-fill baseUrl when API type changes
+  // Auto-fill provider defaults without overwriting custom values.
   const prevApiTypeRef = useRef<AIApiType>('openai');
   useEffect(() => {
     if (form.apiType !== prevApiTypeRef.current) {
+      const previousApiType = prevApiTypeRef.current;
       const nextDefault = DEFAULT_API_ENDPOINTS[form.apiType];
-      const prevDefault = DEFAULT_API_ENDPOINTS[prevApiTypeRef.current];
-      if (nextDefault) {
-        if (form.baseUrl === '' || form.baseUrl === prevDefault) {
-          setForm(prev => ({ ...prev, baseUrl: nextDefault }));
-        }
-      } else if (form.baseUrl === prevDefault) {
-        // Clear baseUrl when switching to a type with no default (e.g., openai-compatible)
-        setForm(prev => ({ ...prev, baseUrl: '' }));
-      }
+      const prevDefault = DEFAULT_API_ENDPOINTS[previousApiType];
+      const nextModel = DEFAULT_API_MODELS[form.apiType];
+      const prevModel = DEFAULT_API_MODELS[previousApiType];
+      setForm(prev => ({
+        ...prev,
+        baseUrl: prev.baseUrl === '' || prev.baseUrl === prevDefault ? nextDefault : prev.baseUrl,
+        model: prev.model === '' || prev.model === prevModel ? (nextModel || '') : prev.model,
+      }));
       prevApiTypeRef.current = form.apiType;
     }
-  }, [form.apiType, form.baseUrl]);
+  }, [form.apiType]);
 
   // Auto-fill baseUrl when MiMo plan changes
   const prevMimoPlanRef = useRef<MiMoPlan>('api');
@@ -455,6 +464,7 @@ Repository information:
                 <option value="claude">Claude</option>
                 <option value="gemini">Gemini</option>
                 <option value="deepseek">DeepSeek</option>
+                <option value="atlascloud">Atlas Cloud</option>
                 <option value="mimo">Xiaomi MiMo</option>
                 <option value="openai-compatible">OpenAI Compatible (Custom Endpoint)</option>
               </select>

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -134,7 +134,9 @@ export class AIService {
   }
 
   private isDeepSeekModel(): boolean {
-    return this.getApiType() === 'deepseek';
+    const apiType = this.getApiType();
+    return apiType === 'deepseek'
+      || (apiType === 'atlascloud' && this.config.model.trim().toLowerCase().includes('deepseek'));
   }
 
   private isDeepSeekReasonerModel(): boolean {
@@ -181,7 +183,7 @@ export class AIService {
     const configId = this.config.id;
     const reasoning = this.getOpenAIReasoningPayload();
 
-    if (apiType === 'openai' || apiType === 'openai-responses' || apiType === 'openai-compatible' || apiType === 'deepseek' || apiType === 'mimo') {
+    if (apiType === 'openai' || apiType === 'openai-responses' || apiType === 'openai-compatible' || apiType === 'deepseek' || apiType === 'atlascloud' || apiType === 'mimo') {
       const messages = [
         ...(options.system.trim()
           ? [{ role: 'system', content: options.system }]

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -206,7 +206,7 @@ export interface GistSearchFilters {
   isAnalyzed?: boolean;
 }
 
-export type AIApiType = 'openai' | 'openai-responses' | 'claude' | 'gemini' | 'deepseek' | 'mimo' | 'openai-compatible';
+export type AIApiType = 'openai' | 'openai-responses' | 'claude' | 'gemini' | 'deepseek' | 'atlascloud' | 'mimo' | 'openai-compatible';
 
 // Embedding 提供商类型
 export type EmbeddingApiType = 'openai' | 'openai-compatible' | 'gemini' | 'cohere' | 'ollama' | 'siliconflow';

--- a/src/utils/apiUrlBuilder.test.ts
+++ b/src/utils/apiUrlBuilder.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { buildFinalApiUrl } from './apiUrlBuilder';
+
+describe('buildFinalApiUrl', () => {
+  it('preserves the Atlas Cloud version prefix', () => {
+    expect(buildFinalApiUrl('https://api.atlascloud.ai/v1', 'atlascloud'))
+      .toBe('https://api.atlascloud.ai/v1/chat/completions');
+  });
+
+  it('handles a trailing slash in the Atlas Cloud base URL', () => {
+    expect(buildFinalApiUrl('https://api.atlascloud.ai/v1/', 'atlascloud'))
+      .toBe('https://api.atlascloud.ai/v1/chat/completions');
+  });
+});


### PR DESCRIPTION
## Summary

- add Atlas Cloud as a first-class OpenAI-compatible AI provider
- prefill the Atlas Cloud base URL and a default chat model without overwriting custom values
- route Atlas Cloud requests through both browser and backend proxy modes
- preserve the existing DeepSeek thinking compatibility behavior for Atlas-hosted DeepSeek models

## Validation

- `npm run test:run -- src/utils/apiUrlBuilder.test.ts` (2 passed)
- `npm run build`
- `npx eslint src/types/index.ts src/components/settings/AIConfigPanel.tsx src/services/aiService.ts src/utils/apiUrlBuilder.test.ts`
- `cd server && npm test` (68 passed)
- `cd server && npm run build`
- Atlas Cloud model catalog probe: HTTP 200, default model present
- Atlas Cloud Chat Completions probe: HTTP 200

## Documentation

No README or public documentation changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Atlas Cloud as an AI provider option with default endpoint and model settings.
  * Added Atlas Cloud support for OpenAI-compatible requests and responses.
  * Improved provider switching to preserve customized endpoint and model values.

* **Bug Fixes**
  * Improved DeepSeek model detection, including Atlas Cloud configurations.
  * Corrected reasoning parameter handling for DeepSeek models.
  * Preserved Atlas Cloud URL version prefixes and handled trailing slashes correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->