### PR TITLE
feat: 隐藏 Windows 原生菜单栏 + 优化窗口滚动条 (closes #252)

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -20,13 +20,17 @@ function createWindow() {
       // Dev may relax for Vite HMR / local services if needed later — keep secure by default.
       webSecurity: true,
       allowRunningInsecureContent: false,
-      devTools: isDev,
+      // 生产环境也放开 DevTools（菜单 toggleDevTools role 可作为入口）
+      devTools: true,
       preload: path.join(__dirname, 'preload.js')
     },
     icon: path.join(__dirname, '../build/icon.png'),
     titleBarStyle: 'default', // 使用默认标题栏，避免重叠问题
     show: false,
-    autoHideMenuBar: false, // 显示菜单栏，确保编辑快捷键行为一致
+    // Windows/Linux 隐藏原生顶部菜单栏（Edit/View/Window），按 Alt 可临时呼出；
+    // 应用菜单仍通过 Menu.setApplicationMenu 安装，role 快捷键（Ctrl+C/V、Ctrl+Shift+I 等）照常生效。
+    // macOS 顶部菜单为系统级常驻，保持可见。
+    autoHideMenuBar: process.platform === 'darwin' ? false : true,
     frame: true, // 保持窗口框架
     backgroundColor: '#ffffff', // 设置背景色，避免白屏闪烁
     titleBarOverlay: false, // 禁用标题栏覆盖

--- a/src/index.css
+++ b/src/index.css
@@ -986,3 +986,52 @@ textarea::-webkit-resizer {
     box-shadow: none;
   }
 }
+
+/* ---- 窗口级原生滚动条（仅作用于 document 滚动容器，不影响各组件 opt-in 滚动条类） ---- */
+
+/* 消灭窗口底部横向滚动条（App 根用 min-h-screen 且 body 未限横向的根因） */
+html,
+body {
+  overflow-x: hidden;
+}
+
+/* 重绘窗口右侧竖向原生滚动条：thin、半透明灰、dark 适配，hover 变深 */
+html {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(156, 163, 175, 0.5) transparent;
+}
+
+/* dark 类挂在 <html> 上（见 App.tsx），用 html.dark 而非 .dark html */
+html.dark {
+  scrollbar-color: rgba(75, 85, 99, 0.5) transparent;
+}
+
+html::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+html::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+html::-webkit-scrollbar-thumb {
+  background: rgba(156, 163, 175, 0.5);
+  border-radius: 6px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+
+html::-webkit-scrollbar-thumb:hover {
+  background: rgba(156, 163, 175, 0.8);
+}
+
+html.dark::-webkit-scrollbar-thumb {
+  background: rgba(75, 85, 99, 0.5);
+}
+
+html.dark::-webkit-scrollbar-thumb:hover {
+  background: rgba(75, 85, 99, 0.8);
+}
+
+


### PR DESCRIPTION
## 🎯 背景

Closes #252。

Windows 构建的窗口顶部会显示原生菜单栏（Edit / View / Window 三个菜单），需要在不影响复制粘贴、DevTools 等快捷键的前提下将其隐藏；同时优化窗口右侧与底部的原生滚动条样式，并确保窗口横向滚动条不再出现。

## 🔧 改动

### `electron/main.js`
- **隐藏菜单栏（保留快捷键）**：`autoHideMenuBar` 从无条件 `false` 改为 `process.platform === 'darwin' ? false : true`。Windows/Linux 隐藏顶部菜单栏（按 Alt 可临时呼出）；macOS 保持可见（系统级常驻）。
  - 关键点：应用菜单仍由 `Menu.setApplicationMenu` 安装，role 快捷键（`copy`/`paste`/`cut`/`selectAll`/`undo`/`redo`、`toggleDevTools`、`reload`、缩放等）在菜单栏隐藏后照常生效。
- **生产环境放开 DevTools**：`webPreferences.devTools` 由 `isDev` 改为 `true`，使菜单 `toggleDevTools` role 成为隐藏菜单后可用的生产 DevTools 入口。
- 菜单模板（Edit/View/Window）**保留不删**——它正是快捷键来源，删除会丢快捷键。
- `globalShortcut` 的 Ctrl+Shift+I 维持 dev-only（避免生产环境全局热键冲突），生产入口由菜单 role 覆盖。

### `src/index.css`（新增全局规则）
- `html, body { overflow-x: hidden }` —— 消除窗口底部横向滚动条（App 根用 `min-h-screen` 且 body 未限横向的根因）。
- 全局重绘窗口右侧竖向原生滚动条：thin、半透明灰、hover 变深，并适配 dark 模式（`html.dark` / `html.dark::-webkit-scrollbar-thumb`）。
- 作用于窗口级 document 滚动容器，**不影响**各组件 opt-in 的 `.scrollbar-auto` / `.category-scrollbar` / `.readme-scrollbar` / `textarea` / `.prose pre`。

## ✅ 验证
- `npm run build` 通过，新规则已正确编译进 `dist/assets/index-*.css`（`html,body{overflow-x:hidden}` 与 `html.dark::-webkit-scrollbar-thumb` 均已产出）。
- `npm run lint` 无新增问题（既有 2 个 error 位于未触及的无关文件）。
- 待在 Windows 机器复测：① 顶部无菜单 ② Ctrl+C/V/X/A/Z 与 Ctrl+Shift+I 仍生效 ③ 缩窄窗口底部无横向滚动条 ④ 右侧滚动条为细瘦半透明灰（dark hover 变深）。

## 📝 附注
本仓库贡献者请知悉：隐藏菜单栏 ≠ 删除菜单，role 快捷键依赖已安装的应用菜单；dark 模式选择器须用 `html.dark`（同元素）而非 `.dark html`（后代），`dark` 类挂在 `<html>` 上。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Developer tools are now consistently available when needed.
  * Application menus automatically hide on non-macOS platforms while remaining visible on macOS.
  * Added slimmer, rounded scrollbars with hover states and dark-mode styling.

* **Style**
  * Improved horizontal overflow handling for a cleaner page layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->