### PR TITLE
fix: persist full vector search config to backend + stop sync loop (#259)

### DIFF
--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -129,6 +129,11 @@ export function initializeSchema(db: Database.Database): void {
       embedding_config_id TEXT,
       index_mode TEXT NOT NULL DEFAULT 'readme',
       readme_max_chars INTEGER NOT NULL DEFAULT 6000,
+      search_threshold REAL DEFAULT 0.35,
+      search_top_k INTEGER DEFAULT 30,
+      enable_hyde INTEGER DEFAULT 1,
+      enable_reranking INTEGER DEFAULT 1,
+      embedding_format_version INTEGER,
       status_json TEXT,
       last_sync_at TEXT,
       created_at TEXT NOT NULL DEFAULT (datetime('now')),
@@ -149,6 +154,11 @@ export function initializeSchema(db: Database.Database): void {
   addColumnIfMissing(db, 'asset_filters', 'sort_order', 'INTEGER DEFAULT 0');
   addColumnIfMissing(db, 'vector_search_configs', 'index_mode', "TEXT NOT NULL DEFAULT 'readme'");
   addColumnIfMissing(db, 'vector_search_configs', 'readme_max_chars', 'INTEGER NOT NULL DEFAULT 6000');
+  addColumnIfMissing(db, 'vector_search_configs', 'search_threshold', 'REAL DEFAULT 0.35');
+  addColumnIfMissing(db, 'vector_search_configs', 'search_top_k', 'INTEGER DEFAULT 30');
+  addColumnIfMissing(db, 'vector_search_configs', 'enable_hyde', 'INTEGER DEFAULT 1');
+  addColumnIfMissing(db, 'vector_search_configs', 'enable_reranking', 'INTEGER DEFAULT 1');
+  addColumnIfMissing(db, 'vector_search_configs', 'embedding_format_version', 'INTEGER');
   addColumnIfMissing(db, 'repositories', 'vector_indexed_at', 'TEXT');
   addColumnIfMissing(db, 'repositories', 'license', 'TEXT');
   // 上一次向量索引时采用的 license 值（SPDX id / null）。用于增量谓词判断 license 是否

--- a/server/src/routes/configs.ts
+++ b/server/src/routes/configs.ts
@@ -681,7 +681,7 @@ router.get('/api/configs/vector-search', (req, res) => {
     const row = db.prepare('SELECT * FROM vector_search_configs WHERE id = ?').get('default') as Record<string, unknown> | undefined;
 
     if (!row) {
-      res.json({ enabled: false, workerUrl: '', authToken: '', embeddingConfigId: '', indexMode: 'readme', readmeMaxChars: 6000 });
+      res.json({ enabled: false, workerUrl: '', authToken: '', embeddingConfigId: '', indexMode: 'readme', readmeMaxChars: 6000, searchThreshold: 0.35, searchTopK: 30, enableHyDE: true, enableReranking: true });
       return;
     }
 
@@ -710,6 +710,11 @@ router.get('/api/configs/vector-search', (req, res) => {
       embeddingConfigId: row.embedding_config_id ?? '',
       indexMode: row.index_mode ?? 'readme',
       readmeMaxChars: row.readme_max_chars ?? 6000,
+      searchThreshold: typeof row.search_threshold === 'number' ? row.search_threshold : 0.35,
+      searchTopK: typeof row.search_top_k === 'number' ? row.search_top_k : 30,
+      enableHyDE: row.enable_hyde === 1,
+      enableReranking: row.enable_reranking === 1,
+      embeddingFormatVersion: typeof row.embedding_format_version === 'number' ? row.embedding_format_version : undefined,
       status,
       lastSyncAt: row.last_sync_at ?? null,
     });
@@ -724,6 +729,7 @@ router.put('/api/configs/vector-search', (req, res) => {
   try {
     const db = getDb();
     const { enabled, workerUrl, authToken, embeddingConfigId, indexMode, readmeMaxChars, status, lastSyncAt } = req.body as Record<string, unknown>;
+    const { searchThreshold, searchTopK, enableHyDE, enableReranking, embeddingFormatVersion } = req.body as Record<string, unknown>;
 
     let encryptedToken = '';
     const hasAuthToken = Object.prototype.hasOwnProperty.call(req.body, 'authToken');
@@ -741,11 +747,22 @@ router.put('/api/configs/vector-search', (req, res) => {
     const statusJson = status ? JSON.stringify(status) : null;
     const mode = indexMode === 'description' ? 'description' : 'readme';
     const maxChars = typeof readmeMaxChars === 'number' && readmeMaxChars > 0 ? readmeMaxChars : 6000;
+    const threshold = typeof searchThreshold === 'number' && Number.isFinite(searchThreshold) && searchThreshold >= 0 && searchThreshold <= 1
+      ? searchThreshold
+      : 0.35;
+    const topK = typeof searchTopK === 'number' && Number.isInteger(searchTopK) && searchTopK >= 5 && searchTopK <= 50
+      ? searchTopK
+      : 30;
+    const hyde = enableHyDE === true ? 1 : 0;
+    const reranking = enableReranking === true ? 1 : 0;
+    const formatVersion = typeof embeddingFormatVersion === 'number' && Number.isInteger(embeddingFormatVersion) && embeddingFormatVersion >= 1
+      ? embeddingFormatVersion
+      : null;
 
     db.prepare(`
-      INSERT OR REPLACE INTO vector_search_configs (id, enabled, worker_url, auth_token_encrypted, embedding_config_id, index_mode, readme_max_chars, status_json, last_sync_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
-    `).run('default', enabled ? 1 : 0, workerUrl ?? '', encryptedToken, embeddingConfigId ?? '', mode, maxChars, statusJson, lastSyncAt ?? null);
+      INSERT OR REPLACE INTO vector_search_configs (id, enabled, worker_url, auth_token_encrypted, embedding_config_id, index_mode, readme_max_chars, search_threshold, search_top_k, enable_hyde, enable_reranking, embedding_format_version, status_json, last_sync_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
+    `).run('default', enabled ? 1 : 0, workerUrl ?? '', encryptedToken, embeddingConfigId ?? '', mode, maxChars, threshold, topK, hyde, reranking, formatVersion, statusJson, lastSyncAt ?? null);
 
     res.json({ updated: true });
   } catch (err) {

--- a/server/tests/routes/vectorSearchConfig.test.ts
+++ b/server/tests/routes/vectorSearchConfig.test.ts
@@ -1,0 +1,144 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it, vi } from 'vitest';
+
+const getDbMock = vi.fn();
+
+vi.mock('../../src/db/connection.js', () => ({
+  getDb: () => getDbMock(),
+}));
+
+vi.mock('../../src/services/crypto.js', () => ({
+  decrypt: (value: string) => value,
+  encrypt: (value: string) => value,
+}));
+
+vi.mock('../../src/config.js', () => ({
+  config: { encryptionKey: 'test-encryption-key' },
+}));
+
+const { default: configsRouter } = await import('../../src/routes/configs.js');
+
+const createTestApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use(configsRouter);
+  return app;
+};
+
+// PUT binds params in INSERT order; capture them so we can assert what persisted.
+function capturePut(): { params: unknown[][] } {
+  const capture = { params: [] as unknown[][] };
+  getDbMock.mockReturnValue({
+    prepare: () => ({
+      get: () => undefined,
+      run: (...p: unknown[]) => {
+        capture.params.push(p);
+      },
+    }),
+  });
+  return capture;
+}
+
+function mockGetReturningRow(row: Record<string, unknown>) {
+  getDbMock.mockReturnValue({
+    prepare: (sql: string) => ({
+      get: () => (sql.includes('vector_search_configs') ? row : undefined),
+      run: () => ({ changes: 1 }),
+    }),
+  });
+}
+
+const fullConfig = {
+  enabled: true,
+  workerUrl: 'https://example.com/vectorize',
+  authToken: 'worker-secret-token',
+  embeddingConfigId: 'emb_test1',
+  indexMode: 'readme',
+  readmeMaxChars: 8000,
+  searchThreshold: 0.42,
+  searchTopK: 25,
+  enableHyDE: false,
+  enableReranking: true,
+  embeddingFormatVersion: 2,
+};
+
+describe('vector search config route (GET/PUT /api/configs/vector-search)', () => {
+  it('PUT persists all vector-search fields to the backend', async () => {
+    const capture = capturePut();
+    const res = await request(createTestApp()).put('/api/configs/vector-search').send(fullConfig);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ updated: true });
+    expect(capture.params).toHaveLength(1);
+
+    const p = capture.params[0];
+    expect(p[0]).toBe('default');
+    expect(p[1]).toBe(1); // enabled
+    expect(p[2]).toBe(fullConfig.workerUrl);
+    expect(p[3]).toBe(fullConfig.authToken); // encrypted (encrypt is identity in mock)
+    expect(p[4]).toBe(fullConfig.embeddingConfigId);
+    expect(p[5]).toBe(fullConfig.indexMode);
+    expect(p[6]).toBe(fullConfig.readmeMaxChars);
+    expect(p[7]).toBe(fullConfig.searchThreshold);
+    expect(p[8]).toBe(fullConfig.searchTopK);
+    expect(p[9]).toBe(0); // enableHyDE false → 0
+    expect(p[10]).toBe(1); // enableReranking true → 1
+    expect(p[11]).toBe(2); // embedding_format_version
+  });
+
+  it('GET returns all persisted vector-search fields', async () => {
+    const row = {
+      id: 'default',
+      enabled: 1,
+      worker_url: fullConfig.workerUrl,
+      auth_token_encrypted: fullConfig.authToken,
+      embedding_config_id: fullConfig.embeddingConfigId,
+      index_mode: fullConfig.indexMode,
+      readme_max_chars: fullConfig.readmeMaxChars,
+      search_threshold: fullConfig.searchThreshold,
+      search_top_k: fullConfig.searchTopK,
+      enable_hyde: 0,
+      enable_reranking: 1,
+      embedding_format_version: 2,
+      status_json: null,
+      last_sync_at: null,
+    };
+    mockGetReturningRow(row);
+
+    const res = await request(createTestApp()).get('/api/configs/vector-search?decrypt=true');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      enabled: true,
+      workerUrl: fullConfig.workerUrl,
+      authToken: fullConfig.authToken,
+      embeddingConfigId: fullConfig.embeddingConfigId,
+      indexMode: fullConfig.indexMode,
+      readmeMaxChars: fullConfig.readmeMaxChars,
+      searchThreshold: fullConfig.searchThreshold,
+      searchTopK: fullConfig.searchTopK,
+      enableHyDE: false,
+      enableReranking: true,
+      embeddingFormatVersion: 2,
+    });
+  });
+
+  it('PUT normalizes out-of-range search params and clears the format version when absent', async () => {
+    const capture = capturePut();
+    await request(createTestApp()).put('/api/configs/vector-search').send({
+      enabled: false,
+      authToken: '',
+      searchThreshold: 5,
+      searchTopK: 999,
+      embeddingFormatVersion: 0,
+    });
+
+    const p = capture.params[0];
+    expect(p[7]).toBe(0.35); // out-of-range threshold → default
+    expect(p[8]).toBe(30); // out-of-range topK → default
+    expect(p[9]).toBe(0); // enable_hyde absent → false
+    expect(p[10]).toBe(0); // enable_reranking absent → false
+    expect(p[11]).toBeNull(); // embeddingFormatVersion 0 (invalid) → null
+  });
+});

--- a/src/services/autoSync.ts
+++ b/src/services/autoSync.ts
@@ -89,6 +89,21 @@ export function shouldPreserveLocalVectorSearch(
   return backendEmpty && localConfigured;
 }
 
+/**
+ * True when the backend's stored vector-search authToken is unusable (empty or
+ * failed to decrypt) but the local client has a working token to preserve. The
+ * caller must then queue a repair push: during a pull the store subscription is
+ * suppressed, so without it the preserved token would never reach the backend,
+ * the stored fingerprint (with the local token) would never match the backend's
+ * empty token, and the poll→push loop would run forever.
+ */
+export function shouldQueueVectorSearchRepairPush(backendConfig: unknown, localConfig: unknown): boolean {
+  const b = (backendConfig ?? {}) as Record<string, unknown>;
+  const l = (localConfig ?? {}) as Record<string, unknown>;
+  const backendTokenUnusable = b.authTokenStatus === 'decrypt_failed' || !b.authToken;
+  return backendTokenUnusable && !!l.authToken;
+}
+
 function setRepositorySyncVisualState(isSyncing: boolean): void {
   if (typeof window === 'undefined') return;
   window.dispatchEvent(new CustomEvent('gsm:repository-sync-visual-state', { detail: { isSyncing } }));
@@ -328,12 +343,14 @@ export async function syncFromBackend(): Promise<void> {
       if (shouldPreserveLocalVectorSearch(backendConfig, localConfig, _lastHash.vectorSearch === '')) {
         _hasPendingPush = true;
       } else {
-        // Preserve local authToken if backend returned empty or decrypt_failed
-        if ((backendConfig as Record<string, unknown>).authTokenStatus === 'decrypt_failed' || !backendConfig.authToken) {
-          if (localConfig.authToken) {
-            logger.warn('sync.decryptFailed', 'Backend decrypt_failed for vector search authToken, preserving local value');
-            backendConfig.authToken = localConfig.authToken;
-          }
+        // Preserve local authToken if backend returned empty or decrypt_failed,
+        // and queue a repair push so the backend is re-synced with it. Without
+        // the push the preserved token stays local-only and the poll loop keeps
+        // re-detecting the backend/effective fingerprint mismatch.
+        if (shouldQueueVectorSearchRepairPush(backendConfig, localConfig)) {
+          logger.warn('sync.decryptFailed', 'Backend decrypt_failed for vector search authToken, preserving local value');
+          backendConfig.authToken = localConfig.authToken;
+          _hasPendingPush = true;
         }
         state.setVectorSearchConfig(backendConfig);
         // Fingerprint the effective store config (after merge/normalization) so it

--- a/src/services/autoSync.ts
+++ b/src/services/autoSync.ts
@@ -43,6 +43,52 @@ function quickHash(data: unknown): string {
   return JSON.stringify(data);
 }
 
+/** Canonical fingerprint for the vector search config.
+ *
+ * The backend GET payload and the store config have different key sets/order
+ * (backend adds authTokenStatus/status/lastSyncAt, the store always carries
+ * embeddingFormatVersion). A naive quickHash over each raw side therefore never
+ * matches, which kept the poll→push loop running forever. Fingerprinting only the
+ * shared, meaningful fields makes both sides converge after one round-trip.
+ */
+export function vectorSearchFingerprint(config: unknown): string {
+  const c = (config ?? {}) as Record<string, unknown>;
+  return quickHash({
+    enabled: !!c.enabled,
+    workerUrl: c.workerUrl ?? '',
+    authToken: c.authToken ?? '',
+    embeddingConfigId: c.embeddingConfigId ?? '',
+    indexMode: c.indexMode ?? 'readme',
+    readmeMaxChars: c.readmeMaxChars ?? 6000,
+    searchThreshold: c.searchThreshold ?? 0.35,
+    searchTopK: c.searchTopK ?? 30,
+    enableHyDE: c.enableHyDE ?? true,
+    enableReranking: c.enableReranking ?? true,
+    embeddingFormatVersion: c.embeddingFormatVersion ?? null,
+  });
+}
+
+/**
+ * Decide whether a fresh/empty backend must NOT overwrite a locally configured
+ * vector search. Mirrors the repositories bootstrap guard: on the first-ever sync
+ * in this session, an empty backend (nothing stored) must not wipe a working local
+ * config — otherwise the local worker/embedding setup is lost and the follow-up
+ * push then persists the wiped (empty) config to the backend. When true, the
+ * caller keeps the local config and pushes it up instead.
+ */
+export function shouldPreserveLocalVectorSearch(
+  backendConfig: unknown,
+  localConfig: unknown,
+  isFirstSync: boolean
+): boolean {
+  if (!isFirstSync) return false;
+  const b = (backendConfig ?? {}) as Record<string, unknown>;
+  const l = (localConfig ?? {}) as Record<string, unknown>;
+  const backendEmpty = !b.enabled && !b.workerUrl && !b.embeddingConfigId;
+  const localConfigured = !!(l.enabled || l.workerUrl || l.embeddingConfigId);
+  return backendEmpty && localConfigured;
+}
+
 function setRepositorySyncVisualState(isSyncing: boolean): void {
   if (typeof window === 'undefined') return;
   window.dispatchEvent(new CustomEvent('gsm:repository-sync-visual-state', { detail: { isSyncing } }));
@@ -171,9 +217,8 @@ export async function syncFromBackend(): Promise<void> {
     }
 
     if (vectorSearchResult.status === 'fulfilled') {
-      const hash = quickHash(vectorSearchResult.value);
+      const hash = vectorSearchFingerprint(vectorSearchResult.value);
       if (hash !== _lastHash.vectorSearch) {
-        hashes.vectorSearch = hash;
         changed.vectorSearch = true;
       }
     }
@@ -277,16 +322,25 @@ export async function syncFromBackend(): Promise<void> {
     }
     if (changed.vectorSearch && vectorSearchResult.status === 'fulfilled') {
       const backendConfig = vectorSearchResult.value;
-      // Preserve local authToken if backend returned empty or decrypt_failed
       const localConfig = state.vectorSearchConfig;
-      if ((backendConfig as Record<string, unknown>).authTokenStatus === 'decrypt_failed' || !backendConfig.authToken) {
-        if (localConfig.authToken) {
-          logger.warn('sync.decryptFailed', 'Backend decrypt_failed for vector search authToken, preserving local value');
-          backendConfig.authToken = localConfig.authToken;
+      // Bootstrap guard (mirrors repositories): a fresh/empty backend must not
+      // wipe a locally-configured vector search — keep local and push it up.
+      if (shouldPreserveLocalVectorSearch(backendConfig, localConfig, _lastHash.vectorSearch === '')) {
+        _hasPendingPush = true;
+      } else {
+        // Preserve local authToken if backend returned empty or decrypt_failed
+        if ((backendConfig as Record<string, unknown>).authTokenStatus === 'decrypt_failed' || !backendConfig.authToken) {
+          if (localConfig.authToken) {
+            logger.warn('sync.decryptFailed', 'Backend decrypt_failed for vector search authToken, preserving local value');
+            backendConfig.authToken = localConfig.authToken;
+          }
         }
+        state.setVectorSearchConfig(backendConfig);
+        // Fingerprint the effective store config (after merge/normalization) so it
+        // matches the push fingerprint in syncToBackend(); hashing the raw backend
+        // payload instead would leave the two sides forever unequal.
+        _lastHash.vectorSearch = vectorSearchFingerprint(useAppStore.getState().vectorSearchConfig);
       }
-      state.setVectorSearchConfig(backendConfig);
-      _lastHash.vectorSearch = hashes.vectorSearch;
     }
     // Sync active selections from settings
     if (changed.settings && settingsResult.status === 'fulfilled') {
@@ -404,7 +458,7 @@ export async function syncToBackend(): Promise<void> {
     if (aiSync.status === 'fulfilled') _lastHash.ai = quickHash(state.aiConfigs);
     if (webdavSync.status === 'fulfilled') _lastHash.webdav = quickHash(state.webdavConfigs);
     if (embeddingSync.status === 'fulfilled') _lastHash.embedding = quickHash(state.embeddingConfigs);
-    if (vectorSearchSync.status === 'fulfilled') _lastHash.vectorSearch = quickHash(state.vectorSearchConfig);
+    if (vectorSearchSync.status === 'fulfilled') _lastHash.vectorSearch = vectorSearchFingerprint(state.vectorSearchConfig);
     if (settingsSync.status === 'fulfilled') {
       _lastHash.settings = quickHash({
         activeAIConfig: state.activeAIConfig,

--- a/src/services/autoSync.vectorSearch.test.ts
+++ b/src/services/autoSync.vectorSearch.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { shouldPreserveLocalVectorSearch, vectorSearchFingerprint } from './autoSync';
+
+const canonical = {
+  enabled: true,
+  workerUrl: 'https://example.com/vectorize',
+  authToken: 'worker-secret-token',
+  embeddingConfigId: 'emb_test1',
+  indexMode: 'readme',
+  readmeMaxChars: 8000,
+  searchThreshold: 0.42,
+  searchTopK: 25,
+  enableHyDE: false,
+  enableReranking: true,
+  embeddingFormatVersion: 2,
+};
+
+describe('vectorSearchFingerprint (loop-breaker)', () => {
+  it('produces identical fingerprints for a backend payload and store config', () => {
+    // Shape returned by GET /api/configs/vector-search (extra derived fields, different key order).
+    const backendPayload = {
+      enabled: true,
+      workerUrl: 'https://example.com/vectorize',
+      authToken: 'secret-secret',
+      authTokenStatus: 'ok',
+      embeddingConfigId: 'ep_test1',
+      indexMode: 'readme',
+      readmeMaxChars: 8000,
+      searchThreshold: 0.42,
+      searchTopK: 25,
+      enableHyDE: false,
+      enableReranking: true,
+      embeddingFormatVersion: 2,
+      status: { connected: true },
+      lastSyncAt: '2026-08-06T00:00:00.000Z',
+    };
+
+    // Shape of the store config after mergeVectorSearchConfig (canonical key order, no extras).
+    const storeConfig = {
+      enabled: true,
+      workerUrl: 'https://example.com/vectorize',
+      authToken: 'secret-secret',
+      embeddingConfigId: 'ep_test1',
+      indexMode: 'readme',
+      readmeMaxChars: 8000,
+      searchThreshold: 0.42,
+      searchTopK: 25,
+      enableHyDE: false,
+      enableReranking: true,
+      embeddingFormatVersion: 2,
+    };
+
+    expect(vectorSearchFingerprint(backendPayload)).toBe(vectorSearchFingerprint(storeConfig));
+  });
+
+  it('is stable regardless of key ordering', () => {
+    const a = vectorSearchFingerprint(canonical);
+    const reordered = {
+      enableReranking: canonical.enableReranking,
+      enableHyDE: canonical.enableHyDE,
+      searchThreshold: canonical.searchThreshold,
+      searchTopK: canonical.searchTopK,
+      embeddingFormatVersion: canonical.embeddingFormatVersion,
+      readmeMaxChars: canonical.readmeMaxChars,
+      enabled: canonical.enabled,
+      workerUrl: canonical.workerUrl,
+      authToken: canonical.authToken,
+      embeddingConfigId: canonical.embeddingConfigId,
+      indexMode: canonical.indexMode,
+    };
+    expect(a).toBe(vectorSearchFingerprint(reordered));
+  });
+
+  it('normalizes defaults so absent optional search fields do not drift', () => {
+    const backendEmpty = vectorSearchFingerprint({ enabled: false, workerUrl: '', authToken: '', embeddingConfigId: '', indexMode: 'readme', readmeMaxChars: 6000 });
+    const storeEmpty = vectorSearchFingerprint({ enabled: false, workerUrl: '', authToken: '', embeddingConfigId: '', indexMode: 'readme', readmeMaxChars: 6000, searchThreshold: 0.35, searchTopK: 30, enableHyDE: true, enableReranking: true, embeddingFormatVersion: null });
+    expect(backendEmpty).toBe(storeEmpty);
+  });
+});
+
+describe('shouldPreserveLocalVectorSearch (bootstrap guard)', () => {
+  it('preserves a configured local config when the backend is empty on first sync', () => {
+    expect(shouldPreserveLocalVectorSearch(
+      { enabled: false, workerUrl: '', embeddingConfigId: '', indexMode: 'readme', readmeMaxChars: 6000 },
+      { enabled: true, workerUrl: 'https://example.com', embeddingConfigId: 'emb_1' },
+      true,
+    )).toBe(true);
+  });
+
+  it('does not preserve when the local config is unconfigured', () => {
+    expect(shouldPreserveLocalVectorSearch(
+      { enabled: false, workerUrl: '', embeddingConfigId: '' },
+      { enabled: false, workerUrl: '', embeddingConfigId: '' },
+      true,
+    )).toBe(false);
+  });
+
+  it('does not preserve when the backend already has a stored config (not first sync)', () => {
+    expect(shouldPreserveLocalVectorSearch(
+      { enabled: false, workerUrl: '', embeddingConfigId: '' },
+      { enabled: true, workerUrl: 'https://example.com', embeddingConfigId: 'emb_1' },
+      false,
+    )).toBe(false);
+    expect(shouldPreserveLocalVectorSearch(
+      { enabled: false, workerUrl: 'https://example.com', embeddingConfigId: 'emb_1' },
+      { enabled: true, workerUrl: '', embeddingConfigId: '' },
+      true,
+    )).toBe(false);
+  });
+});

--- a/src/services/autoSync.vectorSearch.test.ts
+++ b/src/services/autoSync.vectorSearch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { shouldPreserveLocalVectorSearch, vectorSearchFingerprint } from './autoSync';
+import { shouldPreserveLocalVectorSearch, shouldQueueVectorSearchRepairPush, vectorSearchFingerprint } from './autoSync';
 
 const canonical = {
   enabled: true,
@@ -106,5 +106,52 @@ describe('shouldPreserveLocalVectorSearch (bootstrap guard)', () => {
       { enabled: true, workerUrl: '', embeddingConfigId: '' },
       true,
     )).toBe(false);
+  });
+});
+
+describe('shouldQueueVectorSearchRepairPush (decrypt_failed / empty token)', () => {
+  it('queues a repair push when the backend token is decrypt_failed and local has one', () => {
+    expect(shouldQueueVectorSearchRepairPush(
+      { authTokenStatus: 'decrypt_failed', authToken: '' },
+      { authToken: 'local-token' },
+    )).toBe(true);
+  });
+
+  it('queues a repair push when the backend token is empty but local has one', () => {
+    expect(shouldQueueVectorSearchRepairPush(
+      { authToken: '', authTokenStatus: 'empty' },
+      { authToken: 'local-token' },
+    )).toBe(true);
+  });
+
+  it('does not queue when the backend token is usable', () => {
+    expect(shouldQueueVectorSearchRepairPush(
+      { authToken: 'backend-token', authTokenStatus: 'ok' },
+      { authToken: 'local-token' },
+    )).toBe(false);
+  });
+
+  it('does not queue when the local client has no token to preserve', () => {
+    expect(shouldQueueVectorSearchRepairPush(
+      { authTokenStatus: 'decrypt_failed', authToken: '' },
+      { authToken: '' },
+    )).toBe(false);
+  });
+
+  it('converges after two pull cycles once the repair push lands', () => {
+    const localConfig = { workerUrl: 'https://example.com', authToken: 'local-token', embeddingConfigId: 'emb_1' };
+
+    // Cycle 1: backend token is unusable; repair push must be queued.
+    const cycle1Backend = { workerUrl: 'https://example.com', authTokenStatus: 'decrypt_failed', authToken: '', embeddingConfigId: 'emb_1' };
+    expect(shouldQueueVectorSearchRepairPush(cycle1Backend, localConfig)).toBe(true);
+    // Effective store config now carries the preserved local token.
+    const effectiveAfterRepair = { ...cycle1Backend, authToken: localConfig.authToken };
+
+    // Cycle 2: the repair push landed, backend now returns the token.
+    const cycle2Backend = { ...cycle1Backend, authTokenStatus: 'ok', authToken: localConfig.authToken };
+
+    // The stored fingerprint (effective config, cycle 1) must match the backend
+    // payload (cycle 2) so the second poll detects no change.
+    expect(vectorSearchFingerprint(effectiveAfterRepair)).toBe(vectorSearchFingerprint(cycle2Backend));
   });
 });


### PR DESCRIPTION
## Summary

Fixes the vector-search config not being fully persisted to the backend when running with a backend, and a related perpetual poll-push sync loop. Related to #259 (persistence follow-up).

## What changed

**1. Persist all vector-search fields on the backend**
- `server/src/db/schema.ts`: add `search_threshold`, `search_top_k`, `enable_hyde`, `enable_reranking`, `embedding_format_version` columns to `vector_search_configs` (+ `addColumnIfMissing` migration for existing DBs).
- `server/src/routes/configs.ts`: GET returns and PUT stores the full config. Previously `searchThreshold`, `searchTopK`, `enableHyDE`, `enableReranking` and `embeddingFormatVersion` were silently dropped on a round-trip, so they fell back to defaults and the lost `embeddingFormatVersion` could force an unwanted full re-index.

**2. Stop the endless push/pull loop** (`src/services/autoSync.ts`)
- The push fingerprint was computed over the full store config while the pull fingerprint used the smaller backend payload — the two hashes never matched, so `syncFromBackend` re-applied (and re-pushed) the config every 5s.
- Added a canonical `vectorSearchFingerprint()` over the shared meaningful fields so both sides converge after one round-trip.

**3. Audit fixes**
- **Bootstrap guard** `shouldPreserveLocalVectorSearch()`: a fresh/empty backend no longer wipes a locally configured vector search on first sync (mirrors the repositories bootstrap guard) — local config is kept and pushed up.
- Backend validates `embeddingFormatVersion >= 1` (frontend treats lower values as invalid).
- Removed a dead `hashes.vectorSearch` assignment.

## Tests
- `server/tests/routes/vectorSearchConfig.test.ts`: PUT persists all fields, GET round-trip, out-of-range normalization (incl. `embeddingFormatVersion: 0 → null`).
- `src/services/autoSync.vectorSearch.test.ts`: fingerprint convergence (backend payload vs store config, key-order independence, default normalization) + bootstrap-guard behavior.

Verification: frontend 154 tests, server 67 tests, server `tsc` build, and eslint all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable vector search settings, including similarity thresholds, result limits, HyDE, reranking, and embedding format version.
  * Vector search settings now synchronize reliably between local and backend configurations.
  * Local settings are preserved during initial setup when no backend values are available.

* **Bug Fixes**
  * Improved validation and normalization of invalid search parameters.
  * Preserved authentication settings during configuration synchronization.
  * Automatically repairs missing or invalid authentication settings during synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->