### PR TITLE
feat(release): 增量刷新已存在 Release 资产并保留 is_read (#263)

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -164,7 +164,12 @@ jobs:
     - name: Install system dependencies (Linux)
       if: matrix.os == 'ubuntu-latest'
       run: |
-        sudo apt-get update
+        # Microsoft apt sources on GitHub runners occasionally return 403 and break
+        # apt-get update for unrelated electron deps. Disable them before update.
+        sudo rm -f /etc/apt/sources.list.d/azure-cli.list \
+          /etc/apt/sources.list.d/microsoft-prod.list \
+          /etc/apt/sources.list.d/microsoft-prod.list.save 2>/dev/null || true
+        sudo apt-get update -o Acquire::Retries=3
         sudo apt-get install -y libnss3-dev libatk-bridge2.0-dev libdrm2 libxcomposite1 libxdamage1 libxrandr2 libgbm1 libxss1 libasound2-dev
         
     - name: Install Electron dependencies
@@ -410,8 +415,11 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       shell: bash
       run: |
-        # Install xvfb for headless testing
-        sudo apt-get update
+        # Install xvfb for headless testing (same MS apt 403 guard as above)
+        sudo rm -f /etc/apt/sources.list.d/azure-cli.list \
+          /etc/apt/sources.list.d/microsoft-prod.list \
+          /etc/apt/sources.list.d/microsoft-prod.list.save 2>/dev/null || true
+        sudo apt-get update -o Acquire::Retries=3
         sudo apt-get install -y xvfb
         
         # Test if the app can start (will exit quickly but should not crash)

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -55,7 +55,9 @@ export function initializeSchema(db: Database.Database): void {
       repo_name TEXT NOT NULL,
       prerelease INTEGER DEFAULT 0,
       draft INTEGER DEFAULT 0,
-      is_read INTEGER DEFAULT 0
+      is_read INTEGER DEFAULT 0,
+      zipball_url TEXT,
+      tarball_url TEXT
     );
 
     CREATE TABLE IF NOT EXISTS categories (

--- a/server/src/routes/releases.ts
+++ b/server/src/routes/releases.ts
@@ -94,19 +94,61 @@ router.put('/api/releases', (req, res) => {
       }
     }
 
-    const stmt = db.prepare(`
-      INSERT OR REPLACE INTO releases (
+    const stmtPreserveIsRead = db.prepare(`
+      INSERT INTO releases (
         id, tag_name, name, body, html_url, published_at,
         prerelease, draft, is_read, assets,
         repo_id, repo_full_name, repo_name,
         zipball_url, tarball_url
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        tag_name = excluded.tag_name,
+        name = excluded.name,
+        body = excluded.body,
+        html_url = excluded.html_url,
+        published_at = excluded.published_at,
+        prerelease = excluded.prerelease,
+        draft = excluded.draft,
+        is_read = releases.is_read,
+        assets = excluded.assets,
+        repo_id = excluded.repo_id,
+        repo_full_name = excluded.repo_full_name,
+        repo_name = excluded.repo_name,
+        zipball_url = excluded.zipball_url,
+        tarball_url = excluded.tarball_url
+    `);
+    const stmtOverwriteIsRead = db.prepare(`
+      INSERT INTO releases (
+        id, tag_name, name, body, html_url, published_at,
+        prerelease, draft, is_read, assets,
+        repo_id, repo_full_name, repo_name,
+        zipball_url, tarball_url
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(id) DO UPDATE SET
+        tag_name = excluded.tag_name,
+        name = excluded.name,
+        body = excluded.body,
+        html_url = excluded.html_url,
+        published_at = excluded.published_at,
+        prerelease = excluded.prerelease,
+        draft = excluded.draft,
+        is_read = excluded.is_read,
+        assets = excluded.assets,
+        repo_id = excluded.repo_id,
+        repo_full_name = excluded.repo_full_name,
+        repo_name = excluded.repo_name,
+        zipball_url = excluded.zipball_url,
+        tarball_url = excluded.tarball_url
     `);
 
     const upsert = db.transaction(() => {
       let count = 0;
       for (const release of releases) {
         const repository = release.repository as { id?: number; full_name?: string; name?: string } | undefined;
+        // 合并 UPSERT：仅更新数据列，保留库中已有的 is_read 已读状态，避免整行替换把已读清空。
+        // 仅当请求显式携带 is_read（如导入/同步完整快照）时才覆盖已读状态。
+        const hasExplicitIsRead = typeof release.is_read === 'boolean';
+        const stmt = hasExplicitIsRead ? stmtOverwriteIsRead : stmtPreserveIsRead;
         stmt.run(
           release.id,
           release.tag_name ?? null,
@@ -116,7 +158,7 @@ router.put('/api/releases', (req, res) => {
           release.published_at ?? null,
           release.prerelease ? 1 : 0,
           release.draft ? 1 : 0,
-          release.is_read ? 1 : 0,
+          hasExplicitIsRead ? (release.is_read ? 1 : 0) : 0,
           JSON.stringify(release.assets ?? []),
           repository?.id ?? release.repo_id ?? null,
           repository?.full_name ?? release.repo_full_name ?? null,

--- a/server/src/routes/sync.ts
+++ b/server/src/routes/sync.ts
@@ -120,14 +120,14 @@ router.post('/api/sync/import', (req, res) => {
         const repoId = r.repo_id ?? repository?.id;
         const repoFullName = r.repo_full_name ?? repository?.full_name;
         const repoName = r.repo_name ?? repository?.name;
-        if (typeof id !== 'number' || !Number.isFinite(id) || id <= 0) {
+        if (typeof id !== 'number' || !Number.isInteger(id) || id <= 0) {
           res.status(400).json({
             error: 'Each release must have a valid positive integer id',
             code: 'RELEASE_ID_REQUIRED',
           });
           return;
         }
-        if (typeof repoId !== 'number' || !Number.isFinite(repoId) || repoId <= 0) {
+        if (typeof repoId !== 'number' || !Number.isInteger(repoId) || repoId <= 0) {
           res.status(400).json({
             error: 'Each release must have a valid positive integer repo_id',
             code: 'RELEASE_REPO_ID_REQUIRED',
@@ -224,8 +224,9 @@ router.post('/api/sync/import', (req, res) => {
           INSERT INTO releases (
             id, tag_name, name, body, html_url, published_at,
             prerelease, draft, is_read, assets,
-            repo_id, repo_full_name, repo_name
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            repo_id, repo_full_name, repo_name,
+            zipball_url, tarball_url
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
           ON CONFLICT(id) DO UPDATE SET
             tag_name = excluded.tag_name,
             name = excluded.name,
@@ -238,14 +239,17 @@ router.post('/api/sync/import', (req, res) => {
             assets = excluded.assets,
             repo_id = excluded.repo_id,
             repo_full_name = excluded.repo_full_name,
-            repo_name = excluded.repo_name
+            repo_name = excluded.repo_name,
+            zipball_url = excluded.zipball_url,
+            tarball_url = excluded.tarball_url
         `);
         const relStmtOverwriteIsRead = db.prepare(`
           INSERT INTO releases (
             id, tag_name, name, body, html_url, published_at,
             prerelease, draft, is_read, assets,
-            repo_id, repo_full_name, repo_name
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            repo_id, repo_full_name, repo_name,
+            zipball_url, tarball_url
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
           ON CONFLICT(id) DO UPDATE SET
             tag_name = excluded.tag_name,
             name = excluded.name,
@@ -258,7 +262,9 @@ router.post('/api/sync/import', (req, res) => {
             assets = excluded.assets,
             repo_id = excluded.repo_id,
             repo_full_name = excluded.repo_full_name,
-            repo_name = excluded.repo_name
+            repo_name = excluded.repo_name,
+            zipball_url = excluded.zipball_url,
+            tarball_url = excluded.tarball_url
         `);
         for (const r of rels) {
           const repository = r.repository as { id?: number; full_name?: string; name?: string } | undefined;
@@ -274,7 +280,9 @@ router.post('/api/sync/import', (req, res) => {
             typeof r.assets === 'string' ? r.assets : JSON.stringify(r.assets ?? []),
             r.repo_id ?? repository?.id ?? null,
             r.repo_full_name ?? repository?.full_name ?? null,
-            r.repo_name ?? repository?.name ?? null
+            r.repo_name ?? repository?.name ?? null,
+            r.zipball_url ?? null,
+            r.tarball_url ?? null
           );
         }
         counts.releases = rels.length;

--- a/server/src/routes/sync.ts
+++ b/server/src/routes/sync.ts
@@ -110,6 +110,47 @@ router.post('/api/sync/import', (req, res) => {
       return;
     }
 
+    // 导入前校验 releases：id / repo_id / repo_full_name / repo_name 均非空，
+    // 避免 NOT NULL 列绑 null 导致整笔事务 500。
+    const importRels = data.releases as Record<string, unknown>[] | undefined;
+    if (Array.isArray(importRels)) {
+      for (const r of importRels) {
+        const repository = r.repository as { id?: unknown; full_name?: unknown; name?: unknown } | undefined;
+        const id = r.id;
+        const repoId = r.repo_id ?? repository?.id;
+        const repoFullName = r.repo_full_name ?? repository?.full_name;
+        const repoName = r.repo_name ?? repository?.name;
+        if (typeof id !== 'number' || !Number.isFinite(id) || id <= 0) {
+          res.status(400).json({
+            error: 'Each release must have a valid positive integer id',
+            code: 'RELEASE_ID_REQUIRED',
+          });
+          return;
+        }
+        if (typeof repoId !== 'number' || !Number.isFinite(repoId) || repoId <= 0) {
+          res.status(400).json({
+            error: 'Each release must have a valid positive integer repo_id',
+            code: 'RELEASE_REPO_ID_REQUIRED',
+          });
+          return;
+        }
+        if (typeof repoFullName !== 'string' || !repoFullName.trim()) {
+          res.status(400).json({
+            error: 'Each release must have a non-empty repo_full_name',
+            code: 'RELEASE_REPO_FULL_NAME_REQUIRED',
+          });
+          return;
+        }
+        if (typeof repoName !== 'string' || !repoName.trim()) {
+          res.status(400).json({
+            error: 'Each release must have a non-empty repo_name',
+            code: 'RELEASE_REPO_NAME_REQUIRED',
+          });
+          return;
+        }
+      }
+    }
+
     const importAll = db.transaction(() => {
       // Repositories
       const repos = data.repositories as Record<string, unknown>[] | undefined;
@@ -220,6 +261,7 @@ router.post('/api/sync/import', (req, res) => {
             repo_name = excluded.repo_name
         `);
         for (const r of rels) {
+          const repository = r.repository as { id?: number; full_name?: string; name?: string } | undefined;
           const hasExplicitIsRead = typeof r.is_read === 'boolean';
           const relStmt = hasExplicitIsRead ? relStmtOverwriteIsRead : relStmtPreserveIsRead;
           relStmt.run(
@@ -230,7 +272,9 @@ router.post('/api/sync/import', (req, res) => {
             // 避免新导入行写入 NULL 导致 unread 过滤（is_read = 0）漏行。
             hasExplicitIsRead ? (r.is_read ? 1 : 0) : 0,
             typeof r.assets === 'string' ? r.assets : JSON.stringify(r.assets ?? []),
-            r.repo_id ?? null, r.repo_full_name ?? null, r.repo_name ?? null
+            r.repo_id ?? repository?.id ?? null,
+            r.repo_full_name ?? repository?.full_name ?? null,
+            r.repo_name ?? repository?.name ?? null
           );
         }
         counts.releases = rels.length;

--- a/server/src/routes/sync.ts
+++ b/server/src/routes/sync.ts
@@ -177,11 +177,24 @@ router.post('/api/sync/import', (req, res) => {
       const rels = data.releases as Record<string, unknown>[] | undefined;
       if (Array.isArray(rels) && rels.length > 0) {
         const relStmt = db.prepare(`
-          INSERT OR REPLACE INTO releases (
+          INSERT INTO releases (
             id, tag_name, name, body, html_url, published_at,
             prerelease, draft, is_read, assets,
             repo_id, repo_full_name, repo_name
           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            tag_name = excluded.tag_name,
+            name = excluded.name,
+            body = excluded.body,
+            html_url = excluded.html_url,
+            published_at = excluded.published_at,
+            prerelease = excluded.prerelease,
+            draft = excluded.draft,
+            is_read = CASE WHEN excluded.is_read IS NOT NULL THEN excluded.is_read ELSE releases.is_read END,
+            assets = excluded.assets,
+            repo_id = excluded.repo_id,
+            repo_full_name = excluded.repo_full_name,
+            repo_name = excluded.repo_name
         `);
         for (const r of rels) {
           relStmt.run(

--- a/server/src/routes/sync.ts
+++ b/server/src/routes/sync.ts
@@ -174,9 +174,12 @@ router.post('/api/sync/import', (req, res) => {
       }
 
       // Releases
+      // 合并 UPSERT：冲突时仅更新数据列，保留库中已有的 is_read 已读状态。
+      // 仅当快照显式携带 is_read 布尔值时才覆盖已读状态（stmtOverwriteIsRead）；
+      // 否则走保留分支，避免导入/回退把已读状态误清空。
       const rels = data.releases as Record<string, unknown>[] | undefined;
       if (Array.isArray(rels) && rels.length > 0) {
-        const relStmt = db.prepare(`
+        const relStmtPreserveIsRead = db.prepare(`
           INSERT INTO releases (
             id, tag_name, name, body, html_url, published_at,
             prerelease, draft, is_read, assets,
@@ -190,22 +193,42 @@ router.post('/api/sync/import', (req, res) => {
             published_at = excluded.published_at,
             prerelease = excluded.prerelease,
             draft = excluded.draft,
-            is_read = CASE WHEN excluded.is_read IS NOT NULL THEN excluded.is_read ELSE releases.is_read END,
+            is_read = releases.is_read,
+            assets = excluded.assets,
+            repo_id = excluded.repo_id,
+            repo_full_name = excluded.repo_full_name,
+            repo_name = excluded.repo_name
+        `);
+        const relStmtOverwriteIsRead = db.prepare(`
+          INSERT INTO releases (
+            id, tag_name, name, body, html_url, published_at,
+            prerelease, draft, is_read, assets,
+            repo_id, repo_full_name, repo_name
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ON CONFLICT(id) DO UPDATE SET
+            tag_name = excluded.tag_name,
+            name = excluded.name,
+            body = excluded.body,
+            html_url = excluded.html_url,
+            published_at = excluded.published_at,
+            prerelease = excluded.prerelease,
+            draft = excluded.draft,
+            is_read = excluded.is_read,
             assets = excluded.assets,
             repo_id = excluded.repo_id,
             repo_full_name = excluded.repo_full_name,
             repo_name = excluded.repo_name
         `);
         for (const r of rels) {
-          // 仅当快照显式携带 is_read 布尔值时才覆盖已读状态；否则传 NULL，
-          // 由 UPSERT 的 CASE WHEN excluded.is_read IS NOT NULL 走保留分支，
-          // 避免导入/回退时把库中已有的已读状态误清空。
           const hasExplicitIsRead = typeof r.is_read === 'boolean';
+          const relStmt = hasExplicitIsRead ? relStmtOverwriteIsRead : relStmtPreserveIsRead;
           relStmt.run(
             r.id, r.tag_name ?? null, r.name ?? null, r.body ?? null,
             r.html_url ?? null, r.published_at ?? null,
             r.prerelease ? 1 : 0, r.draft ? 1 : 0,
-            hasExplicitIsRead ? (r.is_read ? 1 : 0) : null,
+            // 保留分支下仍落 0（非空），与 releases 表 is_read DEFAULT 0 语义一致，
+            // 避免新导入行写入 NULL 导致 unread 过滤（is_read = 0）漏行。
+            hasExplicitIsRead ? (r.is_read ? 1 : 0) : 0,
             typeof r.assets === 'string' ? r.assets : JSON.stringify(r.assets ?? []),
             r.repo_id ?? null, r.repo_full_name ?? null, r.repo_name ?? null
           );

--- a/server/src/routes/sync.ts
+++ b/server/src/routes/sync.ts
@@ -197,10 +197,15 @@ router.post('/api/sync/import', (req, res) => {
             repo_name = excluded.repo_name
         `);
         for (const r of rels) {
+          // 仅当快照显式携带 is_read 布尔值时才覆盖已读状态；否则传 NULL，
+          // 由 UPSERT 的 CASE WHEN excluded.is_read IS NOT NULL 走保留分支，
+          // 避免导入/回退时把库中已有的已读状态误清空。
+          const hasExplicitIsRead = typeof r.is_read === 'boolean';
           relStmt.run(
             r.id, r.tag_name ?? null, r.name ?? null, r.body ?? null,
             r.html_url ?? null, r.published_at ?? null,
-            r.prerelease ? 1 : 0, r.draft ? 1 : 0, r.is_read ? 1 : 0,
+            r.prerelease ? 1 : 0, r.draft ? 1 : 0,
+            hasExplicitIsRead ? (r.is_read ? 1 : 0) : null,
             typeof r.assets === 'string' ? r.assets : JSON.stringify(r.assets ?? []),
             r.repo_id ?? null, r.repo_full_name ?? null, r.repo_name ?? null
           );

--- a/server/tests/routes/releasesUpsert.test.ts
+++ b/server/tests/routes/releasesUpsert.test.ts
@@ -1,0 +1,108 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it, vi } from 'vitest';
+
+const getDbMock = vi.fn();
+
+vi.mock('../../src/db/connection.js', () => ({
+  getDb: () => getDbMock(),
+}));
+
+const { default: releasesRouter } = await import('../../src/routes/releases.js');
+
+const createTestApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use(releasesRouter);
+  return app;
+};
+
+/**
+ * Mock DB 只记录 prepare 收到的 SQL 与每次 run 的参数，便于断言合并 UPSERT 的行为。
+ */
+function captureStatements() {
+  const statements: { sql: string; params: unknown[][] }[] = [];
+  const exec: Record<string, unknown> = {};
+
+  const db = {
+    prepare: (sql: string) => {
+      const stmt = {
+        run: (...params: unknown[]) => {
+          statements.push({ sql, params });
+          return { changes: 1 };
+        },
+        all: () => [],
+        get: () => undefined,
+      };
+      return stmt;
+    },
+    transaction: (fn: () => number) => fn,
+    exec,
+  };
+  getDbMock.mockReturnValue(db);
+  return { statements, db };
+}
+
+const sampleRelease = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  tag_name: 'v1',
+  name: 'Release 1',
+  body: null,
+  html_url: 'https://github.com/owner/repo/releases/tag/v1',
+  published_at: '2026-01-01T00:00:00.000Z',
+  assets: [{ id: 100, name: 'a.dmg', size: 1000 }],
+  repository: { id: 10, full_name: 'owner/repo', name: 'repo' },
+  ...overrides,
+});
+
+describe('PUT /api/releases merge upsert', () => {
+  it('preserves existing is_read when release does not carry it explicitly', async () => {
+    const { statements } = captureStatements();
+    await request(createTestApp())
+      .put('/api/releases')
+      .send({ releases: [sampleRelease()] })
+      .expect(200);
+
+    const sql = statements[0].sql;
+    // 未显式携带 is_read 时，冲突分支应保留 releases.is_read
+    expect(sql).toContain('is_read = releases.is_read');
+    expect(sql).not.toContain('is_read = excluded.is_read');
+    // 新插入时 is_read 传入 0（默认未读）
+    expect(statements[0].params[8]).toBe(0);
+  });
+
+  it('overwrites is_read when the release carries it explicitly', async () => {
+    const { statements } = captureStatements();
+    await request(createTestApp())
+      .put('/api/releases')
+      .send({ releases: [sampleRelease({ is_read: true })] })
+      .expect(200);
+
+    const sql = statements[0].sql;
+    expect(sql).toContain('is_read = excluded.is_read');
+    expect(statements[0].params[8]).toBe(1);
+  });
+
+  it('updates data columns while preserving is_read on conflict', async () => {
+    const { statements } = captureStatements();
+    await request(createTestApp())
+      .put('/api/releases')
+      .send({ releases: [sampleRelease({ assets: [{ id: 100, size: 9999 }], name: 'New name' })] })
+      .expect(200);
+
+    const sql = statements[0].sql;
+    // 数据列应更新
+    expect(sql).toContain('assets = excluded.assets');
+    expect(sql).toContain('name = excluded.name');
+    // is_read 保留
+    expect(sql).toContain('is_read = releases.is_read');
+  });
+
+  it('rejects release without a valid positive id', async () => {
+    captureStatements();
+    await request(createTestApp())
+      .put('/api/releases')
+      .send({ releases: [{ ...sampleRelease(), id: 0 }] })
+      .expect(400);
+  });
+});

--- a/server/tests/routes/syncUpsert.test.ts
+++ b/server/tests/routes/syncUpsert.test.ts
@@ -1,0 +1,88 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it, vi } from 'vitest';
+
+const getDbMock = vi.fn();
+
+vi.mock('../../src/db/connection.js', () => ({
+  getDb: () => getDbMock(),
+}));
+// sync 路由顶部引入 config/crypto，但 import 分支不实际使用它们，mock 为空即可。
+vi.mock('../../src/config.js', () => ({ config: { encryptionKey: 'test-key' } }));
+vi.mock('../../src/services/crypto.js', () => ({ encrypt: (v: string) => v, decrypt: (v: string) => v }));
+
+const { default: syncRouter } = await import('../../src/routes/sync.js');
+
+const createTestApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use(syncRouter);
+  return app;
+};
+
+/**
+ * Mock DB：只记录 prepare 收到的 SQL 与每次 run 的参数，便于断言导入合并 UPSERT 的 is_read 语义。
+ */
+function captureStatements() {
+  const statements: { sql: string; params: unknown[][] }[] = [];
+  const exec: Record<string, unknown> = {};
+  const db = {
+    prepare: (sql: string) => {
+      const stmt = {
+        run: (...params: unknown[]) => {
+          statements.push({ sql, params });
+          return { changes: 1 };
+        },
+        all: () => [],
+        get: () => undefined,
+      };
+      return stmt;
+    },
+    // 路由中 `db.transaction(() => {...})` 返回 importAll，随后调用 `importAll()`；
+    // 因此这里返回 fn 本身（与 releasesUpsert.test.ts 的惯例一致）。
+    transaction: (fn: () => number) => fn,
+    exec,
+  };
+  getDbMock.mockReturnValue(db);
+  return { statements, db };
+}
+
+const releaseSqlIndex = (statements: { sql: string }[]) =>
+  statements.findIndex((s) => s.sql.includes('INSERT INTO releases'));
+
+describe('POST /api/sync/import release upsert is_read semantics', () => {
+  it('passes NULL for is_read when snapshot does not carry it, so existing read state is preserved', async () => {
+    const { statements } = captureStatements();
+    await request(createTestApp())
+      .post('/api/sync/import')
+      .send({
+        repositories: [],
+        releases: [{ id: 1, tag_name: 'v1', assets: [] }],
+      })
+      .expect(200);
+
+    const idx = releaseSqlIndex(statements);
+    expect(idx).toBeGreaterThan(-1);
+    const releaseStmt = statements[idx];
+    // is_read 位于 (id, tag_name, name, body, html_url, published_at, prerelease, draft, is_read, ...) 第 9 位
+    expect(releaseStmt.params[8]).toBeNull();
+    // UPSERT 保留分支必须存在，以保留库中已读状态
+    expect(releaseStmt.sql).toContain('is_read = CASE WHEN excluded.is_read IS NOT NULL');
+    expect(releaseStmt.sql).toContain('ELSE releases.is_read');
+  });
+
+  it('passes explicit boolean for is_read when snapshot carries it, overwriting existing state', async () => {
+    const { statements } = captureStatements();
+    await request(createTestApp())
+      .post('/api/sync/import')
+      .send({
+        repositories: [],
+        releases: [{ id: 1, tag_name: 'v1', is_read: true, assets: [] }],
+      })
+      .expect(200);
+
+    const idx = releaseSqlIndex(statements);
+    expect(idx).toBeGreaterThan(-1);
+    expect(statements[idx].params[8]).toBe(1);
+  });
+});

--- a/server/tests/routes/syncUpsert.test.ts
+++ b/server/tests/routes/syncUpsert.test.ts
@@ -57,6 +57,16 @@ const releaseOverwriteIndex = (statements: { sql: string }[]) =>
     s.sql.includes('INSERT INTO releases') && s.sql.includes('is_read = excluded.is_read')
   );
 
+const validRelease = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  tag_name: 'v1',
+  assets: [],
+  repo_id: 10,
+  repo_full_name: 'owner/repo',
+  repo_name: 'repo',
+  ...overrides,
+});
+
 describe('POST /api/sync/import release upsert is_read semantics', () => {
   it('uses preserve-statement and inserts is_read=0 when snapshot does not carry it', async () => {
     const { statements } = captureStatements();
@@ -64,7 +74,7 @@ describe('POST /api/sync/import release upsert is_read semantics', () => {
       .post('/api/sync/import')
       .send({
         repositories: [],
-        releases: [{ id: 1, tag_name: 'v1', assets: [] }],
+        releases: [validRelease()],
       })
       .expect(200);
 
@@ -87,7 +97,7 @@ describe('POST /api/sync/import release upsert is_read semantics', () => {
       .post('/api/sync/import')
       .send({
         repositories: [],
-        releases: [{ id: 1, tag_name: 'v1', is_read: true, assets: [] }],
+        releases: [validRelease({ is_read: true })],
       })
       .expect(200);
 
@@ -98,5 +108,41 @@ describe('POST /api/sync/import release upsert is_read semantics', () => {
     expect(statements[idx].params[8]).toBe(1);
     // 保留分支语句不应被命中
     expect(releasePreserveIndex(statements)).toBe(-1);
+  });
+
+  it('rejects release snapshot missing required repository fields with 400', async () => {
+    captureStatements();
+    const res = await request(createTestApp())
+      .post('/api/sync/import')
+      .send({
+        repositories: [],
+        releases: [{ id: 1, tag_name: 'v1', assets: [] }],
+      })
+      .expect(400);
+
+    expect(res.body.code).toBe('RELEASE_REPO_ID_REQUIRED');
+  });
+
+  it('accepts repository nested object for required repo fields', async () => {
+    const { statements } = captureStatements();
+    await request(createTestApp())
+      .post('/api/sync/import')
+      .send({
+        repositories: [],
+        releases: [{
+          id: 2,
+          tag_name: 'v2',
+          assets: [],
+          repository: { id: 20, full_name: 'owner/other', name: 'other' },
+        }],
+      })
+      .expect(200);
+
+    const idx = releasePreserveIndex(statements);
+    expect(idx).toBeGreaterThan(-1);
+    // repo_id / full_name / name 位于 is_read(8)、assets(9) 之后
+    expect(statements[idx].params[10]).toBe(20);
+    expect(statements[idx].params[11]).toBe('owner/other');
+    expect(statements[idx].params[12]).toBe('other');
   });
 });

--- a/server/tests/routes/syncUpsert.test.ts
+++ b/server/tests/routes/syncUpsert.test.ts
@@ -198,6 +198,9 @@ describe('POST /api/sync/import release upsert is_read semantics', () => {
     const idx = releaseOverwriteIndex(statements);
     expect(idx).toBeGreaterThan(-1);
     expect(statements[idx].sql).toContain('zipball_url = excluded.zipball_url');
+    expect(statements[idx].sql).toContain('tarball_url = excluded.tarball_url');
+    // is_read: false → 覆盖分支绑定 0
+    expect(statements[idx].params[8]).toBe(0);
     expect(statements[idx].params[13]).toBe('https://example.com/z2');
     expect(statements[idx].params[14]).toBe('https://example.com/t2');
   });

--- a/server/tests/routes/syncUpsert.test.ts
+++ b/server/tests/routes/syncUpsert.test.ts
@@ -47,11 +47,18 @@ function captureStatements() {
   return { statements, db };
 }
 
-const releaseSqlIndex = (statements: { sql: string }[]) =>
-  statements.findIndex((s) => s.sql.includes('INSERT INTO releases'));
+// 两段式语句中，保留分支用 releases.is_read，覆盖分支用 excluded.is_read
+const releasePreserveIndex = (statements: { sql: string }[]) =>
+  statements.findIndex((s) =>
+    s.sql.includes('INSERT INTO releases') && s.sql.includes('is_read = releases.is_read')
+  );
+const releaseOverwriteIndex = (statements: { sql: string }[]) =>
+  statements.findIndex((s) =>
+    s.sql.includes('INSERT INTO releases') && s.sql.includes('is_read = excluded.is_read')
+  );
 
 describe('POST /api/sync/import release upsert is_read semantics', () => {
-  it('passes NULL for is_read when snapshot does not carry it, so existing read state is preserved', async () => {
+  it('uses preserve-statement and inserts is_read=0 when snapshot does not carry it', async () => {
     const { statements } = captureStatements();
     await request(createTestApp())
       .post('/api/sync/import')
@@ -61,17 +68,20 @@ describe('POST /api/sync/import release upsert is_read semantics', () => {
       })
       .expect(200);
 
-    const idx = releaseSqlIndex(statements);
+    const idx = releasePreserveIndex(statements);
     expect(idx).toBeGreaterThan(-1);
     const releaseStmt = statements[idx];
+    // 保留分支：冲突时 is_read = releases.is_read（保留库中已读状态）
+    expect(releaseStmt.sql).toContain('is_read = releases.is_read');
+    expect(releaseStmt.sql).not.toContain('is_read = CASE WHEN');
     // is_read 位于 (id, tag_name, name, body, html_url, published_at, prerelease, draft, is_read, ...) 第 9 位
-    expect(releaseStmt.params[8]).toBeNull();
-    // UPSERT 保留分支必须存在，以保留库中已读状态
-    expect(releaseStmt.sql).toContain('is_read = CASE WHEN excluded.is_read IS NOT NULL');
-    expect(releaseStmt.sql).toContain('ELSE releases.is_read');
+    // 非显式时落 0（与 releases 表 DEFAULT 0 语义一致），避免新导入行落 NULL 导致 unread 过滤漏行
+    expect(releaseStmt.params[8]).toBe(0);
+    // 覆盖分支语句不应被命中
+    expect(releaseOverwriteIndex(statements)).toBe(-1);
   });
 
-  it('passes explicit boolean for is_read when snapshot carries it, overwriting existing state', async () => {
+  it('uses overwrite-statement and passes explicit boolean when snapshot carries is_read', async () => {
     const { statements } = captureStatements();
     await request(createTestApp())
       .post('/api/sync/import')
@@ -81,8 +91,12 @@ describe('POST /api/sync/import release upsert is_read semantics', () => {
       })
       .expect(200);
 
-    const idx = releaseSqlIndex(statements);
+    const idx = releaseOverwriteIndex(statements);
     expect(idx).toBeGreaterThan(-1);
+    // 覆盖分支：冲突时 is_read = excluded.is_read（用快照中的已读状态覆盖）
+    expect(statements[idx].sql).toContain('is_read = excluded.is_read');
     expect(statements[idx].params[8]).toBe(1);
+    // 保留分支语句不应被命中
+    expect(releasePreserveIndex(statements)).toBe(-1);
   });
 });

--- a/server/tests/routes/syncUpsert.test.ts
+++ b/server/tests/routes/syncUpsert.test.ts
@@ -145,4 +145,60 @@ describe('POST /api/sync/import release upsert is_read semantics', () => {
     expect(statements[idx].params[11]).toBe('owner/other');
     expect(statements[idx].params[12]).toBe('other');
   });
+
+  it('rejects decimal release id with 400 (must be integer)', async () => {
+    captureStatements();
+    const res = await request(createTestApp())
+      .post('/api/sync/import')
+      .send({
+        repositories: [],
+        releases: [validRelease({ id: 1.5 })],
+      })
+      .expect(400);
+
+    expect(res.body.code).toBe('RELEASE_ID_REQUIRED');
+  });
+
+  it('persists zipball_url and tarball_url on import UPSERT', async () => {
+    const { statements } = captureStatements();
+    await request(createTestApp())
+      .post('/api/sync/import')
+      .send({
+        repositories: [],
+        releases: [validRelease({
+          zipball_url: 'https://example.com/zip',
+          tarball_url: 'https://example.com/tar',
+        })],
+      })
+      .expect(200);
+
+    const idx = releasePreserveIndex(statements);
+    expect(idx).toBeGreaterThan(-1);
+    expect(statements[idx].sql).toContain('zipball_url = excluded.zipball_url');
+    expect(statements[idx].sql).toContain('tarball_url = excluded.tarball_url');
+    // zipball/tarball 位于 repo_name(12) 之后
+    expect(statements[idx].params[13]).toBe('https://example.com/zip');
+    expect(statements[idx].params[14]).toBe('https://example.com/tar');
+  });
+
+  it('persists archive URLs on overwrite path as well', async () => {
+    const { statements } = captureStatements();
+    await request(createTestApp())
+      .post('/api/sync/import')
+      .send({
+        repositories: [],
+        releases: [validRelease({
+          is_read: false,
+          zipball_url: 'https://example.com/z2',
+          tarball_url: 'https://example.com/t2',
+        })],
+      })
+      .expect(200);
+
+    const idx = releaseOverwriteIndex(statements);
+    expect(idx).toBeGreaterThan(-1);
+    expect(statements[idx].sql).toContain('zipball_url = excluded.zipball_url');
+    expect(statements[idx].params[13]).toBe('https://example.com/z2');
+    expect(statements[idx].params[14]).toBe('https://example.com/t2');
+  });
 });

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -22,6 +22,7 @@ import {
   releaseBelongsToResolvedSources,
   resolveReleaseSources,
 } from '../utils/releaseSources';
+import { assetsFingerprint } from '../utils/releaseAssets';
 
 export const ReleaseTimeline: React.FC = () => {
   const {
@@ -34,6 +35,7 @@ export const ReleaseTimeline: React.FC = () => {
     language,
     assetFilters,
     addReleases,
+    upsertReleases,
     markReleaseAsRead,
     markAllReleasesAsRead,
     batchUnsubscribeReleases,
@@ -400,9 +402,9 @@ export const ReleaseTimeline: React.FC = () => {
     try {
       const githubApi = new GitHubApiService(githubToken);
 
-      const { releases: newReleases, failedRepos } = await githubApi.getMultipleRepositoryReleases(
+      const { releases: newReleases, latestReleases, failedRepos } = await githubApi.getMultipleRepositoryReleases(
         subscribedRepos,
-        { includePreRelease }
+        { includePreRelease, refreshExistingAssets: true }
       );
 
       // Update repository sync metadata only for repos that succeeded
@@ -446,21 +448,39 @@ export const ReleaseTimeline: React.FC = () => {
         addReleases(actuallyNewReleases);
       }
 
+      // 只比每仓最新 1 条资产指纹：对已存在的最新 Release，若资产发生变化则按 id 合并更新，
+      // 保留已读状态（is_read 由 upsertReleases 合并逻辑保证）。
+      const currentReleases = useAppStore.getState().releases;
+      const updatedReleases = (latestReleases || []).filter(latest => {
+        const local = currentReleases.find(r => r.id === latest.id);
+        // 本地不存在（即为新增，已在上方 addReleases 处理）或资产未变化时跳过
+        if (!local) return false;
+        return assetsFingerprint(local.assets) !== assetsFingerprint(latest.assets);
+      });
+      const updatedCount = updatedReleases.length;
+
+      if (updatedReleases.length > 0) {
+        upsertReleases(updatedReleases);
+      }
+
       setLastRefreshTime(now);
 
       // Build success message with failed repos info
       let message: string;
+      const updatedPart = updatedCount > 0
+        ? (language === 'zh' ? `，${updatedCount} 个Release资产已更新` : `, ${updatedCount} release assets updated`)
+        : '';
       if (failedRepos.length > 0) {
         message = language === 'zh'
-          ? `刷新完成！发现 ${actuallyNewCount} 个新Release，${failedRepos.length} 个仓库刷新失败。`
-          : `Refresh completed! Found ${actuallyNewCount} new releases, ${failedRepos.length} repos failed.`;
+          ? `刷新完成！发现 ${actuallyNewCount} 个新Release${updatedPart}，${failedRepos.length} 个仓库刷新失败。`
+          : `Refresh completed! Found ${actuallyNewCount} new releases${updatedPart}, ${failedRepos.length} repos failed.`;
       } else {
         message = language === 'zh'
-          ? `刷新完成！发现 ${actuallyNewCount} 个新Release。`
-          : `Refresh completed! Found ${actuallyNewCount} new releases.`;
+          ? `刷新完成！发现 ${actuallyNewCount} 个新Release${updatedPart}。`
+          : `Refresh completed! Found ${actuallyNewCount} new releases${updatedPart}.`;
       }
 
-      toast(message, actuallyNewCount > 0 ? 'success' : 'info');
+      toast(message, actuallyNewCount > 0 || updatedCount > 0 ? 'success' : 'info');
     } catch (error) {
       console.error('Refresh failed:', error);
       const errorMessage = language === 'zh'

--- a/src/services/githubApi.test.ts
+++ b/src/services/githubApi.test.ts
@@ -134,4 +134,34 @@ describe('GitHubApiService.getMultipleRepositoryReleases asset refresh', () => {
     expect(result.latestReleases![0].id).toBe(2);
     expect(result.latestReleases![0].repository.id).toBe(10);
   });
+
+  it('continues past page one of only prereleases to collect the newest stable release', async () => {
+    const service = new GitHubApiService('token');
+    // 第一页 10 条全是预发布（且都在水印之后），第二页才出现正式版
+    const page1 = Array.from({ length: 10 }, (_, i) =>
+      makeRelease(100 + i, `2026-01-${String(20 - i).padStart(2, '0')}T00:00:00.000Z`, { prerelease: true })
+    );
+    const stable = makeRelease(50, '2026-01-05T00:00:00.000Z');
+    const older = makeRelease(40, '2025-12-01T00:00:00.000Z');
+
+    vi.spyOn(service, 'getRepositoryReleases' as never)
+      .mockResolvedValueOnce(page1 as never)
+      .mockResolvedValueOnce([stable, older] as never);
+
+    const repo = makeRepository(10, 'owner/repo', {
+      has_fetched_releases: true,
+      last_release_fetch_time: '2026-01-02T00:00:00.000Z',
+    });
+
+    const result = await service.getMultipleRepositoryReleases(
+      [repo],
+      { includePreRelease: false, refreshExistingAssets: true }
+    );
+
+    expect(result.latestReleases).toHaveLength(1);
+    expect(result.latestReleases![0].id).toBe(50);
+    expect(result.latestReleases![0].repository.id).toBe(10);
+    // 正式版在水印之后，应进入新列表；预发布被 includePreRelease=false 过滤
+    expect(result.releases.map(r => r.id)).toEqual([50]);
+  });
 });

--- a/src/services/githubApi.test.ts
+++ b/src/services/githubApi.test.ts
@@ -111,4 +111,27 @@ describe('GitHubApiService.getMultipleRepositoryReleases asset refresh', () => {
 
     expect(result.latestReleases).toBeUndefined();
   });
+
+  it('skips a prerelease latest when includePreRelease is false and collects the newest stable release instead', async () => {
+    const service = new GitHubApiService('token');
+    const prerelease = makeRelease(1, '2026-01-05T00:00:00.000Z', { prerelease: true });
+    const stable = makeRelease(2, '2026-01-04T00:00:00.000Z');
+
+    // 第一页第一条是新发布（预发布），其下才是最新的正式发行
+    vi.spyOn(service, 'getRepositoryReleases' as never).mockResolvedValueOnce(
+      [prerelease, stable] as never
+    );
+
+    const repo = makeRepository(10, 'owner/repo', { has_fetched_releases: true, last_release_fetch_time: '2026-01-02T00:00:00.000Z' });
+
+    const result = await service.getMultipleRepositoryReleases(
+      [repo],
+      { includePreRelease: false, refreshExistingAssets: true }
+    );
+
+    // 最新 Release 应跳过预发布，收集到第一个正式发行
+    expect(result.latestReleases).toHaveLength(1);
+    expect(result.latestReleases![0].id).toBe(2);
+    expect(result.latestReleases![0].repository.id).toBe(10);
+  });
 });

--- a/src/services/githubApi.test.ts
+++ b/src/services/githubApi.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Repository, Release } from '../types';
+import { GitHubApiService } from './githubApi';
+
+const makeRepository = (id: number, fullName: string, overrides: Partial<Repository> = {}): Repository => {
+  const [owner, name] = fullName.split('/');
+  return {
+    id,
+    name,
+    full_name: fullName,
+    description: null,
+    html_url: `https://github.com/${fullName}`,
+    stargazers_count: 1,
+    forks_count: 0,
+    forks: 0,
+    language: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    pushed_at: '2026-01-01T00:00:00.000Z',
+    owner: { login: owner, avatar_url: `https://github.com/${owner}.png` },
+    topics: [],
+    ...overrides,
+  };
+};
+
+const makeRelease = (id: number, publishedAt: string, overrides: Partial<Release> = {}): Release => ({
+  id,
+  tag_name: `v${id}`,
+  name: `Release ${id}`,
+  body: null,
+  published_at: publishedAt,
+  html_url: `https://github.com/owner/repo/releases/tag/v${id}`,
+  assets: [
+    {
+      id: 100 + id,
+      name: 'app.dmg',
+      size: 1000,
+      download_count: 0,
+      browser_download_url: 'https://example.com/app.dmg',
+      content_type: 'application/octet-stream',
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    },
+  ],
+  repository: { id: 0, full_name: 'owner/repo', name: 'repo' },
+  ...overrides,
+});
+
+describe('GitHubApiService.getMultipleRepositoryReleases asset refresh', () => {
+  it('collects the latest release per already-synced repo when refreshExistingAssets is enabled', async () => {
+    const service = new GitHubApiService('token');
+    const latest = makeRelease(1, '2026-01-03T00:00:00.000Z');
+    const older = makeRelease(2, '2026-01-01T00:00:00.000Z');
+
+    // 已同步仓库：水印在 01-02，最新 Release(01-03) 在水印之后（fresh），老 Release 在水印前。
+    vi.spyOn(service, 'getRepositoryReleases' as never).mockResolvedValueOnce(
+      [latest, older] as never
+    );
+    vi.spyOn(service, 'fetchAllReleasesForRepo' as never).mockResolvedValueOnce([] as never);
+
+    const repo = makeRepository(10, 'owner/repo', { has_fetched_releases: true, last_release_fetch_time: '2026-01-02T00:00:00.000Z' });
+
+    const result = await service.getMultipleRepositoryReleases(
+      [repo],
+      { includePreRelease: true, refreshExistingAssets: true }
+    );
+
+    // 新列表包含水印后的最新 Release
+    expect(result.releases.map(r => r.id)).toEqual([1]);
+    // 最新 Release 也被收集，用于资产指纹比对，且带上了仓库 id
+    expect(result.latestReleases).toHaveLength(1);
+    expect(result.latestReleases![0].id).toBe(1);
+    expect(result.latestReleases![0].repository.id).toBe(10);
+  });
+
+  it('collects latest release even when it is below the watermark (already fetched)', async () => {
+    const service = new GitHubApiService('token');
+    const latest = makeRelease(1, '2026-01-01T00:00:00.000Z'); // 水印之前
+    const older = makeRelease(2, '2025-12-01T00:00:00.000Z');
+
+    // 返回一页包含两条，都在水印之前，故 releases 为空，但最新条仍应被收集
+    vi.spyOn(service, 'getRepositoryReleases' as never).mockResolvedValueOnce(
+      [latest, older] as never
+    );
+
+    const repo = makeRepository(10, 'owner/repo', { has_fetched_releases: true, last_release_fetch_time: '2026-01-02T00:00:00.000Z' });
+
+    const result = await service.getMultipleRepositoryReleases(
+      [repo],
+      { includePreRelease: true, refreshExistingAssets: true }
+    );
+
+    expect(result.releases).toHaveLength(0);
+    expect(result.latestReleases).toHaveLength(1);
+    expect(result.latestReleases![0].id).toBe(1);
+    expect(result.latestReleases![0].repository.id).toBe(10);
+  });
+
+  it('does not populate latestReleases when refreshExistingAssets is disabled', async () => {
+    const service = new GitHubApiService('token');
+    const latest = makeRelease(1, '2026-01-03T00:00:00.000Z');
+
+    vi.spyOn(service, 'getRepositoryReleases' as never).mockResolvedValueOnce([latest] as never);
+
+    const repo = makeRepository(10, 'owner/repo', { has_fetched_releases: true, last_release_fetch_time: '2026-01-02T00:00:00.000Z' });
+
+    const result = await service.getMultipleRepositoryReleases(
+      [repo],
+      { includePreRelease: true, refreshExistingAssets: false }
+    );
+
+    expect(result.latestReleases).toBeUndefined();
+  });
+});

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -90,10 +90,22 @@ export interface GistUpdateInput {
 
 export interface ReleaseFetchOptions {
   includePreRelease?: boolean;
+  /**
+   * 开启后，对已同步仓库额外检测“每仓最新一条 Release”的资产指纹是否变化，
+   * 并把“资产已变化但 id 已存在”的条目放入 updatedReleases，供调用方按 id 合并更新。
+   * 不产生额外网络请求：最新一条 Release 由增量分支第一页（per_page=10）即可获得。
+   */
+  refreshExistingAssets?: boolean;
 }
 
 export interface MultipleReleasesResult {
+  /** 新增（本地不存在的 id）的 Release */
   releases: Release[];
+  /**
+   * 已同步仓库“最新一条”Release（仅当 refreshExistingAssets 开启时收集）。
+   * 用于调用方与本地存储做资产指纹比对，指纹变化则合并更新资产，保留 is_read。
+   */
+  latestReleases?: Release[];
   failedRepos: { repoId: number; full_name: string; error: string }[];
 }
 
@@ -827,8 +839,9 @@ export class GitHubApiService {
     options: ReleaseFetchOptions = {}
   ): Promise<MultipleReleasesResult> {
     const startTime = Date.now();
-    const { includePreRelease = true } = options;
+    const { includePreRelease = true, refreshExistingAssets = false } = options;
     const allReleases: Release[] = [];
+    const latestReleases: Release[] = [];
     const failedRepos: { repoId: number; full_name: string; error: string }[] = [];
 
     // Controlled concurrency: process 3 repos at a time
@@ -862,6 +875,14 @@ export class GitHubApiService {
 
               if (batch.length === 0) break;
 
+              // 开启资产刷新时，收集“每仓最新一条 Release”用于资产指纹比对。
+              // GitHub 按发布时间倒序返回，第一页第一条即最新 Release，不产生额外请求。
+              if (refreshExistingAssets && page === 1 && batch[0]) {
+                const latest = batch[0];
+                latest.repository.id = repo.id;
+                latestReleases.push(latest);
+              }
+
               const fresh = sinceTime
                 ? batch.filter(r => new Date(r.published_at) > sinceTime)
                 : batch;
@@ -891,7 +912,6 @@ export class GitHubApiService {
           }
 
           allReleases.push(...releases);
-
         } catch (error) {
           failedRepos.push({
             repoId: repo.id,
@@ -912,8 +932,14 @@ export class GitHubApiService {
       new Date(b.published_at).getTime() - new Date(a.published_at).getTime()
     );
 
-    logger.info('githubApi', 'Update releases completed', { repoCount: repositories.length, releaseCount: sortedReleases.length, durationMs: Date.now() - startTime });
+    logger.info('githubApi', 'Update releases completed', { repoCount: repositories.length, releaseCount: sortedReleases.length, latestReleaseCount: latestReleases.length, durationMs: Date.now() - startTime });
 
+    if (refreshExistingAssets) {
+      const latest = includePreRelease
+        ? latestReleases
+        : latestReleases.filter(r => !r.prerelease);
+      return { releases: sortedReleases, latestReleases: latest, failedRepos };
+    }
     return { releases: sortedReleases, failedRepos };
   }
 

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -875,12 +875,17 @@ export class GitHubApiService {
 
               if (batch.length === 0) break;
 
-              // 开启资产刷新时，收集“每仓最新一条 Release”用于资产指纹比对。
-              // GitHub 按发布时间倒序返回，第一页第一条即最新 Release，不产生额外请求。
-              if (refreshExistingAssets && page === 1 && batch[0]) {
-                const latest = batch[0];
-                latest.repository.id = repo.id;
-                latestReleases.push(latest);
+              // 开启资产刷新时，收集“每仓最新一条、且符合预发布过滤的 Release”用于资产指纹比对。
+              // GitHub 按发布时间倒序返回，第一页内第一个匹配项即为最新可见 Release，不产生额外请求。
+              // 若直接取 batch[0] 再事后过滤，最新为预发布版时整个仓库会被跳过（见 includePreRelease 为 false 的场景）。
+              if (refreshExistingAssets && page === 1 && batch.length > 0) {
+                const latest = includePreRelease
+                  ? batch[0]
+                  : batch.find(r => !r.prerelease);
+                if (latest) {
+                  latest.repository.id = repo.id;
+                  latestReleases.push(latest);
+                }
               }
 
               const fresh = sinceTime

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -870,21 +870,23 @@ export class GitHubApiService {
 
             let page = 1;
             releases = [];
+            // 资产刷新：收集“每仓最新一条、且符合预发布过滤的 Release”。
+            // 当 includePreRelease=false 且前几页全是预发布时，需继续翻页找最新正式版，
+            // 不能只看 page=1 就停（否则正式版资产变化会被漏掉）。
+            let collectedLatest = false;
             while (true) {
               const batch = await this.getRepositoryReleases(owner, name, page, 10);
 
               if (batch.length === 0) break;
 
-              // 开启资产刷新时，收集“每仓最新一条、且符合预发布过滤的 Release”用于资产指纹比对。
-              // GitHub 按发布时间倒序返回，第一页内第一个匹配项即为最新可见 Release，不产生额外请求。
-              // 若直接取 batch[0] 再事后过滤，最新为预发布版时整个仓库会被跳过（见 includePreRelease 为 false 的场景）。
-              if (refreshExistingAssets && page === 1 && batch.length > 0) {
+              if (refreshExistingAssets && !collectedLatest && batch.length > 0) {
                 const latest = includePreRelease
                   ? batch[0]
                   : batch.find(r => !r.prerelease);
                 if (latest) {
                   latest.repository.id = repo.id;
                   latestReleases.push(latest);
+                  collectedLatest = true;
                 }
               }
 
@@ -893,6 +895,14 @@ export class GitHubApiService {
                 : batch;
 
               releases.push(...fresh);
+
+              // 未收集到符合过滤条件的最新 Release 时，即使已触达水印也继续翻页，
+              // 直到找到候选或耗尽分页（避免前 10 条全是预发布时漏掉正式版）。
+              const needMoreForLatest = refreshExistingAssets && !collectedLatest && batch.length >= 10;
+              if (needMoreForLatest) {
+                page++;
+                continue;
+              }
 
               // Stop if we hit the watermark or ran out of data
               if (

--- a/src/store/useAppStore.test.ts
+++ b/src/store/useAppStore.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { EmbeddingConfig, Repository, VectorSearchConfig, defaultReleaseSourceSettings } from '../types';
+import { EmbeddingConfig, Release, Repository, VectorSearchConfig, defaultReleaseSourceSettings } from '../types';
 import { EMBEDDING_FORMAT_VERSION, indexAllRepos } from '../services/vectorSearchService';
 import { CUSTOM_RELEASE_SOURCE_ID, createCustomReleaseRepository } from '../utils/releaseSources';
 
@@ -65,6 +65,67 @@ describe('useAppStore release source settings', () => {
     useAppStore.getState().removeReleaseSourceRepository(CUSTOM_RELEASE_SOURCE_ID, 'OWNER/repo');
 
     expect(useAppStore.getState().releaseSourceSettings.customReleaseRepos).toHaveLength(0);
+  });
+});
+
+describe('useAppStore release add/upsert actions', () => {
+  const makeRelease = (id: number, overrides: Partial<Release> = {}): Release => ({
+    id,
+    tag_name: `v${id}`,
+    name: `Release ${id}`,
+    body: null,
+    published_at: '2026-01-01T00:00:00.000Z',
+    html_url: `https://github.com/owner/repo/releases/tag/v${id}`,
+    assets: [
+      {
+        id: 100 + id,
+        name: 'app.dmg',
+        size: 1000,
+        download_count: 0,
+        browser_download_url: 'https://example.com/app.dmg',
+        content_type: 'application/octet-stream',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+      },
+    ],
+    repository: { id: 1, full_name: 'owner/repo', name: 'repo' },
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    useAppStore.setState({
+      releaseSourceSettings: defaultReleaseSourceSettings,
+      releaseSubscriptions: new Set<number>(),
+      releases: [],
+      readReleases: new Set<number>(),
+    });
+  });
+
+  it('addReleases only appends new ids', () => {
+    useAppStore.getState().addReleases([makeRelease(1), makeRelease(2)]);
+    useAppStore.getState().addReleases([makeRelease(2), makeRelease(3)]);
+    expect(useAppStore.getState().releases.map(r => r.id)).toEqual([1, 2, 3]);
+  });
+
+  it('upsertReleases updates assets/metadata but preserves is_read', () => {
+    useAppStore.getState().addReleases([makeRelease(1, { is_read: true })]);
+
+    const updated = makeRelease(1, {
+      name: 'Updated name',
+      assets: [{ ...makeRelease(1).assets[0], size: 9999 }],
+    });
+    useAppStore.getState().upsertReleases([updated]);
+
+    const result = useAppStore.getState().releases[0];
+    expect(result.name).toBe('Updated name');
+    expect(result.assets[0].size).toBe(9999);
+    expect(result.is_read).toBe(true);
+  });
+
+  it('upsertReleases ignores ids not present in store', () => {
+    useAppStore.getState().addReleases([makeRelease(1)]);
+    useAppStore.getState().upsertReleases([makeRelease(99)]);
+    expect(useAppStore.getState().releases.map(r => r.id)).toEqual([1]);
   });
 });
 

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -390,6 +390,8 @@ interface AppActions {
   // Release actions
   setReleases: (releases: Release[]) => void;
   addReleases: (releases: Release[]) => void;
+  /** 按 id 合并更新已存在 Release 的资产/元数据，保留 is_read 等已读状态 */
+  upsertReleases: (releases: Release[]) => void;
   toggleReleaseSubscription: (repoId: number) => void;
   batchUnsubscribeReleases: (repoIds: number[]) => void;
   removeReleasesByRepoId: (repoId: number) => void;
@@ -1684,6 +1686,19 @@ export const useAppStore = create<AppState & AppActions>()(
         const existingIds = new Set(state.releases.map(r => r.id));
         const uniqueReleases = newReleases.filter(r => !existingIds.has(r.id));
         return { releases: [...state.releases, ...uniqueReleases] };
+      }),
+      upsertReleases: (updates) => set((state) => {
+        const byId = new Map(updates.map(r => [r.id, r]));
+        const merged = state.releases.map(r => {
+          const update = byId.get(r.id);
+          if (!update) return r;
+          // 保留已读状态，仅覆盖资产与元数据字段
+          return {
+            ...update,
+            is_read: r.is_read,
+          };
+        });
+        return { releases: merged };
       }),
       toggleReleaseSubscription: (repoId) => set((state) => {
         const newSubscriptions = new Set(state.releaseSubscriptions);

--- a/src/utils/releaseAssets.test.ts
+++ b/src/utils/releaseAssets.test.ts
@@ -19,9 +19,9 @@ const makeAsset = (overrides: Partial<ReleaseAsset> = {}): ReleaseAsset => ({
 });
 
 describe('assetFingerprint', () => {
-  it('serializes id, updated_at, size and download_count', () => {
+  it('serializes id, updated_at and size', () => {
     const asset = makeAsset();
-    expect(assetFingerprint(asset)).toBe('1:2026-01-01T00:00:00.000Z:1000:5');
+    expect(assetFingerprint(asset)).toBe('1:2026-01-01T00:00:00.000Z:1000');
   });
 
   it('differs when updated_at changes', () => {
@@ -36,10 +36,10 @@ describe('assetFingerprint', () => {
     expect(assetFingerprint(a)).not.toBe(assetFingerprint(b));
   });
 
-  it('differs when download_count changes', () => {
+  it('does not differ when only download_count changes (volatile metadata)', () => {
     const a = makeAsset({ id: 1, download_count: 5 });
-    const b = makeAsset({ id: 1, download_count: 6 });
-    expect(assetFingerprint(a)).not.toBe(assetFingerprint(b));
+    const b = makeAsset({ id: 1, download_count: 999 });
+    expect(assetFingerprint(a)).toBe(assetFingerprint(b));
   });
 });
 
@@ -81,5 +81,12 @@ describe('hasAssetsChanged', () => {
     const one = [makeAsset({ id: 1 })];
     const two = [makeAsset({ id: 1 }), makeAsset({ id: 2 })];
     expect(hasAssetsChanged(one, two)).toBe(true);
+  });
+
+  it('returns false when only download_count changed across refreshes', () => {
+    // download_count 在每次下载时会 +1；若纳入指纹会导致刷新必然“资产已更新”的噪声。
+    const before = [makeAsset({ id: 1, download_count: 0 })];
+    const after = [makeAsset({ id: 1, download_count: 12345 })];
+    expect(hasAssetsChanged(before, after)).toBe(false);
   });
 });

--- a/src/utils/releaseAssets.test.ts
+++ b/src/utils/releaseAssets.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import type { ReleaseAsset } from '../types';
+import {
+  assetFingerprint,
+  assetsFingerprint,
+  hasAssetsChanged,
+} from './releaseAssets';
+
+const makeAsset = (overrides: Partial<ReleaseAsset> = {}): ReleaseAsset => ({
+  id: 1,
+  name: 'app.dmg',
+  size: 1000,
+  download_count: 5,
+  browser_download_url: 'https://example.com/app.dmg',
+  content_type: 'application/octet-stream',
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+describe('assetFingerprint', () => {
+  it('serializes id, updated_at, size and download_count', () => {
+    const asset = makeAsset();
+    expect(assetFingerprint(asset)).toBe('1:2026-01-01T00:00:00.000Z:1000:5');
+  });
+
+  it('differs when updated_at changes', () => {
+    const a = makeAsset({ id: 1, updated_at: '2026-01-01T00:00:00.000Z' });
+    const b = makeAsset({ id: 1, updated_at: '2026-01-02T00:00:00.000Z' });
+    expect(assetFingerprint(a)).not.toBe(assetFingerprint(b));
+  });
+
+  it('differs when size changes', () => {
+    const a = makeAsset({ id: 1, size: 1000 });
+    const b = makeAsset({ id: 1, size: 2000 });
+    expect(assetFingerprint(a)).not.toBe(assetFingerprint(b));
+  });
+
+  it('differs when download_count changes', () => {
+    const a = makeAsset({ id: 1, download_count: 5 });
+    const b = makeAsset({ id: 1, download_count: 6 });
+    expect(assetFingerprint(a)).not.toBe(assetFingerprint(b));
+  });
+});
+
+describe('assetsFingerprint', () => {
+  it('returns empty string for empty/undefined assets', () => {
+    expect(assetsFingerprint(undefined)).toBe('');
+    expect(assetsFingerprint([])).toBe('');
+  });
+
+  it('is stable regardless of asset order', () => {
+    const assetA = makeAsset({ id: 1, name: 'a' });
+    const assetB = makeAsset({ id: 2, name: 'b' });
+    const assets1 = [assetB, assetA];
+    const assets2 = [assetA, assetB];
+    expect(assetsFingerprint(assets1)).toBe(assetsFingerprint(assets2));
+  });
+
+  it('changes when any asset field changes', () => {
+    const before = [makeAsset({ id: 1, updated_at: '2026-01-01T00:00:00.000Z' })];
+    const after = [makeAsset({ id: 1, updated_at: '2026-01-02T00:00:00.000Z' })];
+    expect(assetsFingerprint(before)).not.toBe(assetsFingerprint(after));
+  });
+});
+
+describe('hasAssetsChanged', () => {
+  it('returns false when assets are identical', () => {
+    const assets = [makeAsset({ id: 1 })];
+    expect(hasAssetsChanged(assets, assets)).toBe(false);
+    expect(hasAssetsChanged(assets, [makeAsset({ id: 1 })])).toBe(false);
+  });
+
+  it('returns true when assets differ', () => {
+    const before = [makeAsset({ id: 1 })];
+    const after = [makeAsset({ id: 1, size: 9999 })];
+    expect(hasAssetsChanged(before, after)).toBe(true);
+  });
+
+  it('returns true when asset added/removed', () => {
+    const one = [makeAsset({ id: 1 })];
+    const two = [makeAsset({ id: 1 }), makeAsset({ id: 2 })];
+    expect(hasAssetsChanged(one, two)).toBe(true);
+  });
+});

--- a/src/utils/releaseAssets.ts
+++ b/src/utils/releaseAssets.ts
@@ -1,0 +1,34 @@
+import type { ReleaseAsset } from '../types';
+
+/**
+ * 计算单个资产的指纹。
+ * 资产指纹用于判断某条 Release 的资产是否发生变化。
+ * 依据：GitHub 资产一旦被替换/重传，`updated_at` 会更新；用 `size` 与 `download_count`
+ * 做兜底，覆盖同时间戳内出现大小或下载量变化的极端情况。
+ */
+export function assetFingerprint(asset: ReleaseAsset): string {
+  return [asset.id, asset.updated_at, asset.size, asset.download_count].join(':');
+}
+
+/**
+ * 计算一组资产的稳定指纹。
+ * 对资产数组做稳定排序（按 id）后逐个序列化，保证幂等：
+ * - 同一组资产无论顺序如何，指纹一致；
+ * - 资产未变化时指纹不变，可用于短路（不触发 store/后端写入）。
+ */
+export function assetsFingerprint(assets: ReleaseAsset[] | undefined): string {
+  if (!Array.isArray(assets) || assets.length === 0) return '';
+  const sorted = [...assets].sort((a, b) => a.id - b.id);
+  return sorted.map(assetFingerprint).join('|');
+}
+
+/**
+ * 判断两组资产的指纹是否一致（即资产是否发生变化）。
+ * 用于增量刷新时判断已存在 Release 的资产是否需要更新。
+ */
+export function hasAssetsChanged(
+  current: ReleaseAsset[] | undefined,
+  incoming: ReleaseAsset[] | undefined
+): boolean {
+  return assetsFingerprint(current) !== assetsFingerprint(incoming);
+}

--- a/src/utils/releaseAssets.ts
+++ b/src/utils/releaseAssets.ts
@@ -2,12 +2,14 @@ import type { ReleaseAsset } from '../types';
 
 /**
  * 计算单个资产的指纹。
- * 资产指纹用于判断某条 Release 的资产是否发生变化。
- * 依据：GitHub 资产一旦被替换/重传，`updated_at` 会更新；用 `size` 与 `download_count`
- * 做兜底，覆盖同时间戳内出现大小或下载量变化的极端情况。
+ * 资产指纹用于判断某条 Release 的资产内容是否发生变化。
+ * 依据：GitHub 资产一旦被替换/重传，`updated_at` 会更新；用 `size` 做兜底，
+ * 覆盖同时间戳内出现大小变化的极端情况。
+ * 注意：`download_count` 是易变元数据（每次下载都会 +1），若纳入指纹会导致
+ * 指纹在两次刷新间必然变化，从而让增量刷新的“无变化则短路”失效，故不纳入。
  */
 export function assetFingerprint(asset: ReleaseAsset): string {
-  return [asset.id, asset.updated_at, asset.size, asset.download_count].join(':');
+  return [asset.id, asset.updated_at, asset.size].join(':');
 }
 
 /**


### PR DESCRIPTION
## Summary
- 刷新时只比对每仓最新 1 条 Release 的资产指纹；指纹变化则按 id 合并更新资产/元数据
- 服务端 UPSERT 默认保留库中 `is_read`，仅当请求显式携带布尔 `is_read` 时才覆盖
- 审计修复：导入不写 NULL `is_read`、排除预发布时取最新正式版、指纹去掉易变的 `download_count`

Fixes #263

## Changes
- Frontend: `getMultipleRepositoryReleases({ refreshExistingAssets })` + `upsertReleases` + `assetsFingerprint`
- Server: `PUT /api/releases` 与 `POST /api/sync/import` 改为 merge UPSERT，保留已读状态
- Tests: 覆盖 upsert / fingerprint / 预发布过滤 / 导入 is_read 语义

## Test plan
- [x] `npx vitest run` (frontend)
- [x] `cd server && npx vitest run`
- [x] `tsc --noEmit` (frontend + server)
- [ ] 手动：订阅仓库 → 标记已读 → 刷新 → 已读状态仍在
- [ ] 手动：仓库最新 Release 资产被替换后刷新 → 资产列表更新
- [ ] 手动：关闭预发布后刷新 → 比对最新正式版而非预发布

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Release refreshes now detect added, removed, or updated assets and report asset changes.
  - Release records support downloadable archive links.
  - Newly imported releases default to unread unless explicitly specified.

- **Bug Fixes**
  - Duplicate releases merge without losing read/unread status.
  - Release metadata and assets update reliably.
  - Invalid release IDs and repository metadata are rejected with clear validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->