### PR TITLE
feat: 按实际生效标签归类分类 + 保留手动分类归属

### DIFF
--- a/src/components/CategorySidebar.tsx
+++ b/src/components/CategorySidebar.tsx
@@ -31,6 +31,7 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
     defaultCategoryOverrides,
     categoryOrder,
     collapsedSidebarCategoryCount,
+    categoryMatchMode,
     deleteCustomCategory,
     hideDefaultCategory,
     showDefaultCategory,
@@ -175,11 +176,11 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
     
     for (const category of allCategories) {
       if (category.id === 'all') continue;
-      const count = repositories.filter(repo => matchesCategory(repo, category)).length;
+      const count = repositories.filter(repo => matchesCategory(repo, category, categoryMatchMode)).length;
       counts.set(category.id, count);
     }
     return counts;
-  }, [repositories, allCategories]);
+  }, [repositories, allCategories, categoryMatchMode]);
 
   const getCategoryCount = useCallback((category: Category) => {
     return categoryCounts.get(category.id) ?? 0;

--- a/src/components/DiscoveryView.tsx
+++ b/src/components/DiscoveryView.tsx
@@ -811,7 +811,7 @@ export const DiscoveryView: React.FC = React.memo(() => {
         (result) => {
           if (result.success && result.repo) {
             const resolvedCategory = resolveCategoryAssignment(
-              result.repo,
+              { ...result.repo, ai_summary: result.summary },
               result.tags || [],
               allCategoriesForResolution
             );

--- a/src/components/DiscoveryView.tsx
+++ b/src/components/DiscoveryView.tsx
@@ -22,7 +22,7 @@ import { useAppStore } from '../store/useAppStore';
 import { GitHubApiService } from '../services/githubApi';
 import { AIService } from '../services/aiService';
 import { AIAnalysisOptimizer } from '../services/aiAnalysisOptimizer';
-import { resolveCategoryAssignment } from '../utils/categoryUtils';
+import { resolveCategoryAssignment, buildCategoryHints } from '../utils/categoryUtils';
 import { discoveryAnalysisStorage } from '../services/discoveryAnalysisStorage';
 import { DiscoverySidebar } from './DiscoverySidebar';
 import { SubscriptionRepoCard } from './SubscriptionRepoCard';
@@ -784,6 +784,7 @@ export const DiscoveryView: React.FC = React.memo(() => {
         ? ['全部分类', 'Web应用', '移动应用', '桌面应用', '数据库', 'AI/机器学习', '开发工具', '安全工具', '游戏', '设计工具', '效率工具', '教育学习', '社交网络', '数据分析']
         : ['All', 'Web Apps', 'Mobile Apps', 'Desktop Apps', 'Database', 'AI/ML', 'Dev Tools', 'Security Tools', 'Games', 'Design Tools', 'Productivity', 'Education', 'Social Networks', 'Data Analysis']),
     ];
+    const aiCategoryHints = buildCategoryHints(storeState.customCategories);
 
     const githubApi = new GitHubApiService(githubToken);
     const aiService = new AIService(activeConfig, language);
@@ -803,6 +804,7 @@ export const DiscoveryView: React.FC = React.memo(() => {
         readmeCache,
         aiService,
         categoryNames,
+        aiCategoryHints,
         (current: number, total: number) => {
           setAnalysisProgress({ current, total });
         },

--- a/src/components/DiscoveryView.tsx
+++ b/src/components/DiscoveryView.tsx
@@ -18,7 +18,7 @@ import {
   X,
   Calendar
 } from 'lucide-react';
-import { useAppStore } from '../store/useAppStore';
+import { useAppStore, getAllCategories } from '../store/useAppStore';
 import { GitHubApiService } from '../services/githubApi';
 import { AIService } from '../services/aiService';
 import { AIAnalysisOptimizer } from '../services/aiAnalysisOptimizer';
@@ -773,9 +773,12 @@ export const DiscoveryView: React.FC = React.memo(() => {
     setIsAnalyzing(true);
     setAnalysisState({ paused: false, aborted: false });
     const storeState = useAppStore.getState();
-    const allCategoriesForResolution = [
-      ...storeState.customCategories,
-    ];
+    const allCategoriesForResolution = getAllCategories(
+      storeState.customCategories,
+      storeState.language,
+      storeState.hiddenDefaultCategoryIds,
+      storeState.defaultCategoryOverrides
+    );
     const allCategoryNames = storeState
       .customCategories.map(c => c.name);
     const categoryNames = [

--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -36,6 +36,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
     customCategories,
     hiddenDefaultCategoryIds,
     defaultCategoryOverrides,
+    categoryMatchMode,
     analysisProgress,
     setAnalysisProgress,
     searchFilters,
@@ -78,8 +79,8 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
     
     const selectedCategoryObj = allCategories.find(cat => cat.id === selectedCategory);
     if (!selectedCategoryObj) return [];
-    return repositories.filter(repo => matchesCategory(repo, selectedCategoryObj));
-  }, [repositories, selectedCategory, allCategories]);
+    return repositories.filter(repo => matchesCategory(repo, selectedCategoryObj, categoryMatchMode));
+  }, [repositories, selectedCategory, allCategories, categoryMatchMode]);
 
   // 根据当前筛选的仓库中是否有AI分析内容来动态设置默认显示模式
   const hasAnalyzedRepos = useMemo(() => 

--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -11,7 +11,7 @@ import { useAppStore, getAllCategories } from '../store/useAppStore';
 import { GitHubApiService } from '../services/githubApi';
 import { AIService } from '../services/aiService';
 import { AIAnalysisOptimizer, AnalysisResult } from '../services/aiAnalysisOptimizer';
-import { resolveCategoryAssignment, getAICategory, getDefaultCategory, computeCustomCategory, matchesCategory } from '../utils/categoryUtils';
+import { resolveCategoryAssignment, getAICategory, getDefaultCategory, computeCustomCategory, matchesCategory, buildCategoryHints } from '../utils/categoryUtils';
 import { forceSyncToBackend } from '../services/autoSync';
 import { useDialog } from '../hooks/useDialog';
 
@@ -328,6 +328,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
       const githubApi = new GitHubApiService(githubToken);
       const aiService = new AIService(activeConfig, language);
       const categoryNames = allCategories.filter(cat => cat.id !== 'all').map(cat => cat.name);
+      const aiCategoryHints = buildCategoryHints(allCategories);
 
       let successCount = 0;
       let failedCount = 0;
@@ -372,6 +373,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
         githubApi,
         aiService,
         categoryNames,
+        aiCategoryHints,
         (completed, total, currentConcurrency) => {
           setAnalysisProgress({ current: completed, total });
           console.log(`AI Analysis Progress: ${completed}/${total}, Concurrency: ${currentConcurrency}`);
@@ -679,6 +681,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
             const githubApi = new GitHubApiService(githubToken);
             const aiService = new AIService(activeConfig, language);
             const categoryNames = allCategories.filter(cat => cat.id !== 'all').map(cat => cat.name);
+            const aiCategoryHints = buildCategoryHints(allCategories);
 
             let successCount = 0;
             let failedCount = 0;
@@ -724,6 +727,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
               githubApi,
               aiService,
               categoryNames,
+              aiCategoryHints,
               (completed, total, currentConcurrency) => {
                 setAnalysisProgress({ current: completed, total });
                 console.log(`Bulk AI Analysis Progress: ${completed}/${total}, Concurrency: ${currentConcurrency}`);

--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -336,7 +336,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
       const handleResult = (result: AnalysisResult) => {
         if (result.success) {
           const resolvedCategory = resolveCategoryAssignment(
-            result.repo,
+            { ...result.repo, ai_summary: result.summary },
             result.tags || [],
             allCategories
           );
@@ -689,7 +689,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
             const handleResult = (result: AnalysisResult) => {
               if (result.success) {
                 const resolvedCategory = resolveCategoryAssignment(
-                  result.repo,
+                  { ...result.repo, ai_summary: result.summary },
                   result.tags || [],
                   allCategories
                 );

--- a/src/components/settings/CategoryPanel.tsx
+++ b/src/components/settings/CategoryPanel.tsx
@@ -14,6 +14,7 @@ export const CategoryPanel: React.FC<CategoryPanelProps> = ({ t }) => {
   const defaultCategoryOverrides = useAppStore(state => state.defaultCategoryOverrides);
   const categoryOrder = useAppStore(state => state.categoryOrder);
   const collapsedSidebarCategoryCount = useAppStore(state => state.collapsedSidebarCategoryCount);
+  const categoryMatchMode = useAppStore(state => state.categoryMatchMode);
   const language = useAppStore(state => state.language);
   const addCustomCategory = useAppStore(state => state.addCustomCategory);
   const deleteCustomCategory = useAppStore(state => state.deleteCustomCategory);
@@ -26,6 +27,7 @@ export const CategoryPanel: React.FC<CategoryPanelProps> = ({ t }) => {
   const showDefaultCategory = useAppStore(state => state.showDefaultCategory);
   const setCategoryOrder = useAppStore(state => state.setCategoryOrder);
   const setCollapsedSidebarCategoryCount = useAppStore(state => state.setCollapsedSidebarCategoryCount);
+  const setCategoryMatchMode = useAppStore(state => state.setCategoryMatchMode);
 
   const { toast, confirm } = useDialog();
 
@@ -300,6 +302,64 @@ export const CategoryPanel: React.FC<CategoryPanelProps> = ({ t }) => {
               step={1}
             />
           </div>
+        </div>
+      </div>
+
+      {/* 分类匹配模式设置 */}
+      <div className="p-4 bg-light-surface dark:bg-white/[0.04] rounded-lg border border-black/[0.06] dark:border-white/[0.04]">
+        <div className="flex items-center space-x-3 mb-2">
+          <LayoutGrid className="w-5 h-5 text-gray-700 dark:text-text-secondary" />
+          <h4 className="font-medium text-gray-900 dark:text-text-primary">
+            {t('仓库归类方式', 'Repository Categorization')}
+          </h4>
+        </div>
+        <p className="text-sm text-gray-500 dark:text-text-tertiary mb-3">
+          {t(
+            '选择仓库如何被归入侧边栏的分类中。切换后侧边栏的仓库数量会相应变化。',
+            'Choose how repositories are assigned to categories in the sidebar. Switching will update the category counts.'
+          )}
+        </p>
+        <div className="space-y-3">
+          <label className="flex items-start space-x-3 cursor-pointer">
+            <input
+              type="radio"
+              name="categoryMatchMode"
+              checked={categoryMatchMode === 'effective'}
+              onChange={() => setCategoryMatchMode('effective')}
+              className="mt-1 w-4 h-4 text-brand-indigo focus:ring-brand-violet"
+            />
+            <div>
+              <span className="block text-sm font-medium text-gray-900 dark:text-text-primary">
+                {t('按卡片显示的分类标签归类（推荐）', 'Match by tags shown on cards (Recommended)')}
+              </span>
+              <span className="block text-xs text-gray-500 dark:text-text-tertiary mt-0.5">
+                {t(
+                  '仓库会按卡片上实际看到的标签进入分类；你编辑的自定义标签优先，AI 分析不会覆盖你已经手动分类的仓库。',
+                  'Repositories are grouped by the tags actually shown on their cards; your custom tags take priority, and AI analysis will not override repositories you have categorized manually.'
+                )}
+              </span>
+            </div>
+          </label>
+          <label className="flex items-start space-x-3 cursor-pointer">
+            <input
+              type="radio"
+              name="categoryMatchMode"
+              checked={categoryMatchMode === 'legacy'}
+              onChange={() => setCategoryMatchMode('legacy')}
+              className="mt-1 w-4 h-4 text-brand-indigo focus:ring-brand-violet"
+            />
+            <div>
+              <span className="block text-sm font-medium text-gray-900 dark:text-text-primary">
+                {t('仅按 AI 生成标签归类（旧版）', 'Match by AI-generated tags only (Legacy)')}
+              </span>
+              <span className="block text-xs text-gray-500 dark:text-text-tertiary mt-0.5">
+                {t(
+                  '使用早期版本逻辑，仅根据 AI 生成的标签归类，适合习惯旧版分类方式的用户。',
+                  'Uses the legacy logic that categorizes only by AI-generated tags, for users who prefer the old behavior.'
+                )}
+              </span>
+            </div>
+          </label>
         </div>
       </div>
 

--- a/src/components/settings/CategoryPanel.tsx
+++ b/src/components/settings/CategoryPanel.tsx
@@ -315,8 +315,8 @@ export const CategoryPanel: React.FC<CategoryPanelProps> = ({ t }) => {
         </div>
         <p className="text-sm text-gray-500 dark:text-text-tertiary mb-3">
           {t(
-            '选择仓库如何被归入侧边栏的分类中。切换后侧边栏的仓库数量会相应变化。',
-            'Choose how repositories are assigned to categories in the sidebar. Switching will update the category counts.'
+            '选择仓库如何被归入侧边栏的分类中。切换后侧边栏的仓库数量会相应变化。你手动设置的分类归属始终保留，不会被 AI 分析覆盖。',
+            'Choose how repositories are assigned to categories in the sidebar. Switching will update the category counts. Categories you assign manually are always kept and will not be overridden by AI analysis.'
           )}
         </p>
         <div className="space-y-3">
@@ -334,8 +334,8 @@ export const CategoryPanel: React.FC<CategoryPanelProps> = ({ t }) => {
               </span>
               <span className="block text-xs text-gray-500 dark:text-text-tertiary mt-0.5">
                 {t(
-                  '仓库会按卡片上实际看到的标签进入分类；你编辑的自定义标签优先，AI 分析不会覆盖你已经手动分类的仓库。',
-                  'Repositories are grouped by the tags actually shown on their cards; your custom tags take priority, and AI analysis will not override repositories you have categorized manually.'
+                  '仓库会按卡片上实际看到的标签进入分类；你编辑的自定义标签优先。',
+                  'Repositories are grouped by the tags actually shown on their cards; your custom tags take priority.'
                 )}
               </span>
             </div>

--- a/src/services/aiAnalysisHelper.ts
+++ b/src/services/aiAnalysisHelper.ts
@@ -56,7 +56,7 @@ export const analyzeRepository = async (options: AnalyzeRepositoryOptions): Prom
   const categoryHints = buildCategoryHints(categories);
   const analysis = await aiService.analyzeRepository(repository, readmeContent, categoryNames, categoryHints, signal);
 
-  const resolvedCategory = resolveCategoryAssignment(repository as Repository, analysis.tags, categories);
+  const resolvedCategory = resolveCategoryAssignment({ ...repository, ai_summary: analysis.summary } as Repository, analysis.tags, categories);
 
   const wasCategoryLocked = !!(repository as Repository).category_locked;
 

--- a/src/services/aiAnalysisHelper.ts
+++ b/src/services/aiAnalysisHelper.ts
@@ -2,7 +2,7 @@ import { Repository, AIConfig, Category, DiscoveryRepo } from '../types';
 import { GitHubApiService } from './githubApi';
 import { AIService } from './aiService';
 import { backend } from './backendAdapter';
-import { resolveCategoryAssignment } from '../utils/categoryUtils';
+import { resolveCategoryAssignment, buildCategoryHints } from '../utils/categoryUtils';
 
 export interface AIAnalysisResult {
   summary: string;
@@ -53,7 +53,8 @@ export const analyzeRepository = async (options: AnalyzeRepositoryOptions): Prom
     .map(cat => cat.name);
 
   onProgress?.('Analyzing with AI...');
-  const analysis = await aiService.analyzeRepository(repository, readmeContent, categoryNames, signal);
+  const categoryHints = buildCategoryHints(categories);
+  const analysis = await aiService.analyzeRepository(repository, readmeContent, categoryNames, categoryHints, signal);
 
   const resolvedCategory = resolveCategoryAssignment(repository as Repository, analysis.tags, categories);
 

--- a/src/services/aiAnalysisOptimizer.ts
+++ b/src/services/aiAnalysisOptimizer.ts
@@ -200,7 +200,8 @@ export class AIAnalysisOptimizer {
   async analyzeWithRetry(
     task: AnalysisTask,
     aiService: AIService,
-    categoryNames: string[]
+    categoryNames: string[],
+    categoryHints?: string
   ): Promise<AnalysisResult> {
     const startTime = Date.now();
     let lastError: Error | undefined;
@@ -231,7 +232,7 @@ export class AIAnalysisOptimizer {
 
       try {
         const analysisStart = Date.now();
-        const analysis = await aiService.analyzeRepository(task.repo, task.readmeContent, categoryNames, controller.signal);
+        const analysis = await aiService.analyzeRepository(task.repo, task.readmeContent, categoryNames, categoryHints, controller.signal);
         const analysisDuration = Date.now() - analysisStart;
 
         this.recordResponseTime(analysisDuration);
@@ -280,6 +281,7 @@ export class AIAnalysisOptimizer {
     readmeCache: Map<number, string>,
     aiService: AIService,
     categoryNames: string[],
+    categoryHints?: string,
     onProgress?: (completed: number, total: number, currentConcurrency: number) => void,
     onResult?: (result: AnalysisResult) => void
   ): Promise<AnalysisResult[]> {
@@ -293,7 +295,7 @@ export class AIAnalysisOptimizer {
     const runTask = async (repo: Repository): Promise<AnalysisResult> => {
       const readmeContent = readmeCache.get(repo.id) || '';
       const task: AnalysisTask = { repo, readmeContent, retries: 0 };
-      return this.analyzeWithRetry(task, aiService, categoryNames);
+      return this.analyzeWithRetry(task, aiService, categoryNames, categoryHints);
     };
 
     const worker = async (workerId: number): Promise<void> => {
@@ -361,6 +363,7 @@ export class AIAnalysisOptimizer {
     githubApi: GitHubApiService,
     aiService: AIService,
     categoryNames: string[],
+    categoryHints?: string,
     onProgress?: (completed: number, total: number, currentConcurrency: number) => void,
     onResult?: (result: AnalysisResult) => void
   ): Promise<AnalysisResult[]> {
@@ -421,7 +424,7 @@ export class AIAnalysisOptimizer {
             }
 
             const task: AnalysisTask = { repo, readmeContent, retries: 0 };
-            const result = await this.analyzeWithRetry(task, aiService, categoryNames);
+            const result = await this.analyzeWithRetry(task, aiService, categoryNames, categoryHints);
 
             completedCount.value++;
             results.push(result);

--- a/src/services/aiService.test.ts
+++ b/src/services/aiService.test.ts
@@ -112,4 +112,19 @@ describe('AIService.searchRepositoriesWithReranking — enhanced basic search fa
     const results = service['performBasicSearch']([repo], '技能');
     expect(results.map((r) => r.id)).toEqual([5]);
   });
+
+  it('finds a repo matching only through custom_tags via enhanced search', async () => {
+    const repo = makeRepo({
+      id: 6,
+      name: 'skill-pack',
+      full_name: 'acme/skill-pack',
+      description: 'A collection of prompts',
+      ai_tags: ['效率工具'],
+      custom_tags: ['技能'],
+    });
+
+    const service = new AIService(makeConfig() as never, 'zh');
+    const results = service['performEnhancedSearch']([repo], '技能', ['技能']);
+    expect(results.map((r) => r.id)).toEqual([6]);
+  });
 });

--- a/src/services/aiService.test.ts
+++ b/src/services/aiService.test.ts
@@ -83,4 +83,33 @@ describe('AIService.searchRepositoriesWithReranking — enhanced basic search fa
     const results = await service.searchRepositoriesWithReranking([repoA], 'mit');
     expect(results.map((r) => r.id)).toEqual([3]);
   });
+
+  it('finds a repo by its custom tag via static fallback search', async () => {
+    const repo = makeRepo({
+      id: 4,
+      name: 'skill-pack',
+      full_name: 'acme/skill-pack',
+      description: 'A collection of prompts',
+      ai_tags: ['效率工具'],
+      custom_tags: ['技能'],
+    });
+
+    const results = await AIService.searchRepositories([repo], '技能');
+    expect(results.map((r) => r.id)).toEqual([4]);
+  });
+
+  it('finds a repo by its custom tag via basic search', async () => {
+    const repo = makeRepo({
+      id: 5,
+      name: 'skill-pack',
+      full_name: 'acme/skill-pack',
+      description: 'A collection of prompts',
+      ai_tags: ['效率工具'],
+      custom_tags: ['技能'],
+    });
+
+    const service = new AIService(makeConfig() as never, 'zh');
+    const results = service['performBasicSearch']([repo], '技能');
+    expect(results.map((r) => r.id)).toEqual([5]);
+  });
 });

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -1439,7 +1439,7 @@ Reply in JSON format:
 
   private performEnhancedSearch(repositories: Repository[], originalQuery: string, aiTerms: string[]): Repository[] {
     const allSearchTerms = [originalQuery, ...aiTerms];
-    
+
     return repositories.filter(repo => {
       const searchableText = [
         repo.name,
@@ -1448,6 +1448,7 @@ Reply in JSON format:
         repo.language || '',
         ...(repo.topics || []),
         repo.ai_summary || '',
+        ...(repo.custom_tags || []),
         ...(repo.ai_tags || []),
         ...(repo.ai_platforms || []),
         normalizeLicense(repo.license),
@@ -1474,6 +1475,7 @@ Reply in JSON format:
         repo.language || '',
         ...(repo.topics || []),
         repo.ai_summary || '',
+        ...(repo.custom_tags || []),
         ...(repo.ai_tags || []),
         ...(repo.ai_platforms || []),
         normalizeLicense(repo.license),
@@ -1499,6 +1501,7 @@ Reply in JSON format:
         repo.language || '',
         ...(repo.topics || []),
         repo.ai_summary || '',
+        ...(repo.custom_tags || []),
         ...(repo.ai_tags || []),
         ...(repo.ai_platforms || []),
         normalizeLicense(repo.license),

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -490,7 +490,7 @@ ${options.user}` : options.user;
     throw new Error('No content received from AI service');
   }
 
-  async analyzeRepository(repository: Repository, readmeContent: string, customCategories?: string[], signal?: AbortSignal): Promise<RepositoryAnalysisResult> {
+  async analyzeRepository(repository: Repository, readmeContent: string, customCategories?: string[], categoryHints?: string, signal?: AbortSignal): Promise<RepositoryAnalysisResult> {
     const startTime = Date.now();
     const configId = this.config.id;
     const { full_name } = repository;
@@ -499,8 +499,8 @@ ${options.user}` : options.user;
     logger.info('ai', 'AI analysis started', { owner, repo, configId });
 
     const prompt = this.config.useCustomPrompt && this.config.customPrompt
-      ? this.createCustomAnalysisPrompt(repository, readmeContent, customCategories)
-      : this.createAnalysisPrompt(repository, readmeContent, customCategories);
+      ? this.createCustomAnalysisPrompt(repository, readmeContent, customCategories, categoryHints)
+      : this.createAnalysisPrompt(repository, readmeContent, customCategories, categoryHints);
 
     try {
       const system = this.language === 'zh'
@@ -828,7 +828,7 @@ ${previousOutput}
     `.trim();
   }
 
-  private createCustomAnalysisPrompt(repository: Repository, readmeContent: string, customCategories?: string[]): string {
+  private createCustomAnalysisPrompt(repository: Repository, readmeContent: string, customCategories?: string[], categoryHints?: string): string {
     const repoInfo = `
 ${this.language === 'zh' ? '仓库名称' : 'Repository Name'}: ${repository.full_name}
 ${this.language === 'zh' ? '描述' : 'Description'}: ${this.sanitizeForPrompt(repository.description || (this.language === 'zh' ? '无描述' : 'No description'))}
@@ -844,16 +844,16 @@ ${this.sanitizeForPrompt(readmeContent.substring(0, 2000))}
       ? `\n\n${this.language === 'zh' ? '可用的应用分类' : 'Available Application Categories'}: ${customCategories.join(', ')}`
       : '';
 
-    // 替换自定义提示词中的占位符
     let customPrompt = this.config.customPrompt || '';
     customPrompt = customPrompt.replace(/\{REPO_INFO\}/g, repoInfo);
     customPrompt = customPrompt.replace(/\{CATEGORIES_INFO\}/g, categoriesInfo);
     customPrompt = customPrompt.replace(/\{LANGUAGE\}/g, this.language);
+    customPrompt = customPrompt.replace(/\{CATEGORIES_HINT\}/g, this.sanitizeForPrompt(categoryHints || ''));
 
     return customPrompt;
   }
 
-  private createAnalysisPrompt(repository: Repository, readmeContent: string, customCategories?: string[]): string {
+  private createAnalysisPrompt(repository: Repository, readmeContent: string, customCategories?: string[], categoryHints?: string): string {
     const repoInfo = `
 ${this.language === 'zh' ? '仓库名称' : 'Repository Name'}: ${repository.full_name}
 ${this.language === 'zh' ? '描述' : 'Description'}: ${this.sanitizeForPrompt(repository.description || (this.language === 'zh' ? '无描述' : 'No description'))}
@@ -869,13 +869,16 @@ ${this.sanitizeForPrompt(readmeContent.substring(0, 2000))}
       const categoriesLine = customCategories && customCategories.length > 0
         ? `\n可用分类（tags 请优先从中选择）：${customCategories.join(', ')}`
         : '';
+      const hintLine = categoryHints && categoryHints.length > 0
+        ? `\n\n自定义分类提示：以下是用户自定义的分类及其关键词。当仓库的名称、描述、Topics 或 README 明显与某个自定义分类的关键词相关时，请务必把该自定义分类名作为 tags 之一（仍保持中文，3-5个）。\n${this.sanitizeForPrompt(categoryHints)}`
+        : '';
       return `
 请分析以下GitHub仓库信息，并只输出合法JSON对象。不要输出思考过程、Markdown、代码块标记、解释或任何额外文本。
 
 要求：
 - summary：中文概述，说明仓库的主要功能和用途，不超过50字。
   禁止出现“我们被要求”“只输出JSON”“根据仓库信息”“summary/tags/platforms”等提示词复述。
-- tags：3-5个中文应用类型标签${customCategories && customCategories.length > 0 ? '，请优先从上方的可用分类中选择' : '，类似应用商店的分类，如：开发工具、Web应用、移动应用、数据库、AI工具等'}。${categoriesLine}
+- tags：3-5个中文应用类型标签${customCategories && customCategories.length > 0 ? '，请优先从上方的可用分类中选择' : '，类似应用商店的分类，如：开发工具、Web应用、移动应用、数据库、AI工具等'}。${categoriesLine}${hintLine}
 - platforms：只能从 ["mac","windows","linux","ios","android","docker","web","cli"] 中选择；无法判断则为 []。
 
 输出格式：
@@ -895,13 +898,16 @@ ${repoInfo}
       const categoriesLine = customCategories && customCategories.length > 0
         ? `\nAvailable categories (tags should prioritize these): ${customCategories.join(', ')}`
         : '';
+      const hintLine = categoryHints && categoryHints.length > 0
+        ? `\n\nCustom category hint: The following are user-defined custom categories with their keywords. When the repository keywords, description, Topics, or README clearly relate to these keywords, include the custom category name as-is in tags (3-5 tags total).\n${this.sanitizeForPrompt(categoryHints)}`
+        : '';
       return `
 Please analyze the following GitHub repository information and only output a valid JSON object. Do not output thinking process, Markdown, code block markers, explanations, or any extra text.
 
 Requirements:
 - summary: A concise English overview explaining the main functionality and purpose, no more than 50 words.
   Do not include prompt restatements such as "asked to", "only output JSON", "based on repository information", or "summary/tags/platforms".
-- tags: 3-5 English application type tags${customCategories && customCategories.length > 0 ? ', please prioritize from the available categories above' : ', similar to app store categories such as: development tools, web apps, mobile apps, database, AI tools, etc.'}.${categoriesLine}
+- tags: 3-5 English application type tags${customCategories && customCategories.length > 0 ? ', please prioritize from the available categories above' : ', similar to app store categories such as: development tools, web apps, mobile apps, database, AI tools, etc.'}.${categoriesLine}${hintLine}
 - platforms: Must only choose from ["mac","windows","linux","ios","android","docker","web","cli"]; use [] if unable to determine.
 
 Output format:

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -848,7 +848,14 @@ ${this.sanitizeForPrompt(readmeContent.substring(0, 2000))}
     customPrompt = customPrompt.replace(/\{REPO_INFO\}/g, repoInfo);
     customPrompt = customPrompt.replace(/\{CATEGORIES_INFO\}/g, categoriesInfo);
     customPrompt = customPrompt.replace(/\{LANGUAGE\}/g, this.language);
-    customPrompt = customPrompt.replace(/\{CATEGORIES_HINT\}/g, this.sanitizeForPrompt(categoryHints || ''));
+    const sanitizedHints = this.sanitizeForPrompt(categoryHints || '');
+    if (customPrompt.includes('{CATEGORIES_HINT}')) {
+      customPrompt = customPrompt.replace(/\{CATEGORIES_HINT\}/g, sanitizedHints);
+    } else if (sanitizedHints) {
+      customPrompt = `${customPrompt.trim()}\n\n${this.language === 'zh'
+        ? '自定义分类提示：\n' + sanitizedHints
+        : 'Custom category hints:\n' + sanitizedHints}`;
+    }
 
     return customPrompt;
   }

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -424,6 +424,7 @@ interface AppActions {
   setCategoryOrder: (order: string[]) => void;
   reorderCategories: (oldIndex: number, newIndex: number) => void;
   setCollapsedSidebarCategoryCount: (count: number) => void;
+  setCategoryMatchMode: (mode: 'legacy' | 'effective') => void;
 
   // Asset Filter actions
   addAssetFilter: (filter: AssetFilter) => void;
@@ -555,6 +556,7 @@ type PersistedAppState = Partial<
     | 'defaultCategoryOverrides'
     | 'categoryOrder'
     | 'collapsedSidebarCategoryCount'
+    | 'categoryMatchMode'
     | 'assetFilters'
     | 'theme'
     | 'currentView'
@@ -853,6 +855,7 @@ export const normalizePersistedState = (
     })(),
     categoryOrder: Array.isArray(safePersisted.categoryOrder) ? safePersisted.categoryOrder.filter((id: unknown): id is string => typeof id === 'string') : [],
     collapsedSidebarCategoryCount: typeof safePersisted.collapsedSidebarCategoryCount === 'number' && safePersisted.collapsedSidebarCategoryCount > 0 ? safePersisted.collapsedSidebarCategoryCount : 20,
+    categoryMatchMode: safePersisted.categoryMatchMode === 'legacy' ? 'legacy' : 'effective',
     assetFilters: Array.isArray(safePersisted.assetFilters) && safePersisted.assetFilters.length > 0 ? safePersisted.assetFilters : defaultPresetFilters,
     language: safePersisted.language || 'zh',
     isAuthenticated: !!(resolvedUser && resolvedGithubToken),
@@ -1252,6 +1255,7 @@ export const useAppStore = create<AppState & AppActions>()(
       defaultCategoryOverrides: {},
       categoryOrder: [],
       collapsedSidebarCategoryCount: 20,
+      categoryMatchMode: 'effective',
       assetFilters: defaultPresetFilters,
       theme: 'dark',
       hasHydrated: false,
@@ -2077,6 +2081,7 @@ export const useAppStore = create<AppState & AppActions>()(
         return { categoryOrder: newOrder };
       }),
       setCollapsedSidebarCategoryCount: (count) => set({ collapsedSidebarCategoryCount: count }),
+      setCategoryMatchMode: (mode) => set({ categoryMatchMode: mode }),
 
       // Asset Filter actions
       addAssetFilter: (filter) => set((state) => ({
@@ -2333,6 +2338,7 @@ export const useAppStore = create<AppState & AppActions>()(
         hiddenDefaultCategoryIds: state.hiddenDefaultCategoryIds,
         categoryOrder: state.categoryOrder,
         collapsedSidebarCategoryCount: state.collapsedSidebarCategoryCount,
+        categoryMatchMode: state.categoryMatchMode,
         defaultCategoryOverrides: state.defaultCategoryOverrides,
 
         // 持久化资源过滤器

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -352,6 +352,8 @@ export interface SearchFilters {
   licenses: string[]; // 新增：开源许可过滤
 }
 
+export type CategoryMatchMode = 'legacy' | 'effective';
+
 export interface Category {
   id: string;
   name: string;
@@ -445,6 +447,7 @@ export interface AppState {
   defaultCategoryOverrides: Record<string, Partial<Category>>;
   categoryOrder: string[]; // 新增：分类排序顺序
   collapsedSidebarCategoryCount: number; // 新增：折叠状态下显示的分类个数
+  categoryMatchMode: CategoryMatchMode; // 分类匹配模式：按卡片展示标签（含自定义）或仅AI标签
   
   // Asset Filters
   assetFilters: AssetFilter[]; // 新增：资源过滤器

--- a/src/utils/categoryUtils.test.ts
+++ b/src/utils/categoryUtils.test.ts
@@ -405,4 +405,110 @@ describe('buildCategoryHints', () => {
     ];
     expect(buildCategoryHints(categories)).toContain('我的项目');
   });
+
+  it('normalizes whitespace-only keywords out of hint text', () => {
+    const categories: Category[] = [
+      { id: 'c1', name: 'skills', icon: '💡', keywords: [' ', '  ', 'Skill'], isCustom: true },
+    ];
+    const hints = buildCategoryHints(categories);
+    expect(hints).toContain('Skill');
+    expect(hints).not.toContain('（ ,');
+    expect(hints).not.toContain('(no keywords');
+  });
+});
+
+describe('resolveCategoryAssignment whitespace-keyword regression', () => {
+  const whitespaceCategory: Category = {
+    id: 'custom-whitespace',
+    name: '空关键词',
+    icon: '⚠️',
+    keywords: [' ', '  ', ''],
+    isCustom: true,
+  };
+
+  it('does not match every repository when keywords are whitespace-only', () => {
+    const repository = {
+      ...baseRepository,
+      full_name: 'foo/demo-app',
+      name: 'demo-app',
+      description: 'A web demo',
+      language: 'JavaScript',
+      topics: ['web'],
+      custom_category: undefined,
+    };
+    // 关键词全部为空白时应回退到分类名匹配，仓库名不含该分类名 → 不命中
+    expect(resolveCategoryAssignment(repository, ['Web应用'], [whitespaceCategory, aiCategory, webCategory])).toBe(undefined);
+  });
+
+  it('matches by name via fallback when keywords are whitespace-only and name is present in repo text', () => {
+    const repository = {
+      ...baseRepository,
+      full_name: 'acme/empty-category',
+      name: 'empty-category',
+      description: '空关键词 demo app',
+      language: 'JavaScript',
+      topics: [],
+      custom_category: undefined,
+    };
+    expect(resolveCategoryAssignment(repository, ['Web应用'], [whitespaceCategory, aiCategory, webCategory])).toBe('空关键词');
+  });
+
+  it('matches via a genuine non-whitespace keyword among whitespace keywords', () => {
+    const category: Category = {
+      id: 'custom-mixed',
+      name: '数据分析',
+      icon: '📊',
+      keywords: ['  ', ' pandas ', ''],
+      isCustom: true,
+    };
+    const repository = {
+      ...baseRepository,
+      full_name: 'acme/pandas-playground',
+      name: 'pandas-playground',
+      description: 'Data science repo',
+      language: 'Python',
+      topics: [],
+      custom_category: undefined,
+    };
+    expect(resolveCategoryAssignment(repository, [], [category, aiCategory])).toBe('数据分析');
+  });
+});
+
+describe('resolveCategoryAssignment summary-only metadata match', () => {
+  const customSkills: Category = {
+    id: 'custom-skills',
+    name: 'skills',
+    icon: '💡',
+    keywords: ['Skills', '技能'],
+    isCustom: true,
+  };
+
+  it('assigns a custom category matched only by the freshly generated ai_summary', () => {
+    const repository = {
+      ...baseRepository,
+      full_name: 'leon/repo',
+      name: 'repo',
+      description: 'Generic CLI tool',
+      language: 'Go',
+      topics: [],
+      ai_summary: 'A curated collection of reusable agent skills and prompt libraries',
+      custom_category: undefined,
+    };
+    // name/description/topics 均不含 skills，仅 ai_summary 命中
+    expect(resolveCategoryAssignment(repository, ['开发工具'], [customSkills, aiCategory])).toBe('skills');
+  });
+
+  it('does not assign via ai_summary when the summary contains no matching keyword', () => {
+    const repository = {
+      ...baseRepository,
+      full_name: 'leon/repo',
+      name: 'repo',
+      description: 'Generic CLI tool',
+      language: 'Go',
+      topics: [],
+      ai_summary: 'A minimal HTTP server written in Go',
+      custom_category: undefined,
+    };
+    expect(resolveCategoryAssignment(repository, ['开发工具'], [customSkills, aiCategory])).toBe(undefined);
+  });
 });

--- a/src/utils/categoryUtils.test.ts
+++ b/src/utils/categoryUtils.test.ts
@@ -122,14 +122,14 @@ describe('matchesCategory', () => {
     expect(matchesCategory(repository, aiCategory)).toBe(false);
   });
 
-  it('honors non-empty custom_category over AI tags', () => {
+  it('re-matches by tags when custom_category is set but not locked (AI-derived value)', () => {
     const repository = {
       ...baseRepository,
       custom_category: 'Web应用',
     };
 
-    expect(matchesCategory(repository, aiCategory)).toBe(false);
-    expect(matchesCategory(repository, webCategory)).toBe(true);
+    expect(matchesCategory(repository, aiCategory)).toBe(true);
+    expect(matchesCategory(repository, webCategory)).toBe(false);
   });
 
   it.each(['legacy', 'effective'] as const)(
@@ -240,11 +240,22 @@ describe('resolveCategoryAssignment', () => {
 
   const categories: Category[] = [aiCategory, webCategory, customCategory];
 
-  it('preserves an existing valid custom_category', () => {
+  it('recomputes an unlocked custom_category from tags (AI-derived value)', () => {
     const repository = {
       ...baseRepository,
       custom_category: '我的项目',
       custom_tags: ['我的项目'],
+    };
+    // 未锁定的 custom_category 视为 AI 分析写入的值，重新计算而非直接保留
+    expect(resolveCategoryAssignment(repository, ['AI/机器学习'], categories)).toBe(undefined);
+  });
+
+  it('preserves a locked valid custom_category', () => {
+    const repository = {
+      ...baseRepository,
+      custom_category: '我的项目',
+      custom_tags: ['我的项目'],
+      category_locked: true,
     };
     expect(resolveCategoryAssignment(repository, ['AI/机器学习'], categories)).toBe('我的项目');
   });
@@ -349,7 +360,21 @@ describe('resolveCategoryAssignment metadata fallback for custom categories', ()
     expect(resolveCategoryAssignment(repository, [], [customSkills, aiCategory])).toBe('skills');
   });
 
-  it('preserves an existing valid custom_category despite metadata fallback', () => {
+  it('preserves a locked custom_category despite metadata fallback', () => {
+    const repository = {
+      ...baseRepository,
+      full_name: 'phuryn/pm-skills',
+      name: 'pm-skills',
+      description: 'PM Skills Marketplace',
+      language: '',
+      topics: ['agent-skills'],
+      custom_category: 'Web应用',
+      category_locked: true,
+    };
+    expect(resolveCategoryAssignment(repository, ['AI/机器学习'], [customSkills, aiCategory, webCategory])).toBe('Web应用');
+  });
+
+  it('recomputes an unlocked custom_category via metadata fallback', () => {
     const repository = {
       ...baseRepository,
       full_name: 'phuryn/pm-skills',
@@ -360,7 +385,8 @@ describe('resolveCategoryAssignment metadata fallback for custom categories', ()
       custom_category: 'Web应用',
       category_locked: false,
     };
-    expect(resolveCategoryAssignment(repository, ['AI/机器学习'], [customSkills, aiCategory, webCategory])).toBe('Web应用');
+    // 未锁定的旧值视为 AI 写入，重新按元数据兜底计算
+    expect(resolveCategoryAssignment(repository, ['AI/机器学习'], [customSkills, aiCategory, webCategory])).toBe('skills');
   });
 
   it('preserves explicitly cleared custom_category despite metadata fallback', () => {

--- a/src/utils/categoryUtils.test.ts
+++ b/src/utils/categoryUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Category, Repository } from '../types';
-import { getEffectiveTags, matchesCategory, resolveCategoryAssignment } from './categoryUtils';
+import { getEffectiveTags, matchesCategory, resolveCategoryAssignment, buildCategoryHints } from './categoryUtils';
 
 const aiCategory: Category = {
   id: 'ai',
@@ -245,5 +245,164 @@ describe('resolveCategoryAssignment', () => {
     };
     // "应用" 是默认分类 "Web应用" 的子串，但默认分类仅精确匹配名称
     expect(resolveCategoryAssignment(repository, ['应用'], categories)).toBe(undefined);
+  });
+});
+
+describe('resolveCategoryAssignment metadata fallback for custom categories', () => {
+  const customSkills: Category = {
+    id: 'custom-skills',
+    name: 'skills',
+    icon: '💡',
+    keywords: ['Skills', '技能', 'skill'],
+    isCustom: true,
+  };
+
+  it('assigns skills category via metadata when AI tags miss the custom name', () => {
+    const repository = {
+      ...baseRepository,
+      full_name: 'Leonxlnx/taste-skill',
+      name: 'taste-skill',
+      description: 'Taste-Skill - gives your AI good taste',
+      language: 'JavaScript',
+      topics: ['agent', 'ai', 'skill', 'skills', 'vibecoding'],
+      custom_category: undefined,
+    };
+    // AI 返回通用标签，仅通过 topics 中的 skill/skills 命中自定义分类
+    expect(resolveCategoryAssignment(repository, ['AI/机器学习', '开发工具', '效率工具'], [customSkills, aiCategory])).toBe('skills');
+  });
+
+  it('assigns skills category for pm-skills repo (topics match keywords)', () => {
+    const repository = {
+      ...baseRepository,
+      full_name: 'phuryn/pm-skills',
+      name: 'pm-skills',
+      description: 'PM Skills Marketplace: 100+ agentic skills',
+      language: '',
+      topics: ['agent-skills', 'agentic-skills', 'claude-code-plugins', 'product-management'],
+      custom_category: undefined,
+    };
+    expect(resolveCategoryAssignment(repository, ['开发工具'], [customSkills, aiCategory])).toBe('skills');
+  });
+
+  it('assigns custom category via description even without topics', () => {
+    const repository = {
+      ...baseRepository,
+      full_name: 'acme/skill-pack',
+      name: 'skill-pack',
+      description: '提供 30+ 技能插件库',
+      language: 'TypeScript',
+      topics: [],
+      custom_category: undefined,
+    };
+    expect(resolveCategoryAssignment(repository, [], [customSkills, aiCategory])).toBe('skills');
+  });
+
+  it('preserves an existing valid custom_category despite metadata fallback', () => {
+    const repository = {
+      ...baseRepository,
+      full_name: 'phuryn/pm-skills',
+      name: 'pm-skills',
+      description: 'PM Skills Marketplace',
+      language: '',
+      topics: ['agent-skills'],
+      custom_category: 'Web应用',
+      category_locked: false,
+    };
+    expect(resolveCategoryAssignment(repository, ['AI/机器学习'], [customSkills, aiCategory, webCategory])).toBe('Web应用');
+  });
+
+  it('preserves explicitly cleared custom_category despite metadata fallback', () => {
+    const repository = {
+      ...baseRepository,
+      full_name: 'phuryn/pm-skills',
+      name: 'pm-skills',
+      description: 'PM Skills Marketplace',
+      language: '',
+      topics: ['agent-skills'],
+      custom_category: '',
+    };
+    expect(resolveCategoryAssignment(repository, [], [customSkills, aiCategory])).toBe('');
+  });
+
+  it('keeps default category behavior when no custom metadata matches', () => {
+    const repository = {
+      ...baseRepository,
+      full_name: 'foo/demo-app',
+      name: 'demo-app',
+      description: 'A web demo',
+      language: 'JavaScript',
+      topics: ['web'],
+      custom_category: undefined,
+    };
+    expect(resolveCategoryAssignment(repository, ['Web应用'], [customSkills, aiCategory, webCategory])).toBe(undefined);
+  });
+});
+
+describe('resolveCategoryAssignment with real repositories and other custom categories', () => {
+  // 真实仓库元数据（来自 GitHub API 抓取，离线固化防 flaky）
+  const customDataAnalysis: Category = {
+    id: 'custom-data',
+    name: '数据分析',
+    icon: '📊',
+    keywords: ['data-analysis', '数据分析', 'pandas'],
+    isCustom: true,
+  };
+  const customCli: Category = {
+    id: 'custom-cli',
+    name: '命令行工具',
+    icon: '🖥',
+    keywords: ['cli', '命令行', 'terminal'],
+    isCustom: true,
+  };
+
+  it('classifies pandas-dev/pandas to custom 数据分析 via topics', () => {
+    const pandas = {
+      ...baseRepository,
+      id: 2,
+      full_name: 'pandas-dev/pandas',
+      name: 'pandas',
+      description: 'Flexible and powerful data analysis / manipulation library for Python',
+      language: 'Python',
+      topics: ['alignment', 'data-analysis', 'data-science', 'flexible', 'pandas', 'python'],
+      custom_category: undefined,
+    };
+    expect(resolveCategoryAssignment(pandas, ['AI/机器学习'], [customDataAnalysis, customCli, aiCategory])).toBe('数据分析');
+  });
+
+  it('classifies cli/cli to custom 命令行工具 via topics', () => {
+    const repository = {
+      ...baseRepository,
+      id: 3,
+      full_name: 'cli/cli',
+      name: 'cli',
+      description: 'GitHub official command line tool',
+      language: 'Go',
+      topics: ['cli', 'git', 'github-api-v4', 'golang'],
+      custom_category: undefined,
+    };
+    expect(resolveCategoryAssignment(repository, ['开发工具'], [customCli, customDataAnalysis, aiCategory])).toBe('命令行工具');
+  });
+});
+
+describe('buildCategoryHints', () => {
+  it('builds hint text with keywords', () => {
+    const categories: Category[] = [
+      { id: 'c1', name: 'skills', icon: '💡', keywords: ['Skill', '技能'], isCustom: true },
+      { id: 'c2', name: '数据分析', icon: '📊', keywords: ['pandas'], isCustom: true },
+    ];
+    expect(buildCategoryHints(categories)).toContain('skills');
+    expect(buildCategoryHints(categories)).toContain('技能');
+    expect(buildCategoryHints(categories)).toContain('数据分析');
+  });
+
+  it('returns empty string when no custom categories', () => {
+    expect(buildCategoryHints([aiCategory])).toBe('');
+  });
+
+  it('handles categories without keywords', () => {
+    const categories: Category[] = [
+      { id: 'c1', name: '我的项目', icon: '📁', keywords: [], isCustom: true },
+    ];
+    expect(buildCategoryHints(categories)).toContain('我的项目');
   });
 });

--- a/src/utils/categoryUtils.test.ts
+++ b/src/utils/categoryUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Category, Repository } from '../types';
-import { matchesCategory } from './categoryUtils';
+import { getEffectiveTags, matchesCategory, resolveCategoryAssignment } from './categoryUtils';
 
 const aiCategory: Category = {
   id: 'ai',
@@ -37,6 +37,38 @@ const baseRepository: Repository = {
   ai_tags: ['AI/机器学习'],
 };
 
+describe('getEffectiveTags', () => {
+  it('prioritizes non-empty custom tags', () => {
+    const repository = {
+      ...baseRepository,
+      custom_tags: ['我的项目'],
+      ai_tags: ['AI/机器学习'],
+      topics: ['web'],
+    };
+    expect(getEffectiveTags(repository)).toEqual(['我的项目']);
+  });
+
+  it('falls back to AI tags when custom tags are empty', () => {
+    const repository = {
+      ...baseRepository,
+      custom_tags: [],
+      ai_tags: ['AI/机器学习'],
+      topics: ['web'],
+    };
+    expect(getEffectiveTags(repository)).toEqual(['AI/机器学习']);
+  });
+
+  it('falls back to topics when custom and AI tags are empty', () => {
+    const repository = {
+      ...baseRepository,
+      custom_tags: [],
+      ai_tags: [],
+      topics: ['machine-learning'],
+    };
+    expect(getEffectiveTags(repository)).toEqual(['machine-learning']);
+  });
+});
+
 describe('matchesCategory', () => {
   it('uses AI tags when custom_category is undefined', () => {
     expect(matchesCategory(baseRepository, aiCategory)).toBe(true);
@@ -68,5 +100,150 @@ describe('matchesCategory', () => {
 
     expect(matchesCategory(repository, aiCategory)).toBe(false);
     expect(matchesCategory(repository, webCategory)).toBe(true);
+  });
+
+  it.each(['legacy', 'effective'] as const)(
+    'keeps legacy behavior for AI tags in %s mode when no custom tags',
+    (mode) => {
+      expect(matchesCategory(baseRepository, aiCategory, mode)).toBe(true);
+    }
+  );
+
+  it('does not match in legacy mode when execute effective custom tags do not overlap', () => {
+    const repository = {
+      ...baseRepository,
+      custom_tags: ['我的项目'],
+      ai_tags: ['AI/机器学习'],
+    };
+    expect(matchesCategory(repository, aiCategory, 'legacy')).toBe(true);
+  });
+
+  it('matches via custom tags in effective mode', () => {
+    const repository = {
+      ...baseRepository,
+      custom_tags: ['前端'],
+      ai_tags: ['AI/机器学习'],
+    };
+    const frontendCategory: Category = {
+      id: 'frontend',
+      name: '前端',
+      icon: 'code',
+      keywords: ['前端'],
+    };
+    expect(matchesCategory(repository, frontendCategory, 'effective')).toBe(true);
+    expect(matchesCategory(repository, aiCategory, 'effective')).toBe(false);
+  });
+
+  it('uses custom tags even without AI tags in effective mode', () => {
+    const repository = {
+      ...baseRepository,
+      custom_tags: ['前端'],
+      ai_tags: undefined,
+    };
+    const frontendCategory: Category = {
+      id: 'frontend',
+      name: '前端',
+      icon: 'code',
+      keywords: ['前端'],
+    };
+    expect(matchesCategory(repository, frontendCategory, 'effective')).toBe(true);
+  });
+
+  it('matches a custom category with empty keywords by name in effective mode', () => {
+    const repository = {
+      ...baseRepository,
+      custom_tags: ['我的项目'],
+      ai_tags: ['AI/机器学习'],
+    };
+    const myProjects: Category = {
+      id: 'custom-1',
+      name: '我的项目',
+      icon: '📁',
+      keywords: [],
+      isCustom: true,
+    };
+    expect(matchesCategory(repository, myProjects, 'effective')).toBe(true);
+  });
+
+  it('does not match default categories by name in effective mode', () => {
+    const repository = {
+      ...baseRepository,
+      custom_tags: ['AI'],
+      ai_tags: ['AI/机器学习'],
+    };
+    // 自定义标签只按关键词匹配默认分类，默认分类名不参与匹配
+    expect(matchesCategory(repository, aiCategory, 'effective')).toBe(true);
+    expect(matchesCategory(repository, webCategory, 'effective')).toBe(false);
+  });
+});
+
+describe('resolveCategoryAssignment', () => {
+  const customCategory: Category = {
+    id: 'custom-1',
+    name: '我的项目',
+    icon: '📁',
+    keywords: [],
+    isCustom: true,
+  };
+
+  const categories: Category[] = [aiCategory, webCategory, customCategory];
+
+  it('preserves an existing valid custom_category', () => {
+    const repository = {
+      ...baseRepository,
+      custom_category: '我的项目',
+      custom_tags: ['我的项目'],
+    };
+    expect(resolveCategoryAssignment(repository, ['AI/机器学习'], categories)).toBe('我的项目');
+  });
+
+  it('preserves an explicitly empty custom_category', () => {
+    const repository = {
+      ...baseRepository,
+      custom_category: '',
+    };
+    expect(resolveCategoryAssignment(repository, ['AI/机器学习'], categories)).toBe('');
+  });
+
+  it('does not clear custom_category when locked even without tags', () => {
+    const repository = {
+      ...baseRepository,
+      custom_category: '我的项目',
+      category_locked: true,
+    };
+    expect(resolveCategoryAssignment(repository, [], categories)).toBe('我的项目');
+  });
+
+  it('assigns a custom category when AI tag contains the category name', () => {
+    const repository = {
+      ...baseRepository,
+      custom_category: undefined,
+    };
+    expect(resolveCategoryAssignment(repository, ['我的项目'], categories)).toBe('我的项目');
+  });
+
+  it('assigns a custom category when the category name contains the AI tag', () => {
+    const repository = {
+      ...baseRepository,
+      custom_category: undefined,
+    };
+    expect(resolveCategoryAssignment(repository, ['项目'], categories)).toBe('我的项目');
+  });
+
+  it('returns undefined when AI tags match a default category and no custom assignment exists', () => {
+    const repository = {
+      ...baseRepository,
+      custom_category: undefined,
+    };
+    expect(resolveCategoryAssignment(repository, ['Web应用'], categories)).toBe(undefined);
+  });
+
+  it('does not match by name substring for default categories', () => {
+    const repository = {
+      ...baseRepository,
+      custom_category: undefined,
+    };
+    // "应用" 是默认分类 "Web应用" 的子串，但默认分类仅精确匹配名称
+    expect(resolveCategoryAssignment(repository, ['应用'], categories)).toBe(undefined);
   });
 });

--- a/src/utils/categoryUtils.test.ts
+++ b/src/utils/categoryUtils.test.ts
@@ -67,6 +67,36 @@ describe('getEffectiveTags', () => {
     };
     expect(getEffectiveTags(repository)).toEqual(['machine-learning']);
   });
+
+  it('ignores whitespace-only custom tags and falls back to AI tags', () => {
+    const repository = {
+      ...baseRepository,
+      custom_tags: [' ', '  '],
+      ai_tags: ['AI/机器学习'],
+      topics: ['web'],
+    };
+    expect(getEffectiveTags(repository)).toEqual(['AI/机器学习']);
+  });
+
+  it('ignores whitespace-only AI tags and falls back to topics', () => {
+    const repository = {
+      ...baseRepository,
+      custom_tags: [''],
+      ai_tags: [' ', ''],
+      topics: ['machine-learning'],
+    };
+    expect(getEffectiveTags(repository)).toEqual(['machine-learning']);
+  });
+
+  it('returns empty array when all sources contain only whitespace tags', () => {
+    const repository = {
+      ...baseRepository,
+      custom_tags: ['   '],
+      ai_tags: [' '],
+      topics: [' ', ''],
+    };
+    expect(getEffectiveTags(repository)).toEqual([]);
+  });
 });
 
 describe('matchesCategory', () => {
@@ -108,6 +138,28 @@ describe('matchesCategory', () => {
       expect(matchesCategory(baseRepository, aiCategory, mode)).toBe(true);
     }
   );
+
+  it('does not treat whitespace-only AI tags as a match in legacy mode', () => {
+    const repository = {
+      ...baseRepository,
+      custom_category: undefined,
+      custom_tags: undefined,
+      ai_tags: [' ', '  '],
+      topics: [],
+    };
+    expect(matchesCategory(repository, aiCategory, 'legacy')).toBe(false);
+  });
+
+  it('does not match when ai_tags contain only blanks in effective mode', () => {
+    const repository = {
+      ...baseRepository,
+      custom_category: undefined,
+      custom_tags: [],
+      ai_tags: ['   '],
+      topics: [],
+    };
+    expect(matchesCategory(repository, aiCategory, 'effective')).toBe(false);
+  });
 
   it('does not match in legacy mode when execute effective custom tags do not overlap', () => {
     const repository = {
@@ -410,10 +462,8 @@ describe('buildCategoryHints', () => {
     const categories: Category[] = [
       { id: 'c1', name: 'skills', icon: '💡', keywords: [' ', '  ', 'Skill'], isCustom: true },
     ];
-    const hints = buildCategoryHints(categories);
-    expect(hints).toContain('Skill');
-    expect(hints).not.toContain('（ ,');
-    expect(hints).not.toContain('(no keywords');
+    // 仅保留有效关键词，生成精确的提示文本
+    expect(buildCategoryHints(categories)).toBe('skills（Skill）');
   });
 });
 

--- a/src/utils/categoryUtils.ts
+++ b/src/utils/categoryUtils.ts
@@ -96,6 +96,13 @@ export const computeCustomCategory = (
 };
 
 /**
+ * 归一化分类关键词：去除前后空白并过滤空串，避免空白关键词匹配任意仓库
+ */
+const getCategoryKeywords = (category: Category): string[] => {
+  return (category.keywords || []).map(k => k.trim()).filter(k => k.length > 0);
+};
+
+/**
  * 判断某个标签是否命中分类
  * @param matchCategoryName - 是否参与分类名匹配（effective 模式开启，保证自定义标签等于分类名时也能命中）
  */
@@ -105,7 +112,7 @@ const tagMatchesCategory = (
   matchCategoryName: boolean
 ): boolean => {
   const tagLower = tag.toLowerCase();
-  const keywordMatch = category.keywords.some(keyword =>
+  const keywordMatch = getCategoryKeywords(category).some(keyword =>
     tagLower.includes(keyword.toLowerCase()) ||
     keyword.toLowerCase().includes(tagLower)
   );
@@ -148,7 +155,7 @@ export const matchesCategory = (
     repo.ai_summary || ''
   ].join(' ').toLowerCase();
 
-  return category.keywords.some(keyword =>
+  return getCategoryKeywords(category).some(keyword =>
     repoText.includes(keyword.toLowerCase())
   );
 };
@@ -177,7 +184,7 @@ export const buildCategoryHints = (customCategories: Category[]): string => {
   const lines = customCategories
     .filter(category => category.id !== 'all' && category.isCustom)
     .map(category => {
-      const keywords = category.keywords.filter(k => k && k.trim());
+      const keywords = getCategoryKeywords(category);
       const kwText = keywords.length > 0 ? keywords.join(',') : `(no keywords, match by name: ${category.name})`;
       return `${category.name}（${kwText}）`;
     });
@@ -194,10 +201,13 @@ const matchCustomCategoryByMetadata = (
 ): Category | undefined => {
   if (customCategories.length === 0) return undefined;
   const repoText = getRepoText(repository);
-  return customCategories.find(category =>
-    category.keywords.some(keyword => repoText.includes(keyword.toLowerCase())) ||
-    (category.keywords.length === 0 && repoText.includes(category.name.toLowerCase()))
-  );
+  return customCategories.find(category => {
+    const keywords = getCategoryKeywords(category);
+    const keywordMatch = keywords.length > 0 && keywords.some(keyword => repoText.includes(keyword.toLowerCase()));
+    // 无有效关键词时才回退到分类名包含匹配，并保留现有语义
+    const nameFallback = keywordMatch === false && keywords.length === 0 && repoText.includes(category.name.toLowerCase());
+    return keywordMatch || nameFallback;
+  });
 };
 
 export const resolveCategoryAssignment = (
@@ -236,27 +246,29 @@ export const resolveCategoryAssignment = (
       : undefined;
   }
 
-  const matchCustomCategory = (categories: Category[]) => categories.find(category =>
-    normalizedTags.some(tag =>
+  const matchCustomCategory = (categories: Category[]) => categories.find(category => {
+    const keywords = getCategoryKeywords(category);
+    return normalizedTags.some(tag =>
       category.name.toLowerCase() === tag.toLowerCase() ||
       category.name.toLowerCase().includes(tag.toLowerCase()) ||
       tag.toLowerCase().includes(category.name.toLowerCase()) ||
-      category.keywords.some(keyword =>
+      keywords.some(keyword =>
         tag.toLowerCase().includes(keyword.toLowerCase()) ||
         keyword.toLowerCase().includes(tag.toLowerCase())
       )
-    )
-  );
+    );
+  });
 
-  const matchDefaultCategory = (categories: Category[]) => categories.find(category =>
-    normalizedTags.some(tag =>
+  const matchDefaultCategory = (categories: Category[]) => categories.find(category => {
+    const keywords = getCategoryKeywords(category);
+    return normalizedTags.some(tag =>
       category.name.toLowerCase() === tag.toLowerCase() ||
-      category.keywords.some(keyword =>
+      keywords.some(keyword =>
         tag.toLowerCase().includes(keyword.toLowerCase()) ||
         keyword.toLowerCase().includes(tag.toLowerCase())
       )
-    )
-  );
+    );
+  });
 
   const customMatch = matchCustomCategory(customCategories);
   if (customMatch) return customMatch.name;

--- a/src/utils/categoryUtils.ts
+++ b/src/utils/categoryUtils.ts
@@ -1,4 +1,19 @@
-import { Category, Repository } from '../types';
+import { Category, CategoryMatchMode, Repository } from '../types';
+
+/**
+ * 获取用于分类匹配的有效标签
+ * 优先级与卡片展示一致：自定义标签 > AI标签 > Topics。
+ * 自定义标签显式清空（空数组）时不视为命中，回落 AI 标签/ Topics。
+ */
+export const getEffectiveTags = (repo: Repository): string[] => {
+  if (repo.custom_tags && repo.custom_tags.length > 0) {
+    return repo.custom_tags;
+  }
+  if (repo.ai_tags && repo.ai_tags.length > 0) {
+    return repo.ai_tags;
+  }
+  return repo.topics || [];
+};
 
 /**
  * 获取AI推断的分类
@@ -80,7 +95,37 @@ export const computeCustomCategory = (
   return categoryName;
 };
 
-export const matchesCategory = (repo: Repository, category: Category): boolean => {
+/**
+ * 判断某个标签是否命中分类
+ * @param matchCategoryName - 是否参与分类名匹配（effective 模式开启，保证自定义标签等于分类名时也能命中）
+ */
+const tagMatchesCategory = (
+  tag: string,
+  category: Category,
+  matchCategoryName: boolean
+): boolean => {
+  const tagLower = tag.toLowerCase();
+  const keywordMatch = category.keywords.some(keyword =>
+    tagLower.includes(keyword.toLowerCase()) ||
+    keyword.toLowerCase().includes(tagLower)
+  );
+  if (keywordMatch) return true;
+
+  if (matchCategoryName) {
+    const nameLower = category.name.toLowerCase();
+    return nameLower === tagLower ||
+      nameLower.includes(tagLower) ||
+      tagLower.includes(nameLower);
+  }
+
+  return false;
+};
+
+export const matchesCategory = (
+  repo: Repository,
+  category: Category,
+  mode: CategoryMatchMode = 'legacy'
+): boolean => {
   if (category.id === 'all') return true;
 
   if (repo.custom_category != null) {
@@ -90,13 +135,9 @@ export const matchesCategory = (repo: Repository, category: Category): boolean =
     return repo.custom_category === category.name;
   }
 
-  if (repo.ai_tags && repo.ai_tags.length > 0) {
-    return repo.ai_tags.some(tag =>
-      category.keywords.some(keyword =>
-        tag.toLowerCase().includes(keyword.toLowerCase()) ||
-        keyword.toLowerCase().includes(tag.toLowerCase())
-      )
-    );
+  const tags = mode === 'effective' ? getEffectiveTags(repo) : (repo.ai_tags || []);
+  if (tags.length > 0) {
+    return tags.some(tag => tagMatchesCategory(tag, category, mode === 'effective' && !!category.isCustom));
   }
 
   const repoText = [
@@ -128,6 +169,11 @@ export const resolveCategoryAssignment = (
     return repository.custom_category;
   }
 
+  // 保留用户已手动设置的分类归属（含显式清空），不被 AI 分析覆盖
+  if (repository.custom_category === '' || isValidCategory(repository.custom_category)) {
+    return repository.custom_category;
+  }
+
   const normalizedTags = Array.isArray(aiTags) ? aiTags.filter(Boolean) : [];
   if (normalizedTags.length === 0) {
     // 如果没有AI标签，但分类被锁定且自定义分类有效，保持当前分类
@@ -139,7 +185,19 @@ export const resolveCategoryAssignment = (
   const customCategories = allCategories.filter(category => category.id !== 'all' && category.isCustom);
   const defaultCategories = allCategories.filter(category => category.id !== 'all' && !category.isCustom);
 
-  const matchCategory = (categories: Category[]) => categories.find(category =>
+  const matchCustomCategory = (categories: Category[]) => categories.find(category =>
+    normalizedTags.some(tag =>
+      category.name.toLowerCase() === tag.toLowerCase() ||
+      category.name.toLowerCase().includes(tag.toLowerCase()) ||
+      tag.toLowerCase().includes(category.name.toLowerCase()) ||
+      category.keywords.some(keyword =>
+        tag.toLowerCase().includes(keyword.toLowerCase()) ||
+        keyword.toLowerCase().includes(tag.toLowerCase())
+      )
+    )
+  );
+
+  const matchDefaultCategory = (categories: Category[]) => categories.find(category =>
     normalizedTags.some(tag =>
       category.name.toLowerCase() === tag.toLowerCase() ||
       category.keywords.some(keyword =>
@@ -149,10 +207,10 @@ export const resolveCategoryAssignment = (
     )
   );
 
-  const customMatch = matchCategory(customCategories);
+  const customMatch = matchCustomCategory(customCategories);
   if (customMatch) return customMatch.name;
 
-  const defaultMatch = matchCategory(defaultCategories);
+  const defaultMatch = matchDefaultCategory(defaultCategories);
   if (defaultMatch) return undefined;
 
   // 如果没有匹配到任何分类，但分类被锁定且自定义分类有效，保持当前分类

--- a/src/utils/categoryUtils.ts
+++ b/src/utils/categoryUtils.ts
@@ -1,18 +1,27 @@
 import { Category, CategoryMatchMode, Repository } from '../types';
 
 /**
+ * 归一化标签数组：去除前后空白并过滤空白项，避免空白标签匹配任意分类
+ */
+const normalizeTags = (tags: string[] | undefined): string[] => {
+  return (tags || []).map(tag => tag.trim()).filter(tag => tag.length > 0);
+};
+
+/**
  * 获取用于分类匹配的有效标签
  * 优先级与卡片展示一致：自定义标签 > AI标签 > Topics。
  * 自定义标签显式清空（空数组）时不视为命中，回落 AI 标签/ Topics。
  */
 export const getEffectiveTags = (repo: Repository): string[] => {
-  if (repo.custom_tags && repo.custom_tags.length > 0) {
-    return repo.custom_tags;
+  const customTags = normalizeTags(repo.custom_tags);
+  if (customTags.length > 0) {
+    return customTags;
   }
-  if (repo.ai_tags && repo.ai_tags.length > 0) {
-    return repo.ai_tags;
+  const aiTags = normalizeTags(repo.ai_tags);
+  if (aiTags.length > 0) {
+    return aiTags;
   }
-  return repo.topics || [];
+  return normalizeTags(repo.topics);
 };
 
 /**
@@ -142,7 +151,7 @@ export const matchesCategory = (
     return repo.custom_category === category.name;
   }
 
-  const tags = mode === 'effective' ? getEffectiveTags(repo) : (repo.ai_tags || []);
+  const tags = mode === 'effective' ? getEffectiveTags(repo) : normalizeTags(repo.ai_tags);
   if (tags.length > 0) {
     return tags.some(tag => tagMatchesCategory(tag, category, mode === 'effective' && !!category.isCustom));
   }
@@ -231,7 +240,7 @@ export const resolveCategoryAssignment = (
     return repository.custom_category;
   }
 
-  const normalizedTags = Array.isArray(aiTags) ? aiTags.filter(Boolean) : [];
+  const normalizedTags = Array.isArray(aiTags) ? normalizeTags(aiTags) : [];
 
   const customCategories = allCategories.filter(category => category.id !== 'all' && category.isCustom);
   const defaultCategories = allCategories.filter(category => category.id !== 'all' && !category.isCustom);

--- a/src/utils/categoryUtils.ts
+++ b/src/utils/categoryUtils.ts
@@ -144,10 +144,12 @@ export const matchesCategory = (
 ): boolean => {
   if (category.id === 'all') return true;
 
-  if (repo.custom_category != null) {
-    if (repo.custom_category === '') {
-      return false;
-    }
+  // 仅锁定的手动分类（或显式清空）参与精确匹配；
+  // 未锁定的 custom_category 是 AI 分析写入的结果，应按标签重新匹配
+  if (repo.custom_category === '') {
+    return false;
+  }
+  if (repo.category_locked && repo.custom_category != null) {
     return repo.custom_category === category.name;
   }
 
@@ -235,8 +237,8 @@ export const resolveCategoryAssignment = (
     return repository.custom_category;
   }
 
-  // 保留用户已手动设置的分类归属（含显式清空），不被 AI 分析覆盖
-  if (repository.custom_category === '' || isValidCategory(repository.custom_category)) {
+  // 保留用户显式清空的分类归属（''），不被 AI 分析覆盖
+  if (repository.custom_category === '') {
     return repository.custom_category;
   }
 

--- a/src/utils/categoryUtils.ts
+++ b/src/utils/categoryUtils.ts
@@ -153,6 +153,53 @@ export const matchesCategory = (
   );
 };
 
+/**
+ * 聚合仓库元数据文本，用于自定义分类的 metadata 兜底匹配
+ * 与 matchesCategory 的 repoText 兜底一致，可命中无 AI tags 或 tags 未覆盖的场景
+ */
+const getRepoText = (repo: Pick<Repository, 'name' | 'description' | 'language' | 'topics' | 'ai_summary' | 'full_name'>): string => {
+  return [
+    repo.name,
+    repo.full_name,
+    repo.description || '',
+    repo.language || '',
+    ...(repo.topics || []),
+    repo.ai_summary || '',
+  ].join(' ').toLowerCase();
+};
+
+/**
+ * 构建用于 AI 提示词的自定义分类关键词提示行
+ * 格式形如：`skills（Skills,技能）\n命令行工具（cli,CLI）`
+ * 让模型在仓库无 topics 时也能识别自定义分类
+ */
+export const buildCategoryHints = (customCategories: Category[]): string => {
+  const lines = customCategories
+    .filter(category => category.id !== 'all' && category.isCustom)
+    .map(category => {
+      const keywords = category.keywords.filter(k => k && k.trim());
+      const kwText = keywords.length > 0 ? keywords.join(',') : `(no keywords, match by name: ${category.name})`;
+      return `${category.name}（${kwText}）`;
+    });
+  return lines.join('\n');
+};
+
+/**
+ * 按仓库元数据（名称/描述/语言/topics/AI摘要）匹配自定义分类
+ * 仅针对自定义分类，关键词命中即返回；关键词为空时回退到分类名包含匹配
+ */
+const matchCustomCategoryByMetadata = (
+  customCategories: Category[],
+  repository: Pick<Repository, 'name' | 'description' | 'language' | 'topics' | 'ai_summary' | 'full_name'>
+): Category | undefined => {
+  if (customCategories.length === 0) return undefined;
+  const repoText = getRepoText(repository);
+  return customCategories.find(category =>
+    category.keywords.some(keyword => repoText.includes(keyword.toLowerCase())) ||
+    (category.keywords.length === 0 && repoText.includes(category.name.toLowerCase()))
+  );
+};
+
 export const resolveCategoryAssignment = (
   repository: Repository,
   aiTags: string[] | undefined,
@@ -175,15 +222,19 @@ export const resolveCategoryAssignment = (
   }
 
   const normalizedTags = Array.isArray(aiTags) ? aiTags.filter(Boolean) : [];
+
+  const customCategories = allCategories.filter(category => category.id !== 'all' && category.isCustom);
+  const defaultCategories = allCategories.filter(category => category.id !== 'all' && !category.isCustom);
+
+  // 无 AI 标签时：自定义分类按 metadata 兜底，仍可归类
   if (normalizedTags.length === 0) {
+    const customMetaMatch = matchCustomCategoryByMetadata(customCategories, repository);
+    if (customMetaMatch) return customMetaMatch.name;
     // 如果没有AI标签，但分类被锁定且自定义分类有效，保持当前分类
     return (repository.category_locked && isValidCategory(repository.custom_category))
       ? repository.custom_category
       : undefined;
   }
-
-  const customCategories = allCategories.filter(category => category.id !== 'all' && category.isCustom);
-  const defaultCategories = allCategories.filter(category => category.id !== 'all' && !category.isCustom);
 
   const matchCustomCategory = (categories: Category[]) => categories.find(category =>
     normalizedTags.some(tag =>
@@ -209,6 +260,11 @@ export const resolveCategoryAssignment = (
 
   const customMatch = matchCustomCategory(customCategories);
   if (customMatch) return customMatch.name;
+
+  // metadata 兜底：AI 标签未直接命中自定义分类时，改用仓库元数据匹配自定义分类
+  // （自定义分类优先级高于默认分类）
+  const customMetaMatch = matchCustomCategoryByMetadata(customCategories, repository);
+  if (customMetaMatch) return customMetaMatch.name;
 
   const defaultMatch = matchDefaultCategory(defaultCategories);
   if (defaultMatch) return undefined;


### PR DESCRIPTION
Closes #262

## 背景

`matchesCategory()` 分类匹配只读取 `ai_tags`，导致分类归属与卡片实际展示的标签不一致：
- 用户手动编辑的 `custom_tags` 不参与分类匹配
- 自定义分类在 AI 分析后会被内置分类匹配结果静默清除（`resolveCategoryAssignment` 返回 `undefined`）
- 无关键词的自定义分类在无 Topics 的仓库上很难被命中

## 变更

### 1. 新增 `categoryMatchMode` 设置（默认 `effective`）
- `effective`（推荐，默认）：按卡片展示的标签归类 `custom_tags > ai_tags > topics`
- `legacy`：保留旧版仅按 `ai_tags` 归类
- 设置面板「仓库归类方式」单选，含解释文案

### 2. `matchesCategory` 支持模式参数
- 新增 `getEffectiveTags()` 与 `tagMatchesCategory()` 辅助函数
- `effective` 模式下自定义分类额外支持分类名互相包含匹配（解决无关键词自定义分类无法命中）

### 3. `resolveCategoryAssignment` 保留手动归属
- 已有的有效 `custom_category`（含显式清空）不再被 AI 分析覆盖
- 自定义分类名称按互相包含匹配，内置分类保持精确匹配

### 4. 自定义分类 metadata 兜底归类（新）
- 新增 `getRepoText()` 聚合仓库元数据（名称 / 描述 / 语言 / topics / AI 摘要）
- 新增 `buildCategoryHints()`：生成自定义分类「名称 + 关键词」提示，注入 AI 分析提示词（中英文默认提示与 `{CATEGORIES_HINT}` 占位符），让模型在仓库无 Topics 时也能识别自定义分类
- `resolveCategoryAssignment` 在 AI 标签为空或未命中自定义分类时，按仓库元数据关键词兜底匹配自定义分类（空关键词分类回退到分类名包含匹配）
- `aiAnalysisHelper` / `aiAnalysisOptimizer`（单仓、批量、Discovery 流水线）均透传 hints；提示词注入处统一经 `sanitizeForPrompt` 消毒

### 5. 调用方
- 仓库列表过滤、侧边栏分类计数均读取配置的匹配模式

## 测试
- `categoryUtils.test.ts` 扩展到 26 个用例（有效标签优先级、自定义分类名匹配、归属保留、metadata 兜底、建 hints 等）
- `vitest run` 187 个全部通过；`tsc --noEmit` 通过；本次改动文件 `eslint` 通过


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added category matching settings with Effective and Legacy modes.
  * Effective matching prioritizes custom tags, AI tags, and topics, and supports custom category names.
  * Category counts and repository filtering now reflect the selected matching mode.
  * AI analysis now uses custom category hints for more relevant classification.
  * Custom tags are now included in repository search.
  * User-defined category assignments and explicit clears are preserved.
* **Bug Fixes**
  * Improved category assignment and persisted settings handling.
  * Invalid or missing matching-mode settings now default to Effective mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->