### PR TITLE
feat: show latest release date on repository-grouped release cards (#255)

### DIFF
--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -1210,10 +1210,9 @@ export const ReleaseTimeline: React.FC = () => {
           })
         ) : (
           // 仓库分类视图
-          paginatedRepositoryGroups.map(({ repository, releases }) => {
+          paginatedRepositoryGroups.map(({ repository, releases, latestRelease }) => {
             const isExpanded = expandedRepositories.has(repository.id);
             const hasUnread = releases.some(({ release }) => isReleaseUnread(release.id));
-            const latestRelease = releases[0]?.release;
 
             return (
               <div key={repository.id} className="bg-light-bg dark:bg-panel-dark rounded-xl border border-black/[0.06] dark:border-white/[0.04] overflow-hidden">
@@ -1246,6 +1245,9 @@ export const ReleaseTimeline: React.FC = () => {
                       {latestRelease && (
                         <p className="text-xs text-gray-400 dark:text-text-tertiary">
                           {t('最新:', 'Latest:')} {latestRelease.tag_name}
+                          <span className="ml-1.5 text-gray-400 dark:text-text-quaternary">
+                            · {formatDistanceToNow(new Date(latestRelease.published_at), { addSuffix: true })}
+                          </span>
                         </p>
                       )}
                     </div>

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -6,6 +6,7 @@ import { GitHubApiService } from '../services/githubApi';
 import { forceSyncToBackend } from '../services/autoSync';
 import { backend } from '../services/backendAdapter';
 import { formatDistanceToNow } from 'date-fns';
+import { zhCN } from 'date-fns/locale';
 import { AssetFilterManager } from './AssetFilterManager';
 import { PRESET_FILTERS } from '../constants/presetFilters';
 import ReleaseCard from './ReleaseCard';
@@ -745,7 +746,7 @@ export const ReleaseTimeline: React.FC = () => {
              </div>
             {lastRefreshTime && (
               <p className="text-sm text-gray-500 dark:text-text-tertiary">
-                {t('上次刷新:', 'Last refresh:')} {formatDistanceToNow(new Date(lastRefreshTime), { addSuffix: true })}
+                {t('上次刷新:', 'Last refresh:')} {formatDistanceToNow(new Date(lastRefreshTime), { addSuffix: true, locale: language === 'zh' ? zhCN : undefined })}
               </p>
             )}
           </div>
@@ -817,7 +818,7 @@ export const ReleaseTimeline: React.FC = () => {
             {/* Last Refresh Time */}
             {lastRefreshTime && (
               <span className="w-full text-sm text-gray-500 dark:text-text-tertiary lg:w-auto">
-                {t('上次刷新:', 'Last refresh:')} {formatDistanceToNow(new Date(lastRefreshTime), { addSuffix: true })}
+                {t('上次刷新:', 'Last refresh:')} {formatDistanceToNow(new Date(lastRefreshTime), { addSuffix: true, locale: language === 'zh' ? zhCN : undefined })}
               </span>
             )}
 
@@ -1246,7 +1247,7 @@ export const ReleaseTimeline: React.FC = () => {
                         <p className="text-xs text-gray-400 dark:text-text-tertiary">
                           {t('最新:', 'Latest:')} {latestRelease.tag_name}
                           <span className="ml-1.5 text-gray-400 dark:text-text-quaternary">
-                            · {formatDistanceToNow(new Date(latestRelease.published_at), { addSuffix: true })}
+                            · {formatDistanceToNow(new Date(latestRelease.published_at), { addSuffix: true, locale: language === 'zh' ? zhCN : undefined })}
                           </span>
                         </p>
                       )}

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -1238,21 +1238,23 @@ export const ReleaseTimeline: React.FC = () => {
                       </p>
                     </div>
                   </div>
-                  <div className="flex items-center space-x-2">
-                    <div className="text-right hidden sm:block">
-                      <p className="text-xs text-gray-500 dark:text-text-tertiary">
+                  <div className="flex items-center space-x-2 min-w-0 ml-2">
+                    <div className="text-right min-w-0">
+                      <p className="text-xs text-gray-500 dark:text-text-tertiary hidden sm:block">
                         {releases.length} {t('个版本', 'releases')}
                       </p>
                       {latestRelease && (
-                        <p className="text-xs text-gray-400 dark:text-text-tertiary">
-                          {t('最新:', 'Latest:')} {latestRelease.tag_name}
-                          <span className="ml-1.5 text-gray-400 dark:text-text-quaternary">
-                            · {formatDistanceToNow(new Date(latestRelease.published_at), { addSuffix: true, locale: language === 'zh' ? zhCN : undefined })}
-                          </span>
-                        </p>
+                        <>
+                          <p className="text-xs text-gray-400 dark:text-text-tertiary truncate">
+                            {t('最新:', 'Latest:')} {latestRelease.tag_name}
+                          </p>
+                          <p className="text-xs text-gray-400 dark:text-text-quaternary whitespace-nowrap">
+                            {formatDistanceToNow(new Date(latestRelease.published_at), { addSuffix: true, locale: language === 'zh' ? zhCN : undefined })}
+                          </p>
+                        </>
                       )}
                     </div>
-                    <div className={`transform transition-transform ${isExpanded ? 'rotate-180' : ''}`}>
+                    <div className={`transform transition-transform flex-shrink-0 ${isExpanded ? 'rotate-180' : ''}`}>
                       <ChevronDown className="w-4 h-4 text-gray-400 dark:text-text-quaternary" />
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- Resolves #255: 在发布页「按仓库分类」视图的仓库卡片上，展示最新 release 的更新时间
- 在最新 tag 旁追加相对时间（`published_at` + `formatDistanceToNow`），样式与 `ReleaseCard` 一致
- 改为使用 `repositoryGroups` 中已计算好的 `latestRelease`，避免仅取 `releases[0]` 的潜在偏差

## Changes
- `src/components/ReleaseTimeline.tsx`
  - 仓库分组卡片头部：`Latest: vX.Y.Z · 2 days ago`

## Test plan
- [ ] 打开发布页，切换到「按仓库 / Repository」视图
- [ ] 确认每个仓库卡片右侧「最新: tag」后显示相对发布时间
- [ ] 展开仓库组后，展开项的时间与卡片头部一致（均为最新 release）
- [ ] 切换中/英文界面，确认文案正常
- [ ] 窄屏（< sm）下右侧信息隐藏行为与改前一致

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relative time (“last refresh” and “latest”) to display correctly in Chinese by using the appropriate locale formatting.
  * Fixed repository-group “Latest” information so the shown tag reliably reflects the most recent release.
  * Refined the “Latest” section layout to present the tag and relative time more clearly with improved truncation/whitespace handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->