### PR TITLE
fix: persist API_SECRET + cross-device session restore (#259)

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -14,6 +14,7 @@ import releasesRouter from './routes/releases.js';
 import categoriesRouter from './routes/categories.js';
 import configsRouter from './routes/configs.js';
 import syncRouter from './routes/sync.js';
+import authRestoreRouter from './routes/authRestore.js';
 import proxyRouter from './routes/proxy.js';
 import logsRouter from './routes/logs.js';
 import mcpAdminRouter from './routes/mcp.js';
@@ -52,6 +53,7 @@ export function createApp(): express.Express {
   app.use(categoriesRouter);
   app.use(configsRouter);
   app.use(syncRouter);
+  app.use(authRestoreRouter);
 
   // Wave 3: Proxy routes
   app.use(proxyRouter);

--- a/server/src/routes/authRestore.ts
+++ b/server/src/routes/authRestore.ts
@@ -1,0 +1,54 @@
+import { Router } from 'express';
+import { getDb } from '../db/connection.js';
+import { decrypt } from '../services/crypto.js';
+import { config } from '../config.js';
+import { logger } from '../services/logger.js';
+
+const router = Router();
+
+/**
+ * POST /api/sync/auth
+ *
+ * Returns the credentials the browser needs to re-establish a session after a
+ * tab/device switch. This route is mounted under the existing /api middleware,
+ * so it is only reachable when the caller already proves knowledge of
+ * `API_SECRET` (Bearer). It therefore only echoes data an authorized client is
+ * already entitled to; an unauthenticated caller is rejected by authMiddleware.
+ *
+ * Response: { github_token: string | null }
+ * (api_secret is intentionally NOT returned — the client must already hold it
+ *  to authenticate, so echoing it would serve no purpose and invite misuse.)
+ */
+// Defence-in-depth: the response carries the decrypted GitHub PAT, so make it
+// uncacheable at every layer even though helmet() already sets no-store globally.
+const NO_STORE_HEADERS = { 'Cache-Control': 'no-store, no-cache, must-revalidate' };
+
+router.post('/api/sync/auth', (_req, res) => {
+  try {
+    const db = getDb();
+    const tokenRow = db
+      .prepare('SELECT value FROM settings WHERE key = ?')
+      .get('github_token') as { value: string } | undefined;
+
+    if (!tokenRow?.value) {
+      res.set(NO_STORE_HEADERS).json({ github_token: null });
+      return;
+    }
+
+    let token: string;
+    try {
+      token = decrypt(tokenRow.value, config.encryptionKey);
+    } catch {
+      logger.error('authRestore', 'Failed to decrypt GitHub token for auth restore');
+      res.set(NO_STORE_HEADERS).json({ github_token: null });
+      return;
+    }
+
+    res.set(NO_STORE_HEADERS).json({ github_token: token });
+  } catch (err) {
+    logger.errorFromError('authRestore', 'POST /api/sync/auth error', err);
+    res.status(500).json({ error: 'Failed to restore auth', code: 'AUTH_RESTORE_FAILED' });
+  }
+});
+
+export default router;

--- a/server/tests/routes/authRestore.test.ts
+++ b/server/tests/routes/authRestore.test.ts
@@ -1,0 +1,61 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it, vi } from 'vitest';
+
+const getDbMock = vi.fn();
+
+vi.mock('../../src/db/connection.js', () => ({
+  getDb: () => getDbMock(),
+}));
+
+vi.mock('../../src/services/crypto.js', () => ({
+  decrypt: (value: string) => {
+    if (value === 'encrypted-token') return 'github-token';
+    throw new Error('boom');
+  },
+  encrypt: (value: string) => value,
+}));
+
+const { default: authRestoreRouter } = await import('../../src/routes/authRestore.js');
+
+const createTestApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use(authRestoreRouter);
+  return app;
+};
+
+describe('authRestore route (POST /api/sync/auth)', () => {
+  it('returns the decrypted GitHub token when stored', async () => {
+    getDbMock.mockReturnValue({
+      prepare: () => ({
+        get: (key: string) => (key === 'github_token' ? { value: 'encrypted-token' } : undefined),
+      }),
+    });
+
+    const res = await request(createTestApp()).post('/api/sync/auth').expect(200);
+    expect(res.body).toEqual({ github_token: 'github-token' });
+  });
+
+  it('returns null github_token when none is stored', async () => {
+    getDbMock.mockReturnValue({
+      prepare: () => ({
+        get: () => undefined,
+      }),
+    });
+
+    const res = await request(createTestApp()).post('/api/sync/auth').expect(200);
+    expect(res.body).toEqual({ github_token: null });
+  });
+
+  it('returns null github_token instead of leaking plaintext on decrypt failure', async () => {
+    getDbMock.mockReturnValue({
+      prepare: () => ({
+        get: () => ({ value: 'unreadable' }),
+      }),
+    });
+
+    const res = await request(createTestApp()).post('/api/sync/auth').expect(200);
+    expect(res.body).toEqual({ github_token: null });
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -156,10 +156,14 @@ function App() {
       try {
         await backend.init();
         if (backend.isAvailable && !cancelled) {
-          await syncFromBackend();
           // Issue #259: recover a session on a fresh browser/device. Only acts
           // when there is no local session and the backend is authenticated.
+          // Run before the backend data pull so auth can complete before the
+          // app decides whether to render LoginScreen.
           await tryRestoreAuthFromBackend();
+          if (!cancelled) {
+            await syncFromBackend();
+          }
           if (!cancelled) {
             unsubscribe = startAutoSync();
           }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import { useAutoUpdateCheck } from './hooks/useAutoUpdateCheck';
 import { logger } from './services/logger';
 import { UpdateNotificationBanner } from './components/UpdateNotificationBanner';
 import { backend } from './services/backendAdapter';
-import { syncFromBackend, startAutoSync, stopAutoSync } from './services/autoSync';
+import { syncFromBackend, startAutoSync, stopAutoSync, tryRestoreAuthFromBackend } from './services/autoSync';
 import {
   startMcpElectronBridge,
   stopMcpElectronBridge,
@@ -157,6 +157,9 @@ function App() {
         await backend.init();
         if (backend.isAvailable && !cancelled) {
           await syncFromBackend();
+          // Issue #259: recover a session on a fresh browser/device. Only acts
+          // when there is no local session and the backend is authenticated.
+          await tryRestoreAuthFromBackend();
           if (!cancelled) {
             unsubscribe = startAutoSync();
           }

--- a/src/components/settings/BackendPanel.tsx
+++ b/src/components/settings/BackendPanel.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Server, TestTube, RefreshCw, Upload, Download, CheckCircle, AlertCircle } from 'lucide-react';
 import { useAppStore } from '../../store/useAppStore';
 import { backend } from '../../services/backendAdapter';
+import { tryRestoreAuthFromBackend } from '../../services/autoSync';
 import { useDialog } from '../../hooks/useDialog';
 
 interface BackendPanelProps {
@@ -71,6 +72,9 @@ export const BackendPanel: React.FC<BackendPanelProps> = ({ t }) => {
         setStatus('connected');
         setHealth({ version: healthData.version, timestamp: healthData.timestamp });
         toast(t('后端连接成功！', 'Backend connection successful!'), 'success');
+        // Issue #259: after the one-time secret bootstrap succeeds on a fresh
+        // browser/device, try to recover the stored GitHub session.
+        void tryRestoreAuthFromBackend();
       } else {
         setStatus('disconnected');
         setHealth(null);

--- a/src/services/autoSync.ts
+++ b/src/services/autoSync.ts
@@ -1,6 +1,7 @@
 import { backend } from './backendAdapter';
 import { useAppStore } from '../store/useAppStore';
 import { mergeRepositoriesPreservingLocalMetadata } from '../utils/repositoryMerge';
+import { GitHubApiService } from './githubApi';
 import { logger } from './logger';
 
 // Prevent sync loops: when we pull data FROM backend and update store,
@@ -45,6 +46,54 @@ function quickHash(data: unknown): string {
 function setRepositorySyncVisualState(isSyncing: boolean): void {
   if (typeof window === 'undefined') return;
   window.dispatchEvent(new CustomEvent('gsm:repository-sync-visual-state', { detail: { isSyncing } }));
+}
+
+let _isRestoringAuth = false;
+
+/**
+ * Cross-browser/device session recovery (Issue #259).
+ *
+ * Only runs on a genuine bootstrap: no local session AND the client already
+ * holds the backend API_SECRET (so it can authenticate). It NEVER overwrites an
+ * existing local session — existing users' credentials and data are untouched.
+ *
+ * Bootstrap guard: the caller must have configured backendApiSecret once in
+ * this browser (BackendPanel). With that, the backend hands back the GitHub
+ * token it stores, and we re-validate it against the GitHub API before logging in.
+ */
+export async function tryRestoreAuthFromBackend(): Promise<boolean> {
+  if (!backend.isAvailable || _isRestoringAuth) return false;
+
+  const state = useAppStore.getState();
+
+  // Never clobber an existing session (single-account safety guard).
+  if (state.user && state.githubToken) return false;
+
+  // Without an authenticated backend we have nothing to restore from.
+  if (!state.backendApiSecret) return false;
+
+  _isRestoringAuth = true;
+  try {
+    const restored = await backend.restoreAuth();
+    if (!restored?.github_token) return false;
+
+    // Re-check right before applying: the user may have logged in meanwhile.
+    const latest = useAppStore.getState();
+    if (latest.user || latest.githubToken) return false;
+
+    const githubApi = new GitHubApiService(restored.github_token);
+    const user = await githubApi.getCurrentUser();
+
+    useAppStore.getState().setGitHubToken(restored.github_token);
+    useAppStore.getState().setUser(user);
+    logger.info('sync.restoreAuth', 'Restored session from backend', { login: user.login });
+    return true;
+  } catch (err) {
+    logger.warn('sync.restoreAuth', 'Failed to restore session from backend', { error: err instanceof Error ? err.message : String(err) });
+    return false;
+  } finally {
+    _isRestoringAuth = false;
+  }
 }
 
 /**

--- a/src/services/backendAdapter.ts
+++ b/src/services/backendAdapter.ts
@@ -737,6 +737,27 @@ class BackendAdapter {
     }
   }
 
+  /**
+   * Restore the GitHub token stored on the backend for cross-browser/device
+   * session recovery. Only callable when the backend is reachable AND this
+   * client already authenticates (Bearer API_SECRET) — the backend never hands
+   * it out to unauthenticated callers.
+   */
+  async restoreAuth(): Promise<{ github_token: string | null } | null> {
+    if (!this._backendUrl) return null;
+
+    try {
+      const res = await this.fetchWithTimeout(`${this._backendUrl}/sync/auth`, {
+        method: 'POST',
+        headers: this.getAuthHeaders(),
+      }, 8000);
+      if (!res.ok) return null;
+      return res.json() as Promise<{ github_token: string | null }>;
+    } catch {
+      return null;
+    }
+  }
+
   // === GitHub Search Proxy ===
 
   async searchRepositories(queryParams: Record<string, string>): Promise<{ items: Repository[] }> {

--- a/src/store/useAppStore.test.ts
+++ b/src/store/useAppStore.test.ts
@@ -316,7 +316,7 @@ describe('useAppStore auth localStorage mirror (Issue #259)', () => {
 
   it('persists backendApiSecret to the mirror and clears on logout', () => {
     useAppStore.getState().setBackendApiSecret('secret-1');
-    let parsed = JSON.parse(window.localStorage.getItem(AUTH_MIRROR_KEY) || '{}');
+    const parsed = JSON.parse(window.localStorage.getItem(AUTH_MIRROR_KEY) || '{}');
     expect(parsed.backendApiSecret).toBe('secret-1');
 
     useAppStore.getState().logout();

--- a/src/store/useAppStore.test.ts
+++ b/src/store/useAppStore.test.ts
@@ -295,3 +295,65 @@ describe('useAppStore repository performance guards', () => {
     expect(useAppStore.getState().analyzingRepositoryIds).toBe(previousAnalyzingIds);
   });
 });
+
+describe('useAppStore auth localStorage mirror (Issue #259)', () => {
+  const AUTH_MIRROR_KEY = 'github-stars-manager-auth';
+  const user = { id: 1, login: 'test-user', name: 'Test', avatar_url: 'https://x/a.png', email: null };
+
+  beforeEach(() => {
+    window.localStorage?.removeItem?.(AUTH_MIRROR_KEY);
+  });
+
+  it('persists auth to the synchronous localStorage mirror on login', () => {
+    useAppStore.getState().setGitHubToken('ghp_xxx');
+    useAppStore.getState().setUser(user);
+
+    const raw = window.localStorage.getItem(AUTH_MIRROR_KEY);
+    const mirror = JSON.parse(raw || '{}');
+    expect(mirror.githubToken).toBe('ghp_xxx');
+    expect(mirror.user.login).toBe('test-user');
+  });
+
+  it('persists backendApiSecret to the mirror and clears on logout', () => {
+    useAppStore.getState().setBackendApiSecret('secret-1');
+    let parsed = JSON.parse(window.localStorage.getItem(AUTH_MIRROR_KEY) || '{}');
+    expect(parsed.backendApiSecret).toBe('secret-1');
+
+    useAppStore.getState().logout();
+    expect(window.localStorage.getItem(AUTH_MIRROR_KEY)).toBeNull();
+    // The in-memory secret and the sessionStorage cache must also be torn down;
+    // otherwise the backend keeps authenticating a logged-out user (and on v10
+    // the secret is re-persisted to IndexedDB on the next partialize).
+    expect(useAppStore.getState().backendApiSecret).toBeNull();
+    expect(window.sessionStorage.getItem('github-stars-manager-backend-secret')).toBeNull();
+  });
+
+  it('restores auth from the mirror when the persisted snapshot lacks credentials', () => {
+    // Simulate the reported bug: async IndexedDB write never landed, so the
+    // persisted snapshot has empty auth while the mirror holds the real values.
+    window.localStorage.setItem(
+      AUTH_MIRROR_KEY,
+      JSON.stringify({ user, githubToken: 'ghp_restored', backendApiSecret: null })
+    );
+
+    const normalized = normalizePersistedState({}, useAppStore.getState());
+    expect(normalized.user).toEqual(user);
+    expect(normalized.githubToken).toBe('ghp_restored');
+    expect(normalized.isAuthenticated).toBe(true);
+  });
+
+  it('prefers persisted credentials over the mirror when both exist', () => {
+    window.localStorage.setItem(
+      AUTH_MIRROR_KEY,
+      JSON.stringify({ user, githubToken: 'ghp_mirror', backendApiSecret: null })
+    );
+    const otherUser = { id: 2, login: 'other', name: 'Other', avatar_url: 'https://x/b.png', email: null };
+
+    const normalized = normalizePersistedState(
+      { user: otherUser, githubToken: 'ghp_persisted' },
+      useAppStore.getState()
+    );
+    expect(normalized.user).toEqual(otherUser);
+    expect(normalized.githubToken).toBe('ghp_persisted');
+  });
+});

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -54,6 +54,48 @@ import { logger } from '../services/logger';
 import { PRESET_FILTERS } from '../constants/presetFilters';
 
 const BACKEND_SECRET_SESSION_KEY = 'github-stars-manager-backend-secret';
+const AUTH_MIRROR_KEY = 'github-stars-manager-auth';
+
+interface AuthMirror {
+  user: GitHubUser | null;
+  githubToken: string | null;
+  backendApiSecret: string | null;
+}
+
+const readAuthMirror = (): AuthMirror | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.localStorage.getItem(AUTH_MIRROR_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<AuthMirror>;
+    return {
+      user: parsed.user ?? null,
+      githubToken: typeof parsed.githubToken === 'string' ? parsed.githubToken : null,
+      backendApiSecret: typeof parsed.backendApiSecret === 'string' ? parsed.backendApiSecret : null,
+    };
+  } catch {
+    return null;
+  }
+};
+
+const writeAuthMirror = (auth: AuthMirror): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(AUTH_MIRROR_KEY, JSON.stringify(auth));
+  } catch {
+    // Quota/security errors are expected in constrained environments; the
+    // IndexedDB persist path remains the fallback there.
+  }
+};
+
+const clearAuthMirror = (): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(AUTH_MIRROR_KEY);
+  } catch {
+    // ignore
+  }
+};
 
 /** Menu IDs that must always remain visible — enforced at store level */
 const REQUIRED_HEADER_MENU_IDS: ReadonlySet<HeaderMenuId> = new Set(['repositories', 'settings']);
@@ -493,6 +535,7 @@ type PersistedAppState = Partial<
     | 'user'
     | 'githubToken'
     | 'isAuthenticated'
+    | 'backendApiSecret'
     | 'repositories'
     | 'gists'
     | 'starredGists'
@@ -695,6 +738,19 @@ export const normalizePersistedState = (
 ): Partial<AppState & AppActions> => {
   const safePersisted = persisted ?? {};
   const defaultDiscoveryChannelIds = new Set(defaultDiscoveryChannels.map((channel) => channel.id));
+  const authMirror = readAuthMirror();
+
+  // Effective auth: persisted values win; the synchronous localStorage mirror
+  // back-fills when the IndexedDB snapshot lost them (asynchronous unload write).
+  const resolvedUser = safePersisted.user ?? authMirror?.user ?? null;
+  const resolvedGithubToken =
+    typeof safePersisted.githubToken === 'string'
+      ? safePersisted.githubToken
+      : (authMirror?.githubToken ?? null);
+  const resolvedBackendApiSecret =
+    typeof safePersisted.backendApiSecret === 'string'
+      ? safePersisted.backendApiSecret
+      : (authMirror?.backendApiSecret ?? null);
 
   const repositories = Array.isArray(safePersisted.repositories) ? safePersisted.repositories : [];
   const gists = Array.isArray(safePersisted.gists) ? safePersisted.gists : [];
@@ -727,6 +783,12 @@ export const normalizePersistedState = (
   return {
     ...currentState,
     ...safePersisted,
+    // Auth fallback: if the IndexedDB snapshot is missing the login credentials
+    // (e.g. async unload write never completed), restore from the synchronous
+    // localStorage mirror. Persisted values always win over the mirror.
+    user: resolvedUser,
+    githubToken: resolvedGithubToken,
+    backendApiSecret: resolvedBackendApiSecret,
     theme:
       safePersisted.theme === 'light' || safePersisted.theme === 'dark'
         ? safePersisted.theme
@@ -793,7 +855,7 @@ export const normalizePersistedState = (
     collapsedSidebarCategoryCount: typeof safePersisted.collapsedSidebarCategoryCount === 'number' && safePersisted.collapsedSidebarCategoryCount > 0 ? safePersisted.collapsedSidebarCategoryCount : 20,
     assetFilters: Array.isArray(safePersisted.assetFilters) && safePersisted.assetFilters.length > 0 ? safePersisted.assetFilters : defaultPresetFilters,
     language: safePersisted.language || 'zh',
-    isAuthenticated: !!(safePersisted.user && safePersisted.githubToken),
+    isAuthenticated: !!(resolvedUser && resolvedGithubToken),
     releaseViewMode: safePersisted.releaseViewMode || 'timeline',
     releaseShowMode: safePersisted.releaseShowMode === 'unread' ? 'unread' : 'all',
     releaseLatestMode: safePersisted.releaseLatestMode === 'latest' ? 'latest' : 'all',
@@ -1251,31 +1313,50 @@ export const useAppStore = create<AppState & AppActions>()(
       setUser: (user) => {
         logger.info('store.setUser', 'Setting user', { hasUser: !!user });
         set({ user, isAuthenticated: !!user });
+        const { githubToken, backendApiSecret } = useAppStore.getState();
+        writeAuthMirror({ user, githubToken, backendApiSecret });
       },
       setGitHubToken: (token) => {
         logger.info('store.setGitHubToken', 'Setting GitHub token', { hasToken: !!token });
         set({ githubToken: token });
+        const { user, backendApiSecret } = useAppStore.getState();
+        writeAuthMirror({ user, githubToken: token, backendApiSecret });
       },
-      logout: () => set({
-        user: null,
-        githubToken: null,
-        isAuthenticated: false,
-        repositories: [],
-        gists: [],
-        starredGists: [],
-        gistSearchResults: [],
-        analyzingGistIds: new Set(),
-        releases: [],
-        releaseSubscriptions: new Set(),
-        releaseSourceSettings: defaultReleaseSourceSettings,
-        readReleases: new Set(),
-        forks: [],
-        readForks: new Set(),
-        analyzingRepositoryIds: new Set(),
-        searchResults: [],
-        similarView: null,
-        lastSync: null,
-      }),
+      setBackendApiSecret: (backendApiSecret) => {
+        writeSessionBackendSecret(backendApiSecret);
+        set({ backendApiSecret });
+        const { user, githubToken } = useAppStore.getState();
+        writeAuthMirror({ user, githubToken, backendApiSecret });
+      },
+      logout: () => {
+        // Full credential teardown: clear the localStorage auth mirror, the
+        // sessionStorage API_SECRET, and the in-memory secret. Without this,
+        // `backendApiSecret` survives logout in memory AND in the v10 IndexedDB
+        // snapshot, so the backend would still authenticate a logged-out user.
+        clearAuthMirror();
+        writeSessionBackendSecret(null);
+        set({
+          user: null,
+          githubToken: null,
+          backendApiSecret: null,
+          isAuthenticated: false,
+          repositories: [],
+          gists: [],
+          starredGists: [],
+          gistSearchResults: [],
+          analyzingGistIds: new Set(),
+          releases: [],
+          releaseSubscriptions: new Set(),
+          releaseSourceSettings: defaultReleaseSourceSettings,
+          readReleases: new Set(),
+          forks: [],
+          readForks: new Set(),
+          analyzingRepositoryIds: new Set(),
+          searchResults: [],
+          similarView: null,
+          lastSync: null,
+        });
+      },
 
       // Repository actions
       setRepositories: (repositories) => set({ repositories, searchResults: repositories }),
@@ -2030,10 +2111,6 @@ export const useAppStore = create<AppState & AppActions>()(
       setUpdateNotification: (notification) => set({ updateNotification: notification }),
       dismissUpdateNotification: () => set({ updateNotification: null }),
       setAnalysisProgress: (newProgress) => set({ analysisProgress: newProgress }),
-      setBackendApiSecret: (backendApiSecret) => {
-        writeSessionBackendSecret(backendApiSecret);
-        set({ backendApiSecret });
-      },
       setProxyConfig: (updates) => set((state) => ({
         proxyConfig: { ...state.proxyConfig, ...updates }
       })),
@@ -2198,7 +2275,7 @@ export const useAppStore = create<AppState & AppActions>()(
     }),
     {
       name: 'github-stars-manager',
-      version: 9,
+      version: 10,
       storage: debouncedPersistStorage,
       partialize: (state) => ({
         // 持久化用户信息和认证状态
@@ -2269,7 +2346,9 @@ export const useAppStore = create<AppState & AppActions>()(
         isSidebarCollapsed: state.isSidebarCollapsed,
         headerMenuConfig: state.headerMenuConfig,
 
-        // backendApiSecret: 保留在内存中，不持久化（安全考虑）
+        // 持久化后端 API Secret（跨会话/跨标签保留，配合修复 #259）。同时保留
+        // localStorage 镜像（AUTH_MIRROR_KEY）作为异步 IndexedDB 写入失败时的兜底。
+        backendApiSecret: state.backendApiSecret,
 
         // 持久化搜索排序设置
         searchFilters: {
@@ -2486,6 +2565,11 @@ export const useAppStore = create<AppState & AppActions>()(
     (state as Record<string, unknown>).headerMenuConfig = defaultHeaderMenuConfig;
   }
 
+  // v9→v10: 初始化 backendApiSecret（旧版仅存 sessionStorage；migrate 前置为 null）
+  if (state && typeof (state as Record<string, unknown>).backendApiSecret !== 'string') {
+    (state as Record<string, unknown>).backendApiSecret = null;
+  }
+
   // 初始化 embeddingConfigs
   if (state && !Array.isArray((state as Record<string, unknown>).embeddingConfigs)) {
     (state as Record<string, unknown>).embeddingConfigs = [];
@@ -2522,10 +2606,19 @@ export const useAppStore = create<AppState & AppActions>()(
           customCategoriesCount: normalized.customCategories?.length || 0,
         });
 
-        return {
+        // Keep the synchronous localStorage mirror aligned with the hydrated
+        // auth state (covers restores that came from IndexedDB or the mirror).
+        const merged = {
           ...currentState,
           ...normalized,
         };
+        writeAuthMirror({
+          user: merged.user ?? null,
+          githubToken: typeof merged.githubToken === 'string' ? merged.githubToken : null,
+          backendApiSecret: typeof merged.backendApiSecret === 'string' ? merged.backendApiSecret : null,
+        });
+
+        return merged;
       },
       onRehydrateStorage: (state) => {
         const hydrationStart = Date.now();

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -31,6 +31,35 @@ Object.defineProperty(window, 'ResizeObserver', {
 
 window.fetch = vi.fn();
 
+// jsdom without an origin URL does not expose localStorage; provide a minimal
+// in-memory shim so persistence paths (e.g. the auth mirror in useAppStore) are testable.
+const storageShim = (): Storage => {
+  let store: Record<string, string> = {};
+  return {
+    get length() {
+      return Object.keys(store).length;
+    },
+    clear: () => {
+      store = {};
+    },
+    getItem: (key: string) => (key in store ? store[key] : null),
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    setItem: (key: string, value: string) => {
+      store[key] = String(value);
+    },
+  };
+};
+
+if (!window.localStorage) {
+  Object.defineProperty(window, 'localStorage', { writable: true, value: storageShim() });
+}
+if (!window.sessionStorage) {
+  Object.defineProperty(window, 'sessionStorage', { writable: true, value: storageShim() });
+}
+
 vi.mock('../store/useAppStore', () => ({
   useAppStore: vi.fn((selector) => {
     const state = {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -31,8 +31,11 @@ Object.defineProperty(window, 'ResizeObserver', {
 
 window.fetch = vi.fn();
 
-// jsdom without an origin URL does not expose localStorage; provide a minimal
-// in-memory shim so persistence paths (e.g. the auth mirror in useAppStore) are testable.
+// Node >=22 exposes an experimental global `localStorage` (undefined unless
+// `--localstorage-file` is passed), which vitest copies in and shadows jsdom's
+// real Storage even once a non-opaque test origin is configured. Provide a
+// minimal in-memory Storage fallback only when none is available so persistence
+// paths (e.g. the auth mirror in useAppStore) stay testable.
 const storageShim = (): Storage => {
   let store: Record<string, string> = {};
   return {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,11 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    environmentOptions: {
+      jsdom: {
+        url: 'http://localhost',
+      },
+    },
     include: ['src/**/*.test.{ts,tsx}'],
     setupFiles: ['./src/test/setup.ts'],
     coverage: {


### PR DESCRIPTION
## Summary

Fixes #259 — the repeated prompts to re-enter the GitHub PAT and `API_SECRET` after a Docker restart / tab close. Per the reporter's (@raphaelbahat) request in the issue, `API_SECRET` is now persisted rather than cleared on tab close.

This PR also layers a code-audit pass on the changeset; the audit findings were applied as fixes within the same PR.

## What changed

### Client persistence
- `backendApiSecret` is now persisted to IndexedDB (persist **v10**) and, additionally, written to a synchronous **localStorage “auth mirror”**. The mirror back-fills when the async IndexedDB unload-write never lands (the failure mode behind the bug). Persisted values always win over the mirror.
- v9→v10 migration initializes `backendApiSecret` to `null` for older snapshots.

### Cross-device session restore
- New `POST /api/sync/auth` route (gated by the existing `authMiddleware` on `/api/*`) returns the stored, decrypted GitHub token so a fresh browser/device holding only `API_SECRET` can re-establish a session.
- `tryRestoreAuthFromBackend` re-validates the restored token against the GitHub API before logging in, with re-entrancy (`_isRestoringAuth`) and double-check guards, and never clobbers an existing local session.

## Audit fixes (applied here, not separate PR)
1. **`logout()` full credential teardown (security)** — After persisting the secret, the old `logout()` left `backendApiSecret` in memory **and** in IndexedDB, so the backend kept authenticating a logged-out user. Now `logout()` clears the localStorage mirror, the sessionStorage cache, and the in-memory secret.
2. **`/api/sync/auth` `Cache-Control: no-store`** — the response carries the decrypted PAT; defence-in-depth beyond the global `helmet()` default.
3. **Test coverage** — logout test now asserts the memory + sessionStorage secret are torn down, not just the localStorage mirror.

## Notes / non-blocking
- The `/api/sync/auth` route deliberately echoes the PAT (unlike `/sync/export` which masks it) — the restore path needs the raw token to re-validate against the GitHub API. Echo is gated behind `API_SECRET` and documented in the route. No PAT is ever logged (verified against `logSanitizer`).

## Test plan
- [x] `src/store/useAppStore.test.ts` — 18/18 pass (incl. 4 new Issue #259 mirror tests)
- [x] Server test suite — 64 pass / 7 skipped (9 files)
- [x] Frontend test suite — 148/148 pass (15 files)
- [x] `tsc --noEmit` (app + server) — clean

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic GitHub sign-in restoration from the backend during app startup and after a successful backend connection check.
  * Improved authentication persistence across refreshes and restarts.

* **Bug Fixes**
  * Authentication data now clears more completely on logout.
  * Missing or unreadable stored credentials safely fall back to no session.

* **Tests**
  * Added coverage for authentication restoration, persistence, and logout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->