### PR TITLE
feat(repositories): add compact list view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "github-stars-manager",
-  "version": "0.5.6",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "github-stars-manager",
-      "version": "0.5.6",
+      "version": "0.7.3",
       "dependencies": {
         "@types/query-string": "^6.2.0",
         "date-fns": "^3.3.1",
@@ -28,6 +28,7 @@
         "@tailwindcss/typography": "^0.5.19",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^14.2.1",
+        "@testing-library/user-event": "^14.6.4",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-legacy": "^8.0.1",
@@ -1205,9 +1206,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1225,9 +1223,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1245,9 +1240,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1265,9 +1257,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1285,9 +1274,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1305,9 +1291,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1462,9 +1445,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1479,9 +1459,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1496,9 +1473,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1513,9 +1487,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1530,9 +1501,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1547,9 +1515,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1564,9 +1529,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1581,9 +1543,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1598,9 +1557,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1615,9 +1571,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1632,9 +1585,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1649,9 +1599,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1666,9 +1613,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1867,6 +1811,20 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.4.tgz",
+      "integrity": "sha512-QCGwP6QrjypBLwyj5cuyfVamkaIEy/XGY+1VDehbtbQqOggYmTFpFOdWR5mPz14vX8vXLMVjDHlRNBcClyO9ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -6671,9 +6629,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6695,9 +6650,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6719,9 +6671,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6743,9 +6692,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@tailwindcss/typography": "^0.5.19",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.6.4",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-legacy": "^8.0.1",

--- a/src/components/FloatingTooltip.tsx
+++ b/src/components/FloatingTooltip.tsx
@@ -40,11 +40,12 @@ export const FloatingTooltip: React.FC<FloatingTooltipProps> = ({
     const tooltipEl = tooltipRef.current;
 
     tooltipEl.style.maxHeight = '280px';
-    const tooltipHeight = tooltipEl.offsetHeight;
     const tooltipWidth = Math.min(
       triggerRect.width * widthRatio,
       window.innerWidth - triggerRect.left - 8,
     );
+    tooltipEl.style.width = `${tooltipWidth}px`;
+    const tooltipHeight = tooltipEl.offsetHeight;
 
     const top = triggerRect.top - tooltipHeight - 8;
     const left = triggerRect.left;
@@ -58,7 +59,6 @@ export const FloatingTooltip: React.FC<FloatingTooltipProps> = ({
     }
 
     tooltipEl.style.left = `${left}px`;
-    tooltipEl.style.width = `${tooltipWidth}px`;
   }, [triggerRef, visible, widthRatio]);
 
   useLayoutEffect(() => {

--- a/src/components/FloatingTooltip.tsx
+++ b/src/components/FloatingTooltip.tsx
@@ -7,6 +7,7 @@ interface FloatingTooltipProps {
   triggerRef: React.RefObject<HTMLElement | null>;
   onMouseLeave: () => void;
   onMouseEnter?: () => void;
+  widthRatio?: number;
 }
 
 function isPointerNear(el: HTMLElement | null, x: number, y: number, padding: number): boolean {
@@ -26,6 +27,7 @@ export const FloatingTooltip: React.FC<FloatingTooltipProps> = ({
   triggerRef,
   onMouseLeave,
   onMouseEnter,
+  widthRatio = 1,
 }) => {
   const tooltipRef = useRef<HTMLDivElement>(null);
   const rafRef = useRef<number>(0);
@@ -39,7 +41,10 @@ export const FloatingTooltip: React.FC<FloatingTooltipProps> = ({
 
     tooltipEl.style.maxHeight = '280px';
     const tooltipHeight = tooltipEl.offsetHeight;
-    const tooltipWidth = triggerRect.width;
+    const tooltipWidth = Math.min(
+      triggerRect.width * widthRatio,
+      window.innerWidth - triggerRect.left - 8,
+    );
 
     const top = triggerRect.top - tooltipHeight - 8;
     const left = triggerRect.left;
@@ -54,7 +59,7 @@ export const FloatingTooltip: React.FC<FloatingTooltipProps> = ({
 
     tooltipEl.style.left = `${left}px`;
     tooltipEl.style.width = `${tooltipWidth}px`;
-  }, [triggerRef, visible]);
+  }, [triggerRef, visible, widthRatio]);
 
   useLayoutEffect(() => {
     if (visible) {

--- a/src/components/RepositoryCard.test.tsx
+++ b/src/components/RepositoryCard.test.tsx
@@ -128,6 +128,26 @@ describe('RepositoryCard view modes', () => {
     expect(screen.queryByText('查找同类')).not.toBeInTheDocument();
   });
 
+  it('closes the list action menu from card whitespace, page whitespace, or Escape', () => {
+    const { container } = render(<RepositoryCard repository={repository} allCategories={[]} viewMode="list" />);
+    const moreActions = screen.getByRole('button', { name: '更多操作' });
+    const card = container.firstElementChild as HTMLElement;
+
+    fireEvent.click(moreActions);
+    expect(screen.getByText('仓库操作')).toBeInTheDocument();
+    fireEvent.click(card);
+    expect(screen.queryByText('仓库操作')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('readme-modal')).not.toBeInTheDocument();
+
+    fireEvent.click(moreActions);
+    fireEvent.click(document.body);
+    expect(screen.queryByText('仓库操作')).not.toBeInTheDocument();
+
+    fireEvent.click(moreActions);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByText('仓库操作')).not.toBeInTheDocument();
+  });
+
   it('does not let the card keyboard handler intercept list menu or direct edit activation', async () => {
     const user = userEvent.setup();
     render(<RepositoryCard repository={repository} allCategories={[]} viewMode="list" />);

--- a/src/components/RepositoryCard.test.tsx
+++ b/src/components/RepositoryCard.test.tsx
@@ -104,6 +104,9 @@ describe('RepositoryCard view modes', () => {
     expect(lastPushed).toBeInTheDocument();
     expect(lastPushed).not.toHaveClass('group-hover:opacity-0');
     expect(screen.getByRole('button', { name: '更多操作' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '编辑仓库信息' })).toBeInTheDocument();
+    expect(screen.getByText('test')).toBeInTheDocument();
+    expect(screen.getByText('TypeScript')).toBeInTheDocument();
     expect(screen.queryByTitle('AI分析此仓库')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: '更多操作' }));
@@ -114,7 +117,7 @@ describe('RepositoryCard view modes', () => {
     expect(screen.getByRole('link', { name: '在 GitHub 中查看' })).toHaveAttribute('href', repository.html_url);
   });
 
-  it('does not let the card keyboard handler intercept list-menu activation', async () => {
+  it('does not let the card keyboard handler intercept list menu or direct edit activation', async () => {
     const user = userEvent.setup();
     render(<RepositoryCard repository={repository} allCategories={[]} viewMode="list" />);
 
@@ -123,10 +126,15 @@ describe('RepositoryCard view modes', () => {
     await user.keyboard('{Enter}');
     expect(screen.queryByTestId('readme-modal')).not.toBeInTheDocument();
 
+    const releaseAction = screen.getByRole('button', { name: '取消订阅 Release' });
+    releaseAction.focus();
+    await user.keyboard('{Enter}');
+    expect(storeState.toggleReleaseSubscription).toHaveBeenCalledWith(repository.id);
+    expect(screen.queryByTestId('readme-modal')).not.toBeInTheDocument();
+
     const editAction = screen.getByRole('button', { name: '编辑仓库信息' });
     editAction.focus();
     await user.keyboard('{Enter}');
-    expect(screen.queryByTestId('readme-modal')).not.toBeInTheDocument();
     expect(screen.getByTestId('repository-edit-modal')).toBeInTheDocument();
   });
 

--- a/src/components/RepositoryCard.test.tsx
+++ b/src/components/RepositoryCard.test.tsx
@@ -91,6 +91,7 @@ const mockUseAppStore = vi.mocked(useAppStore);
 beforeEach(() => {
   vi.clearAllMocks();
   storeState.releaseSubscriptions = new Set<number>([1]);
+  storeState.vectorSearchConfig.enabled = true;
   mockUseAppStore.mockImplementation(((selector?: (state: typeof storeState) => unknown) => (
     selector ? selector(storeState) : storeState
   )) as typeof useAppStore);
@@ -113,8 +114,18 @@ describe('RepositoryCard view modes', () => {
 
     expect(screen.getByText('仓库操作')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'AI 分析' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '查找同类仓库' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '取消 Star' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '在 GitHub 中查看' })).toHaveAttribute('href', repository.html_url);
+  });
+
+  it('only exposes similar-repository search in the menu when vector search is available', () => {
+    storeState.vectorSearchConfig.enabled = false;
+    render(<RepositoryCard repository={repository} allCategories={[]} viewMode="list" />);
+
+    fireEvent.click(screen.getByRole('button', { name: '更多操作' }));
+    expect(screen.queryByRole('button', { name: '查找同类仓库' })).not.toBeInTheDocument();
+    expect(screen.queryByText('查找同类')).not.toBeInTheDocument();
   });
 
   it('does not let the card keyboard handler intercept list menu or direct edit activation', async () => {

--- a/src/components/RepositoryCard.test.tsx
+++ b/src/components/RepositoryCard.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RepositoryCard } from './RepositoryCard';
 import { useAppStore } from '../store/useAppStore';
@@ -113,19 +114,19 @@ describe('RepositoryCard view modes', () => {
     expect(screen.getByRole('link', { name: '在 GitHub 中查看' })).toHaveAttribute('href', repository.html_url);
   });
 
-  it('does not let the card keyboard handler intercept list-menu activation', () => {
+  it('does not let the card keyboard handler intercept list-menu activation', async () => {
+    const user = userEvent.setup();
     render(<RepositoryCard repository={repository} allCategories={[]} viewMode="list" />);
 
     const moreActions = screen.getByRole('button', { name: '更多操作' });
-    expect(fireEvent.keyDown(moreActions, { key: 'Enter' })).toBe(true);
+    moreActions.focus();
+    await user.keyboard('{Enter}');
     expect(screen.queryByTestId('readme-modal')).not.toBeInTheDocument();
 
-    fireEvent.click(moreActions);
     const editAction = screen.getByRole('button', { name: '编辑仓库信息' });
-    expect(fireEvent.keyDown(editAction, { key: 'Enter' })).toBe(true);
+    editAction.focus();
+    await user.keyboard('{Enter}');
     expect(screen.queryByTestId('readme-modal')).not.toBeInTheDocument();
-
-    fireEvent.click(editAction);
     expect(screen.getByTestId('repository-edit-modal')).toBeInTheDocument();
   });
 

--- a/src/components/RepositoryCard.test.tsx
+++ b/src/components/RepositoryCard.test.tsx
@@ -87,7 +87,9 @@ describe('RepositoryCard view modes', () => {
   it('moves single-card actions into an accessible more-actions menu in list mode', () => {
     render(<RepositoryCard repository={repository} allCategories={[]} viewMode="list" />);
 
-    expect(screen.getByText(/最近提交/)).toBeInTheDocument();
+    const lastPushed = screen.getByText(/最近提交/);
+    expect(lastPushed).toBeInTheDocument();
+    expect(lastPushed).not.toHaveClass('group-hover:opacity-0');
     expect(screen.getByRole('button', { name: '更多操作' })).toBeInTheDocument();
     expect(screen.queryByTitle('AI分析此仓库')).not.toBeInTheDocument();
 

--- a/src/components/RepositoryCard.test.tsx
+++ b/src/components/RepositoryCard.test.tsx
@@ -17,6 +17,18 @@ vi.mock('./FloatingTooltip', () => ({
   FloatingTooltip: () => null,
 }));
 
+vi.mock('./RepositoryEditModal', () => ({
+  RepositoryEditModal: ({ isOpen }: { isOpen: boolean }) => (
+    isOpen ? <div data-testid="repository-edit-modal" /> : null
+  ),
+}));
+
+vi.mock('./ReadmeModal', () => ({
+  ReadmeModal: ({ isOpen }: { isOpen: boolean }) => (
+    isOpen ? <div data-testid="readme-modal" /> : null
+  ),
+}));
+
 const repository: Repository = {
   id: 1,
   name: 'example-repository',
@@ -99,6 +111,22 @@ describe('RepositoryCard view modes', () => {
     expect(screen.getByRole('button', { name: 'AI 分析' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '取消 Star' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '在 GitHub 中查看' })).toHaveAttribute('href', repository.html_url);
+  });
+
+  it('does not let the card keyboard handler intercept list-menu activation', () => {
+    render(<RepositoryCard repository={repository} allCategories={[]} viewMode="list" />);
+
+    const moreActions = screen.getByRole('button', { name: '更多操作' });
+    expect(fireEvent.keyDown(moreActions, { key: 'Enter' })).toBe(true);
+    expect(screen.queryByTestId('readme-modal')).not.toBeInTheDocument();
+
+    fireEvent.click(moreActions);
+    const editAction = screen.getByRole('button', { name: '编辑仓库信息' });
+    expect(fireEvent.keyDown(editAction, { key: 'Enter' })).toBe(true);
+    expect(screen.queryByTestId('readme-modal')).not.toBeInTheDocument();
+
+    fireEvent.click(editAction);
+    expect(screen.getByTestId('repository-edit-modal')).toBeInTheDocument();
   });
 
   it('retains the existing quick action row in grid mode', () => {

--- a/src/components/RepositoryCard.test.tsx
+++ b/src/components/RepositoryCard.test.tsx
@@ -176,5 +176,8 @@ describe('RepositoryCard view modes', () => {
     expect(screen.getByTitle('AI分析此仓库')).toBeInTheDocument();
     expect(screen.getByTitle('取消订阅发布')).toBeInTheDocument();
     expect(screen.getByTitle('编辑仓库信息')).toBeInTheDocument();
+
+    const footer = screen.getByText(/最近提交/).closest('.border-t');
+    expect(footer?.parentElement).toHaveClass('mt-4');
   });
 });

--- a/src/components/RepositoryCard.test.tsx
+++ b/src/components/RepositoryCard.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RepositoryCard } from './RepositoryCard';
+import { useAppStore } from '../store/useAppStore';
+import type { Repository } from '../types';
+
+vi.mock('../store/useAppStore', () => ({
+  useAppStore: vi.fn(),
+}));
+
+vi.mock('../hooks/useDialog', () => ({
+  useDialog: () => ({ toast: vi.fn(), confirm: vi.fn() }),
+}));
+
+vi.mock('./FloatingTooltip', () => ({
+  FloatingTooltip: () => null,
+}));
+
+const repository: Repository = {
+  id: 1,
+  name: 'example-repository',
+  full_name: 'owner/example-repository',
+  description: 'Repository description',
+  html_url: 'https://github.com/owner/example-repository',
+  stargazers_count: 128,
+  forks_count: 3,
+  forks: 3,
+  language: 'TypeScript',
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-02T00:00:00.000Z',
+  pushed_at: '2026-01-03T00:00:00.000Z',
+  owner: {
+    login: 'owner',
+    avatar_url: 'https://example.com/avatar.png',
+  },
+  topics: ['test'],
+  ai_platforms: ['web', 'cli'],
+};
+
+const storeState = {
+  releaseSubscriptions: new Set<number>([1]),
+  analyzingRepositoryIds: new Set<number>(),
+  toggleReleaseSubscription: vi.fn(),
+  githubToken: null,
+  activeAIConfig: null,
+  setAnalyzingRepository: vi.fn(),
+  language: 'zh' as const,
+  updateRepository: vi.fn(),
+  deleteRepository: vi.fn(),
+  vectorSearchConfig: {
+    enabled: true,
+    workerUrl: 'https://worker.example.com',
+    authToken: 'token',
+    embeddingConfigId: 'embedding',
+    indexMode: 'readme' as const,
+    readmeMaxChars: 6000,
+  },
+  vectorSearchStatus: { connected: true, vectorCount: 1, dimensions: 1536 },
+  embeddingConfigs: [{
+    id: 'embedding',
+    name: 'Test embedding',
+    apiType: 'openai-compatible' as const,
+    baseUrl: 'https://example.com/v1',
+    apiKey: 'test-key',
+    model: 'test-model',
+    dimensions: 1536,
+    isActive: true,
+  }],
+  activeEmbeddingConfig: 'embedding',
+  repositories: [repository],
+  enterSimilarView: vi.fn(),
+  aiConfigs: [],
+};
+
+const mockUseAppStore = vi.mocked(useAppStore);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  storeState.releaseSubscriptions = new Set<number>([1]);
+  mockUseAppStore.mockImplementation(((selector?: (state: typeof storeState) => unknown) => (
+    selector ? selector(storeState) : storeState
+  )) as typeof useAppStore);
+});
+
+describe('RepositoryCard view modes', () => {
+  it('moves single-card actions into an accessible more-actions menu in list mode', () => {
+    render(<RepositoryCard repository={repository} allCategories={[]} viewMode="list" />);
+
+    expect(screen.getByText(/最近提交/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '更多操作' })).toBeInTheDocument();
+    expect(screen.queryByTitle('AI分析此仓库')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: '更多操作' }));
+
+    expect(screen.getByText('仓库操作')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'AI 分析' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '取消 Star' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '在 GitHub 中查看' })).toHaveAttribute('href', repository.html_url);
+  });
+
+  it('retains the existing quick action row in grid mode', () => {
+    render(<RepositoryCard repository={repository} allCategories={[]} viewMode="grid" />);
+
+    expect(screen.queryByRole('button', { name: '更多操作' })).not.toBeInTheDocument();
+    expect(screen.getByTitle('AI分析此仓库')).toBeInTheDocument();
+    expect(screen.getByTitle('取消订阅发布')).toBeInTheDocument();
+    expect(screen.getByTitle('编辑仓库信息')).toBeInTheDocument();
+  });
+});

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -861,6 +861,9 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
   const isModalOpen = editModalOpen || readmeModalOpen;
   
   const handleCardKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    // 仅由卡片自身获得焦点时处理，避免拦截三点菜单等后代控件的原生键盘行为。
+    if (event.target !== event.currentTarget) return;
+
     // 如果任何模态框打开，不处理键盘事件
     if (isModalOpen) return;
     

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import { createPortal } from 'react-dom';
-import { GripVertical, Star, StarOff, ExternalLink, Calendar, Bell, BellOff, Bot, Sparkles, Monitor, Smartphone, Globe, Terminal, Package, Edit3, BookOpen, Apple, Square, CheckSquare, Loader2, HelpCircle, Search, Scale } from 'lucide-react';
+import { GripVertical, Star, StarOff, ExternalLink, Calendar, Bell, BellOff, Bot, Sparkles, Monitor, Smartphone, Globe, Terminal, Package, Edit3, BookOpen, Apple, Square, CheckSquare, Loader2, HelpCircle, Search, Scale, MoreHorizontal } from 'lucide-react';
 import { Repository, Category } from '../types';
 import { useAppStore } from '../store/useAppStore';
 import { EmbeddingClient, VectorSearchService, findSimilarRepositories } from '../services/vectorSearchService';
@@ -71,6 +71,7 @@ interface RepositoryCardProps {
   selectionMode?: boolean;
   isExitingSelection?: boolean;
   allCategories: Category[];
+  viewMode?: 'grid' | 'list';
 }
 
 const MAX_CACHE_SIZE = 500;
@@ -89,7 +90,8 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
   onSelect,
   selectionMode = false,
   isExitingSelection = false,
-  allCategories
+  allCategories,
+  viewMode = 'grid'
 }) => {
   const repoId = repository.id;
 
@@ -179,6 +181,13 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
   }, [embeddingConfigs, activeEmbeddingConfig, vectorSearchConfig, vectorSearchStatus]);
 
   const [isFindingSimilar, setIsFindingSimilar] = useState(false);
+  const [isActionsMenuOpen, setIsActionsMenuOpen] = useState(false);
+
+  useEffect(() => {
+    if (viewMode !== 'list' || selectionMode) {
+      setIsActionsMenuOpen(false);
+    }
+  }, [viewMode, selectionMode]);
 
   // 高亮搜索关键词的工具函数 - 使用缓存优化
   const highlightSearchTerm = useCallback((text: string, searchTerm: string): React.ReactNode => {
@@ -869,13 +878,15 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
 
   // 使用 useMemo 缓存卡片类名，避免重复计算
   const cardClassName = useMemo(() => {
-    const baseClasses = 'repository-card ui-card group p-5 transition-all duration-200 flex flex-col h-full cursor-pointer select-none';
+    const baseClasses = viewMode === 'list'
+      ? 'repository-card repository-card--list ui-card group relative px-4 py-3 transition-all duration-200 cursor-pointer select-none'
+      : 'repository-card ui-card group p-5 transition-all duration-200 flex flex-col h-full cursor-pointer select-none';
     const selectedClasses = isSelected
       ? 'linear-card-selected'
       : '';
     const exitingClasses = isExitingSelection && isSelected ? 'animate-selection-exit' : '';
     return `${baseClasses} ${selectedClasses} ${exitingClasses}`.trim();
-  }, [isSelected, isExitingSelection]);
+  }, [isSelected, isExitingSelection, viewMode]);
 
   return (
     <div
@@ -890,7 +901,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
       aria-disabled={isModalOpen}
     >
       {/* Header - Repository Info */}
-      <div className="flex items-start space-x-3 mb-3">
+      <div className={`flex items-start space-x-3 ${viewMode === 'list' ? 'mb-0' : 'mb-3'}`}>
         <img
           src={repository.owner.avatar_url}
           alt={repository.owner.login}
@@ -906,7 +917,131 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
         </div>
         
         {/* 拖拽按钮 - 右上角 - 手机和平板端隐藏 */}
-        {!selectionMode && (
+        {viewMode === 'list' && (
+          <div className="ml-auto flex items-center gap-1.5 flex-shrink-0">
+            {displayContent.isAnalysisFailed ? (
+              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[11px] font-medium bg-status-red/10 text-status-red">
+                <Bot className="w-3 h-3" />
+                {language === 'zh' ? '分析失败' : 'Analysis failed'}
+              </span>
+            ) : displayContent.isAnalyzed ? (
+              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[11px] font-medium bg-brand-indigo/10 dark:bg-brand-indigo/20 text-brand-violet">
+                <Sparkles className="w-3 h-3" />
+                {language === 'zh' ? '已分析' : 'Analyzed'}
+              </span>
+            ) : (
+              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[11px] font-medium bg-gray-100 dark:bg-white/[0.04] text-gray-600 dark:text-text-secondary">
+                <Bot className="w-3 h-3" />
+                {language === 'zh' ? '待分析' : 'Not analyzed'}
+              </span>
+            )}
+            {isSubscribed && (
+              <span className="hidden sm:inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[11px] font-medium bg-status-emerald/10 text-status-emerald">
+                <Bell className="w-3 h-3" />
+                Release
+              </span>
+            )}
+            {displayContent.isCustomized && <Edit3 className="w-3.5 h-3.5 text-status-amber" title={language === 'zh' ? '已自定义' : 'Customized'} />}
+          </div>
+        )}
+
+        {viewMode === 'list' && !selectionMode && (
+          <div className="relative flex-shrink-0">
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                setIsActionsMenuOpen((open) => !open);
+              }}
+              className={`linear-icon-button flex items-center justify-center w-8 h-8 ${isActionsMenuOpen ? 'bg-light-surface dark:bg-white/[0.08]' : ''}`}
+              title={language === 'zh' ? '更多操作' : 'More actions'}
+              aria-label={language === 'zh' ? '更多操作' : 'More actions'}
+              aria-expanded={isActionsMenuOpen}
+            >
+              <MoreHorizontal className="w-4 h-4" />
+            </button>
+            {isActionsMenuOpen && (
+              <div
+                className="ui-menu absolute z-30 right-0 top-9 w-48 p-1.5"
+                onClick={(event) => event.stopPropagation()}
+              >
+                <div className="px-2 py-1.5 text-[11px] text-gray-500 dark:text-text-tertiary">
+                  {language === 'zh' ? '仓库操作' : 'Repository actions'}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setIsActionsMenuOpen(false);
+                    void handleAIAnalyze();
+                  }}
+                  disabled={isAnalyzing}
+                  className="ui-menu-item w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm disabled:opacity-50"
+                >
+                  {isAnalyzing ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Bot className="w-3.5 h-3.5" />}
+                  {language === 'zh' ? 'AI 分析' : 'Analyze with AI'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setIsActionsMenuOpen(false);
+                    toggleReleaseSubscription(repository.id);
+                  }}
+                  className="ui-menu-item w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm"
+                >
+                  {isSubscribed ? <Bell className="w-3.5 h-3.5" /> : <BellOff className="w-3.5 h-3.5" />}
+                  {isSubscribed ? (language === 'zh' ? '取消订阅 Release' : 'Unsubscribe from releases') : (language === 'zh' ? '订阅 Release' : 'Subscribe to releases')}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setIsActionsMenuOpen(false);
+                    setEditModalOpen(true);
+                  }}
+                  className="ui-menu-item w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm"
+                >
+                  <Edit3 className="w-3.5 h-3.5" />
+                  {language === 'zh' ? '编辑仓库信息' : 'Edit repository info'}
+                </button>
+                <div className="my-1 border-t ui-divider" />
+                <a
+                  href={language === 'zh' ? getZreadUrl(repository.full_name) : getDeepWikiUrl(repository.html_url)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() => setIsActionsMenuOpen(false)}
+                  className="ui-menu-item flex items-center gap-2 rounded-md px-2 py-1.5 text-sm"
+                >
+                  <BookOpen className="w-3.5 h-3.5" />
+                  {language === 'zh' ? '在 Zread 中查看' : 'View on DeepWiki'}
+                </a>
+                <a
+                  href={repository.html_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() => setIsActionsMenuOpen(false)}
+                  className="ui-menu-item flex items-center gap-2 rounded-md px-2 py-1.5 text-sm"
+                >
+                  <ExternalLink className="w-3.5 h-3.5" />
+                  {language === 'zh' ? '在 GitHub 中查看' : 'View on GitHub'}
+                </a>
+                <div className="my-1 border-t ui-divider" />
+                <button
+                  type="button"
+                  onClick={() => {
+                    setIsActionsMenuOpen(false);
+                    void handleUnstar();
+                  }}
+                  disabled={unstarring}
+                  className="ui-menu-item w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-status-red disabled:opacity-50"
+                >
+                  <StarOff className={`w-3.5 h-3.5 ${unstarring ? 'animate-pulse' : ''}`} />
+                  {language === 'zh' ? '取消 Star' : 'Unstar'}
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+
+        {viewMode === 'grid' && !selectionMode && (
           <div className="hidden lg:block relative flex-shrink-0 mt-[-4px] opacity-0 hover:opacity-100 transition-opacity duration-200 group-hover:opacity-100">
             <div
               ref={dragHandleRef}
@@ -946,6 +1081,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
       </div>
 
       {/* Action Buttons Row - Left and Right Aligned */}
+      {viewMode === 'grid' && (
       <div className="flex items-center justify-between mb-4">
         {/* Left side: AI Analysis, Release Subscription, and Edit */}
         <div className="flex items-center gap-1.5">
@@ -1018,9 +1154,10 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
           </SelectionAwareButton>
         </div>
       </div>
+      )}
 
       {/* Description with Tooltip */}
-      <div className="mb-4 flex-1">
+      <div className={viewMode === 'list' ? 'mt-1.5' : 'mb-4 flex-1'}>
         <div
           ref={descTriggerRef}
           className="relative group"
@@ -1032,7 +1169,9 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
           tabIndex={0}
         >
           <p
-            className="text-gray-800 dark:text-text-secondary text-[13px] leading-[1.625] line-clamp-3 mb-2 transition-colors duration-200 hover:text-gray-900 dark:hover:text-text-primary rounded-md px-1 -mx-1 hover:bg-light-surface dark:hover:bg-white/[0.02]"
+            className={viewMode === 'list'
+              ? 'text-gray-700 dark:text-text-secondary text-[13px] leading-5 line-clamp-1 transition-colors duration-200 hover:text-gray-900 dark:hover:text-text-primary'
+              : 'text-gray-800 dark:text-text-secondary text-[13px] leading-[1.625] line-clamp-3 mb-2 transition-colors duration-200 hover:text-gray-900 dark:hover:text-text-primary rounded-md px-1 -mx-1 hover:bg-light-surface dark:hover:bg-white/[0.02]'}
           >
             {highlightSearchTerm(displayContent.content, searchQuery)}
           </p>
@@ -1046,6 +1185,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
         </div>
 
         {/* 方案一：同时显示多个状态标签 */}
+        {viewMode === 'grid' && (
         <div className="flex items-center space-x-2 flex-wrap gap-y-1">
           {/* 已自定义标签 - 与筛选器逻辑一致 */}
           {displayContent.isCustomized && (
@@ -1079,15 +1219,16 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
             </div>
           ) : null}
         </div>
+        )}
       </div>
 
       {/* Tags - 未AI分析时显示Topics，AI分析后显示AI标签 */}
       {displayTags.tags.length > 0 && (
-        <div className="flex flex-wrap gap-2 mb-4">
+        <div className={`flex flex-wrap ${viewMode === 'list' ? 'gap-1 mt-1.5' : 'gap-2 mb-4'}`}>
           {displayTags.tags.map((tagItem, index) => (
             <span
               key={`tag-${index}`}
-              className="linear-card-tag px-2 py-1 text-xs font-medium"
+              className={`linear-card-tag font-medium ${viewMode === 'list' ? 'px-1.5 py-0.5 text-[11px]' : 'px-2 py-1 text-xs'}`}
             >
               {highlightSearchTerm(tagItem.tag, searchQuery)}
             </span>
@@ -1096,7 +1237,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
       )}
 
       {/* Platform Icons */}
-      {repository.ai_platforms && repository.ai_platforms.length > 0 && (
+      {viewMode === 'grid' && repository.ai_platforms && repository.ai_platforms.length > 0 && (
         <div className="flex items-center space-x-2 mb-4">
           <span className="text-xs text-gray-700 dark:text-text-secondary">
             {language === 'zh' ? '支持平台:' : 'Platforms:'}
@@ -1121,9 +1262,9 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
       )}
 
       {/* Stats */}
-      <div className="space-y-3 mt-auto">
+      <div className={viewMode === 'list' ? 'mt-1.5' : 'space-y-3 mt-auto'}>
         {/* Language and Stars */}
-        <div className="flex items-center space-x-4 text-xs text-gray-700 dark:text-text-secondary">
+        <div className={`flex items-center ${viewMode === 'list' ? 'space-x-3 flex-wrap gap-y-1' : 'space-x-4'} text-xs text-gray-700 dark:text-text-secondary`}>
           {repository.language && (
             <div className="flex items-center space-x-1 min-w-0">
               <div
@@ -1137,6 +1278,12 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
             <Star className="w-3.5 h-3.5" />
             <span className="truncate max-w-16">{formatNumber(repository.stargazers_count)}</span>
           </div>
+          {viewMode === 'list' && repository.ai_platforms && repository.ai_platforms.length > 0 && (
+            <div className="hidden lg:flex items-center space-x-1 min-w-0">
+              <Terminal className="w-3.5 h-3.5 flex-shrink-0" />
+              <span className="truncate max-w-40">{repository.ai_platforms.slice(0, 3).map(getPlatformDisplayName).join(' · ')}</span>
+            </div>
+          )}
           {(() => {
             // license：归一化后展示 SPDX id；无 license 不渲染
             const lic = normalizeLicense(repository.license);
@@ -1151,14 +1298,14 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
         </div>
 
         {/* Update Time / 查找相似仓库 - 悬停时时间淡出，显示高亮按钮 */}
-        <div className="flex items-center justify-between text-sm text-gray-700 dark:text-text-secondary pt-2 border-t ui-divider">
+        <div className={`flex items-center justify-between text-gray-700 dark:text-text-secondary pt-2 border-t ui-divider ${viewMode === 'list' ? 'text-xs mt-1.5' : 'text-sm'}`}>
           <div className="relative flex items-center space-x-1 min-w-0">
             <Calendar className={`w-4 h-4 flex-shrink-0 transition-opacity duration-150 ${vectorSearchAvailable && !selectionMode ? 'group-hover:opacity-0' : ''}`} />
             <span className={`truncate transition-opacity duration-150 ${vectorSearchAvailable && !selectionMode ? 'group-hover:opacity-0' : ''}`}>
               {language === 'zh' ? '最近提交' : 'Last pushed'} {formatDistanceToNow(new Date(repository.pushed_at || repository.updated_at), { addSuffix: true })}
             </span>
 
-            {vectorSearchAvailable && !selectionMode && (
+            {viewMode === 'grid' && vectorSearchAvailable && !selectionMode && (
               <button
                 onClick={(e) => {
                   e.stopPropagation();
@@ -1173,6 +1320,21 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
               </button>
             )}
           </div>
+
+          {viewMode === 'list' && vectorSearchAvailable && !selectionMode && (
+            <button
+              onClick={(event) => {
+                event.stopPropagation();
+                handleFindSimilar();
+              }}
+              disabled={isFindingSimilar}
+              className="flex items-center space-x-1 text-brand-violet dark:text-brand-violet font-medium hover:underline disabled:cursor-not-allowed disabled:hover:no-underline"
+              title={language === 'zh' ? '查找相似仓库' : 'Find similar repositories'}
+            >
+              {isFindingSimilar ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Search className="w-3.5 h-3.5" />}
+              <span>{language === 'zh' ? '查找同类' : 'Find similar'}</span>
+            </button>
+          )}
 
           {/* 选择按钮 */}
           {onSelect && (
@@ -1253,6 +1415,7 @@ export const RepositoryCard = React.memo(RepositoryCardComponent, (prevProps, ne
     prevProps.isSelected === nextProps.isSelected &&
     prevProps.selectionMode === nextProps.selectionMode &&
     prevProps.isExitingSelection === nextProps.isExitingSelection &&
+    prevProps.viewMode === nextProps.viewMode &&
     allCategoriesEqual
   );
 });

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -182,12 +182,35 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
 
   const [isFindingSimilar, setIsFindingSimilar] = useState(false);
   const [isActionsMenuOpen, setIsActionsMenuOpen] = useState(false);
+  const actionsMenuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (viewMode !== 'list' || selectionMode) {
       setIsActionsMenuOpen(false);
     }
   }, [viewMode, selectionMode]);
+
+  useEffect(() => {
+    if (!isActionsMenuOpen) return;
+
+    const handleDocumentClick = (event: MouseEvent) => {
+      if (!actionsMenuRef.current?.contains(event.target as Node)) {
+        setIsActionsMenuOpen(false);
+      }
+    };
+    const handleDocumentKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsActionsMenuOpen(false);
+      }
+    };
+
+    document.addEventListener('click', handleDocumentClick);
+    document.addEventListener('keydown', handleDocumentKeyDown);
+    return () => {
+      document.removeEventListener('click', handleDocumentClick);
+      document.removeEventListener('keydown', handleDocumentKeyDown);
+    };
+  }, [isActionsMenuOpen]);
 
   // 高亮搜索关键词的工具函数 - 使用缓存优化
   const highlightSearchTerm = useCallback((text: string, searchTerm: string): React.ReactNode => {
@@ -827,6 +850,12 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
     // 如果点击的是交互元素，不处理
     if (isInteractiveElement) return;
 
+    // 菜单展开时，点击卡片空白处仅收起菜单，不触发详情或选择。
+    if (isActionsMenuOpen) {
+      setIsActionsMenuOpen(false);
+      return;
+    }
+
     // 如果选择模式下，点击卡片切换选择状态
     if (selectionMode && onSelect) {
       // 阻止默认行为以防止焦点改变导致页面滚动
@@ -846,7 +875,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
     // 打开 README 模态框前隐藏描述悬浮提示，避免遮挡预览层
     hideDescriptionTooltip();
     setReadmeModalOpen(true);
-  }, [selectionMode, onSelect, repository.id, hideDescriptionTooltip]);
+  }, [selectionMode, onSelect, repository.id, hideDescriptionTooltip, isActionsMenuOpen]);
 
   // 处理鼠标按下事件，阻止焦点变化导致页面滚动
   const handleMouseDown = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
@@ -882,7 +911,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
   // 使用 useMemo 缓存卡片类名，避免重复计算
   const cardClassName = useMemo(() => {
     const baseClasses = viewMode === 'list'
-      ? 'repository-card repository-card--list ui-card group relative px-6 py-5 transition-all duration-200 cursor-pointer select-none'
+      ? 'repository-card repository-card--list ui-card group relative px-6 pt-5 pb-0 transition-all duration-200 cursor-pointer select-none'
       : 'repository-card ui-card group p-5 transition-all duration-200 flex flex-col h-full cursor-pointer select-none';
     const selectedClasses = isSelected
       ? 'linear-card-selected'
@@ -956,7 +985,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
         )}
 
         {viewMode === 'list' && !selectionMode && (
-          <div className="relative flex-shrink-0">
+          <div ref={actionsMenuRef} className="relative flex-shrink-0">
             <button
               type="button"
               onClick={(event) => {
@@ -1237,7 +1266,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
       </div>
 
       {/* List mode keeps tags and repository metadata on one wrapping information row. */}
-      <div className={viewMode === 'list' ? 'flex flex-wrap items-center gap-x-3 gap-y-2 mb-5' : 'contents'}>
+      <div className={viewMode === 'list' ? 'flex flex-wrap items-center gap-x-3 gap-y-2' : 'contents'}>
       {/* Tags - 未AI分析时显示Topics，AI分析后显示AI标签 */}
       {displayTags.tags.length > 0 && (
         <div className={`flex flex-wrap ${viewMode === 'list' ? 'gap-1' : 'gap-2 mb-4'}`}>
@@ -1313,8 +1342,9 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
           })()}
         </div>
 
-        {/* Update Time / 查找相似仓库 - 悬停时时间淡出，显示高亮按钮 */}
-        <div className={`flex items-center justify-between text-gray-700 dark:text-text-secondary border-t ui-divider ${viewMode === 'list' ? 'w-full mt-2 py-1 min-h-8 text-sm leading-5' : 'pt-2 text-sm'}`}>
+        {/* Update time is a compact footer in list mode and stays centered between divider and card edge. */}
+        <div className={viewMode === 'list' ? 'basis-full flex-none' : 'contents'}>
+        <div className={`flex items-center justify-between text-gray-700 dark:text-text-secondary border-t ui-divider ${viewMode === 'list' ? 'w-full h-14 mt-4 text-sm leading-5' : 'pt-2 text-sm'}`}>
           <div className="relative flex min-w-0 items-center gap-1.5 leading-none">
             <Calendar className={`w-4 h-4 flex-shrink-0 transition-opacity duration-150 ${viewMode === 'grid' && vectorSearchAvailable && !selectionMode ? 'group-hover:opacity-0' : ''}`} />
             <span className={`truncate transition-opacity duration-150 ${viewMode === 'grid' && vectorSearchAvailable && !selectionMode ? 'group-hover:opacity-0' : ''}`}>
@@ -1356,6 +1386,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
               {isSelected ? <CheckSquare className="w-5 h-5" /> : <Square className="w-5 h-5" />}
             </button>
           )}
+        </div>
         </div>
       </div>
       </div>

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -1001,6 +1001,20 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
                   {isSubscribed ? <Bell className="w-3.5 h-3.5" /> : <BellOff className="w-3.5 h-3.5" />}
                   {isSubscribed ? (language === 'zh' ? '取消订阅 Release' : 'Unsubscribe from releases') : (language === 'zh' ? '订阅 Release' : 'Subscribe to releases')}
                 </button>
+                {vectorSearchAvailable && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setIsActionsMenuOpen(false);
+                      handleFindSimilar();
+                    }}
+                    disabled={isFindingSimilar}
+                    className="ui-menu-item w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm disabled:opacity-50"
+                  >
+                    {isFindingSimilar ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Search className="w-3.5 h-3.5" />}
+                    {language === 'zh' ? '查找同类仓库' : 'Find similar repositories'}
+                  </button>
+                )}
                 <div className="my-1 border-t ui-divider" />
                 <a
                   href={language === 'zh' ? getZreadUrl(repository.full_name) : getDeepWikiUrl(repository.html_url)}
@@ -1180,6 +1194,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
             triggerRef={descTriggerRef}
             onMouseEnter={() => { if (tooltipHideTimerRef.current) clearTimeout(tooltipHideTimerRef.current); }}
             onMouseLeave={() => { tooltipHideTimerRef.current = setTimeout(() => setShowTooltip(false), 150); }}
+            widthRatio={viewMode === 'list' ? 0.5 : 1}
           />
         </div>
 
@@ -1221,9 +1236,11 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
         )}
       </div>
 
+      {/* List mode keeps tags and repository metadata on one wrapping information row. */}
+      <div className={viewMode === 'list' ? 'flex flex-wrap items-center gap-x-3 gap-y-2 mb-5' : 'contents'}>
       {/* Tags - 未AI分析时显示Topics，AI分析后显示AI标签 */}
       {displayTags.tags.length > 0 && (
-        <div className={`flex flex-wrap ${viewMode === 'list' ? 'gap-1 mb-3' : 'gap-2 mb-4'}`}>
+        <div className={`flex flex-wrap ${viewMode === 'list' ? 'gap-1' : 'gap-2 mb-4'}`}>
           {displayTags.tags.map((tagItem, index) => (
             <span
               key={`tag-${index}`}
@@ -1261,7 +1278,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
       )}
 
       {/* Stats */}
-      <div className={viewMode === 'list' ? 'mb-3' : 'space-y-3 mt-auto'}>
+      <div className={viewMode === 'list' ? 'contents' : 'space-y-3 mt-auto'}>
         {/* Language and Stars */}
         <div className={`flex items-center ${viewMode === 'list' ? 'space-x-3 flex-wrap gap-y-1' : 'space-x-4'} text-xs text-gray-700 dark:text-text-secondary`}>
           {repository.language && (
@@ -1297,8 +1314,8 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
         </div>
 
         {/* Update Time / 查找相似仓库 - 悬停时时间淡出，显示高亮按钮 */}
-        <div className={`flex items-center justify-between text-gray-700 dark:text-text-secondary border-t ui-divider ${viewMode === 'list' ? 'pt-3 text-sm' : 'pt-2 text-sm'}`}>
-          <div className="relative flex items-center space-x-1 min-w-0">
+        <div className={`flex items-center justify-between text-gray-700 dark:text-text-secondary border-t ui-divider ${viewMode === 'list' ? 'w-full mt-2 py-1 min-h-8 text-sm leading-5' : 'pt-2 text-sm'}`}>
+          <div className="relative flex min-w-0 items-center gap-1.5 leading-none">
             <Calendar className={`w-4 h-4 flex-shrink-0 transition-opacity duration-150 ${viewMode === 'grid' && vectorSearchAvailable && !selectionMode ? 'group-hover:opacity-0' : ''}`} />
             <span className={`truncate transition-opacity duration-150 ${viewMode === 'grid' && vectorSearchAvailable && !selectionMode ? 'group-hover:opacity-0' : ''}`}>
               {language === 'zh' ? '最近提交' : 'Last pushed'} {formatDistanceToNow(new Date(repository.pushed_at || repository.updated_at), { addSuffix: true })}
@@ -1320,20 +1337,6 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
             )}
           </div>
 
-          {viewMode === 'list' && vectorSearchAvailable && !selectionMode && (
-            <button
-              onClick={(event) => {
-                event.stopPropagation();
-                handleFindSimilar();
-              }}
-              disabled={isFindingSimilar}
-              className="flex items-center space-x-1 text-brand-violet dark:text-brand-violet font-medium hover:underline disabled:cursor-not-allowed disabled:hover:no-underline"
-              title={language === 'zh' ? '查找相似仓库' : 'Find similar repositories'}
-            >
-              {isFindingSimilar ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Search className="w-3.5 h-3.5" />}
-              <span>{language === 'zh' ? '查找同类' : 'Find similar'}</span>
-            </button>
-          )}
 
           {/* 选择按钮 */}
           {onSelect && (
@@ -1343,7 +1346,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
                 e.stopPropagation();
                 onSelect(repository.id);
               }}
-              className={`flex items-center justify-center w-8 h-8 rounded-lg transition-colors ${
+              className={`flex items-center justify-center w-7 h-7 rounded-md transition-colors ${
                 isSelected
                   ? 'bg-gray-200 text-gray-900 dark:bg-white/[0.08] dark:text-text-primary'
                   : 'text-gray-400 dark:text-text-tertiary hover:bg-light-surface dark:hover:bg-white/10'
@@ -1354,6 +1357,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
             </button>
           )}
         </div>
+      </div>
       </div>
 
       {/* Repository Edit Modal - Using portal to render outside card container */}

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -1300,8 +1300,8 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
         {/* Update Time / 查找相似仓库 - 悬停时时间淡出，显示高亮按钮 */}
         <div className={`flex items-center justify-between text-gray-700 dark:text-text-secondary pt-2 border-t ui-divider ${viewMode === 'list' ? 'text-xs mt-1.5' : 'text-sm'}`}>
           <div className="relative flex items-center space-x-1 min-w-0">
-            <Calendar className={`w-4 h-4 flex-shrink-0 transition-opacity duration-150 ${vectorSearchAvailable && !selectionMode ? 'group-hover:opacity-0' : ''}`} />
-            <span className={`truncate transition-opacity duration-150 ${vectorSearchAvailable && !selectionMode ? 'group-hover:opacity-0' : ''}`}>
+            <Calendar className={`w-4 h-4 flex-shrink-0 transition-opacity duration-150 ${viewMode === 'grid' && vectorSearchAvailable && !selectionMode ? 'group-hover:opacity-0' : ''}`} />
+            <span className={`truncate transition-opacity duration-150 ${viewMode === 'grid' && vectorSearchAvailable && !selectionMode ? 'group-hover:opacity-0' : ''}`}>
               {language === 'zh' ? '最近提交' : 'Last pushed'} {formatDistanceToNow(new Date(repository.pushed_at || repository.updated_at), { addSuffix: true })}
             </span>
 

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -1343,7 +1343,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
         </div>
 
         {/* Update time is a compact footer in list mode and stays centered between divider and card edge. */}
-        <div className={viewMode === 'list' ? 'basis-full flex-none' : 'contents'}>
+        <div className={viewMode === 'list' ? 'basis-full flex-none' : 'mt-4'}>
         <div className={`flex items-center justify-between text-gray-700 dark:text-text-secondary border-t ui-divider ${viewMode === 'list' ? 'w-full h-14 mt-4 text-sm leading-5' : 'pt-2 text-sm'}`}>
           <div className="relative flex min-w-0 items-center gap-1.5 leading-none">
             <Calendar className={`w-4 h-4 flex-shrink-0 transition-opacity duration-150 ${viewMode === 'grid' && vectorSearchAvailable && !selectionMode ? 'group-hover:opacity-0' : ''}`} />

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -882,7 +882,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
   // 使用 useMemo 缓存卡片类名，避免重复计算
   const cardClassName = useMemo(() => {
     const baseClasses = viewMode === 'list'
-      ? 'repository-card repository-card--list ui-card group relative px-4 py-3 transition-all duration-200 cursor-pointer select-none'
+      ? 'repository-card repository-card--list ui-card group relative px-6 py-5 transition-all duration-200 cursor-pointer select-none'
       : 'repository-card ui-card group p-5 transition-all duration-200 flex flex-col h-full cursor-pointer select-none';
     const selectedClasses = isSelected
       ? 'linear-card-selected'
@@ -904,14 +904,14 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
       aria-disabled={isModalOpen}
     >
       {/* Header - Repository Info */}
-      <div className={`flex items-start space-x-3 ${viewMode === 'list' ? 'mb-0' : 'mb-3'}`}>
+      <div className="flex items-start space-x-3 mb-3">
         <img
           src={repository.owner.avatar_url}
           alt={repository.owner.login}
-          className="w-8 h-8 rounded-full flex-shrink-0"
+          className={`${viewMode === 'list' ? 'w-10 h-10' : 'w-8 h-8'} rounded-full flex-shrink-0`}
         />
         <div className="min-w-0 flex-1">
-          <h3 className="font-semibold text-gray-900 dark:text-text-primary truncate">
+          <h3 className={`${viewMode === 'list' ? 'text-base' : ''} font-semibold text-gray-900 dark:text-text-primary truncate`}>
             {highlightSearchTerm(repository.name, searchQuery)}
           </h3>
           <p className="text-sm text-gray-500 dark:text-text-secondary truncate">
@@ -938,13 +938,20 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
                 {language === 'zh' ? '待分析' : 'Not analyzed'}
               </span>
             )}
-            {isSubscribed && (
-              <span className="hidden sm:inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[11px] font-medium bg-status-emerald/10 text-status-emerald">
-                <Bell className="w-3 h-3" />
-                Release
-              </span>
+            {!selectionMode && (
+              <button
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  setEditModalOpen(true);
+                }}
+                className="linear-icon-button flex h-8 w-8 items-center justify-center text-status-amber"
+                title={displayContent.isCustomized ? (language === 'zh' ? '已自定义，编辑仓库信息' : 'Customized, edit repository info') : (language === 'zh' ? '编辑仓库信息' : 'Edit repository info')}
+                aria-label={language === 'zh' ? '编辑仓库信息' : 'Edit repository info'}
+              >
+                <Edit3 className="w-4 h-4" />
+              </button>
             )}
-            {displayContent.isCustomized && <Edit3 className="w-3.5 h-3.5 text-status-amber" title={language === 'zh' ? '已自定义' : 'Customized'} />}
           </div>
         )}
 
@@ -993,17 +1000,6 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
                 >
                   {isSubscribed ? <Bell className="w-3.5 h-3.5" /> : <BellOff className="w-3.5 h-3.5" />}
                   {isSubscribed ? (language === 'zh' ? '取消订阅 Release' : 'Unsubscribe from releases') : (language === 'zh' ? '订阅 Release' : 'Subscribe to releases')}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setIsActionsMenuOpen(false);
-                    setEditModalOpen(true);
-                  }}
-                  className="ui-menu-item w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm"
-                >
-                  <Edit3 className="w-3.5 h-3.5" />
-                  {language === 'zh' ? '编辑仓库信息' : 'Edit repository info'}
                 </button>
                 <div className="my-1 border-t ui-divider" />
                 <a
@@ -1160,7 +1156,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
       )}
 
       {/* Description with Tooltip */}
-      <div className={viewMode === 'list' ? 'mt-1.5' : 'mb-4 flex-1'}>
+      <div className={viewMode === 'list' ? 'mb-3' : 'mb-4 flex-1'}>
         <div
           ref={descTriggerRef}
           className="relative group"
@@ -1173,7 +1169,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
         >
           <p
             className={viewMode === 'list'
-              ? 'text-gray-700 dark:text-text-secondary text-[13px] leading-5 line-clamp-1 transition-colors duration-200 hover:text-gray-900 dark:hover:text-text-primary'
+              ? 'text-sm leading-6 text-gray-700 dark:text-text-secondary line-clamp-2 transition-colors duration-200 hover:text-gray-900 dark:hover:text-text-primary'
               : 'text-gray-800 dark:text-text-secondary text-[13px] leading-[1.625] line-clamp-3 mb-2 transition-colors duration-200 hover:text-gray-900 dark:hover:text-text-primary rounded-md px-1 -mx-1 hover:bg-light-surface dark:hover:bg-white/[0.02]'}
           >
             {highlightSearchTerm(displayContent.content, searchQuery)}
@@ -1227,7 +1223,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
 
       {/* Tags - 未AI分析时显示Topics，AI分析后显示AI标签 */}
       {displayTags.tags.length > 0 && (
-        <div className={`flex flex-wrap ${viewMode === 'list' ? 'gap-1 mt-1.5' : 'gap-2 mb-4'}`}>
+        <div className={`flex flex-wrap ${viewMode === 'list' ? 'gap-1 mb-3' : 'gap-2 mb-4'}`}>
           {displayTags.tags.map((tagItem, index) => (
             <span
               key={`tag-${index}`}
@@ -1265,7 +1261,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
       )}
 
       {/* Stats */}
-      <div className={viewMode === 'list' ? 'mt-1.5' : 'space-y-3 mt-auto'}>
+      <div className={viewMode === 'list' ? 'mb-3' : 'space-y-3 mt-auto'}>
         {/* Language and Stars */}
         <div className={`flex items-center ${viewMode === 'list' ? 'space-x-3 flex-wrap gap-y-1' : 'space-x-4'} text-xs text-gray-700 dark:text-text-secondary`}>
           {repository.language && (
@@ -1282,7 +1278,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
             <span className="truncate max-w-16">{formatNumber(repository.stargazers_count)}</span>
           </div>
           {viewMode === 'list' && repository.ai_platforms && repository.ai_platforms.length > 0 && (
-            <div className="hidden lg:flex items-center space-x-1 min-w-0">
+            <div className="flex items-center space-x-1 min-w-0">
               <Terminal className="w-3.5 h-3.5 flex-shrink-0" />
               <span className="truncate max-w-40">{repository.ai_platforms.slice(0, 3).map(getPlatformDisplayName).join(' · ')}</span>
             </div>
@@ -1301,7 +1297,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
         </div>
 
         {/* Update Time / 查找相似仓库 - 悬停时时间淡出，显示高亮按钮 */}
-        <div className={`flex items-center justify-between text-gray-700 dark:text-text-secondary pt-2 border-t ui-divider ${viewMode === 'list' ? 'text-xs mt-1.5' : 'text-sm'}`}>
+        <div className={`flex items-center justify-between text-gray-700 dark:text-text-secondary border-t ui-divider ${viewMode === 'list' ? 'pt-3 text-sm' : 'pt-2 text-sm'}`}>
           <div className="relative flex items-center space-x-1 min-w-0">
             <Calendar className={`w-4 h-4 flex-shrink-0 transition-opacity duration-150 ${viewMode === 'grid' && vectorSearchAvailable && !selectionMode ? 'group-hover:opacity-0' : ''}`} />
             <span className={`truncate transition-opacity duration-150 ${viewMode === 'grid' && vectorSearchAvailable && !selectionMode ? 'group-hover:opacity-0' : ''}`}>

--- a/src/components/RepositoryList.test.tsx
+++ b/src/components/RepositoryList.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RepositoryList } from './RepositoryList';
+import { useAppStore } from '../store/useAppStore';
+import type { Repository } from '../types';
+
+vi.mock('../store/useAppStore', () => ({
+  useAppStore: vi.fn(),
+  getAllCategories: vi.fn(() => []),
+}));
+
+vi.mock('../hooks/useDialog', () => ({
+  useDialog: () => ({ toast: vi.fn(), confirm: vi.fn() }),
+}));
+
+vi.mock('./RepositoryCard', () => ({
+  RepositoryCard: ({ repository, viewMode }: { repository: Repository; viewMode: string }) => (
+    <div data-testid={`repository-card-${repository.id}`} data-view-mode={viewMode}>{repository.name}</div>
+  ),
+}));
+
+vi.mock('./SimilarViewBanner', () => ({ SimilarViewBanner: () => null }));
+vi.mock('./BulkActionToolbar', () => ({ BulkActionToolbar: () => null }));
+vi.mock('./BulkCategorizeModal', () => ({ BulkCategorizeModal: () => null }));
+vi.mock('./BulkRestoreModal', () => ({ BulkRestoreModal: () => null }));
+
+const repository: Repository = {
+  id: 1,
+  name: 'repository-one',
+  full_name: 'owner/repository-one',
+  description: 'Repository description',
+  html_url: 'https://github.com/owner/repository-one',
+  stargazers_count: 42,
+  forks_count: 0,
+  forks: 0,
+  language: 'TypeScript',
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-02T00:00:00.000Z',
+  pushed_at: '2026-01-03T00:00:00.000Z',
+  owner: { login: 'owner', avatar_url: 'https://example.com/avatar.png' },
+  topics: [],
+};
+
+const searchFilters = {
+  query: '',
+  tags: [],
+  languages: [],
+  platforms: [],
+  licenses: [],
+  sortBy: 'stars' as const,
+  sortOrder: 'desc' as const,
+};
+
+const storeState = {
+  githubToken: null,
+  aiConfigs: [],
+  activeAIConfig: null,
+  isLoading: false,
+  setLoading: vi.fn(),
+  updateRepository: vi.fn(),
+  deleteRepository: vi.fn(),
+  language: 'zh' as const,
+  customCategories: [],
+  hiddenDefaultCategoryIds: [],
+  defaultCategoryOverrides: {},
+  categoryMatchMode: 'effective' as const,
+  analysisProgress: { current: 0, total: 0 },
+  setAnalysisProgress: vi.fn(),
+  searchFilters,
+  toggleReleaseSubscription: vi.fn(),
+  batchUnsubscribeReleases: vi.fn(),
+  releaseSubscriptions: new Set<number>(),
+  similarView: null,
+  resetSimilarView: vi.fn(),
+  repositoryViewMode: 'grid' as 'grid' | 'list',
+  setRepositoryViewMode: vi.fn((mode: 'grid' | 'list') => {
+    storeState.repositoryViewMode = mode;
+  }),
+};
+
+const mockUseAppStore = vi.mocked(useAppStore);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  storeState.repositoryViewMode = 'grid';
+  mockUseAppStore.mockImplementation(() => storeState as ReturnType<typeof useAppStore>);
+  Object.assign(mockUseAppStore, {
+    getState: () => storeState,
+  });
+});
+
+describe('RepositoryList view mode controls', () => {
+  it('keeps the established grid as default and switches cards to the compact list mode', () => {
+    const { rerender } = render(<RepositoryList repositories={[repository]} selectedCategory="all" />);
+
+    const card = screen.getByTestId('repository-card-1');
+    expect(card).toHaveAttribute('data-view-mode', 'grid');
+    expect(screen.getByTitle('多列卡片')).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(screen.getByTitle('单列列表'));
+
+    expect(storeState.setRepositoryViewMode).toHaveBeenCalledWith('list');
+    rerender(<RepositoryList repositories={[repository]} selectedCategory="all" />);
+    expect(screen.getByTestId('repository-card-1')).toHaveAttribute('data-view-mode', 'list');
+    expect(screen.getByTitle('单列列表')).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/src/components/RepositoryList.test.tsx
+++ b/src/components/RepositoryList.test.tsx
@@ -98,6 +98,10 @@ describe('RepositoryList view mode controls', () => {
     expect(card).toHaveAttribute('data-view-mode', 'grid');
     expect(screen.getByTitle('多列卡片')).toHaveAttribute('aria-pressed', 'true');
 
+    const layoutControls = screen.getByRole('group', { name: '仓库布局' });
+    const toolbar = layoutControls.closest('.ui-toolbar');
+    expect(toolbar?.lastElementChild).toContainElement(layoutControls);
+
     fireEvent.click(screen.getByTitle('单列列表'));
 
     expect(storeState.setRepositoryViewMode).toHaveBeenCalledWith('list');

--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -1163,33 +1163,11 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
             </div>
           )}
 
-          {!isLoading && (
-            <div className="flex items-center gap-1 rounded-lg border border-black/[0.06] dark:border-white/[0.04] bg-light-surface dark:bg-white/[0.04] p-0.5" role="group" aria-label={t('仓库布局', 'Repository layout')}>
-              <button
-                type="button"
-                onClick={() => setRepositoryViewMode('grid')}
-                aria-pressed={repositoryViewMode === 'grid'}
-                className={`flex items-center justify-center w-8 h-7 rounded-md transition-colors ${repositoryViewMode === 'grid' ? 'bg-white dark:bg-white/[0.08] text-brand-violet shadow-sm' : 'text-gray-500 dark:text-text-tertiary hover:text-gray-900 dark:hover:text-text-primary'}`}
-                title={t('多列卡片', 'Grid view')}
-              >
-                <LayoutGrid className="w-4 h-4" />
-              </button>
-              <button
-                type="button"
-                onClick={() => setRepositoryViewMode('list')}
-                aria-pressed={repositoryViewMode === 'list'}
-                className={`flex items-center justify-center w-8 h-7 rounded-md transition-colors ${repositoryViewMode === 'list' ? 'bg-white dark:bg-white/[0.08] text-brand-violet shadow-sm' : 'text-gray-500 dark:text-text-tertiary hover:text-gray-900 dark:hover:text-text-primary'}`}
-                title={t('单列列表', 'List view')}
-              >
-                <List className="w-4 h-4" />
-              </button>
-            </div>
-          )}
         </div>
 
-        {/* Statistics */}
-        <div className={disableCardAnimations ? 'repository-list-syncing' : undefined}>
-          <div className="text-xs text-gray-500 dark:text-text-tertiary mt-0.5">
+        {/* Statistics and view mode: the layout switch remains at the toolbar's far right. */}
+        <div className={`ml-auto flex w-full flex-col items-end gap-2 sm:w-auto sm:flex-row sm:items-center sm:gap-3 ${disableCardAnimations ? 'repository-list-syncing' : ''}`}>
+          <div className="text-xs text-gray-500 dark:text-text-tertiary mt-0.5 sm:text-right">
             <div className="flex items-center justify-between">
               <div>
                 {t(
@@ -1221,6 +1199,31 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
               </div>
             </div>
           </div>
+
+          {!isLoading && (
+            <div className="flex shrink-0 items-center gap-1 rounded-lg border border-black/[0.06] bg-light-surface p-0.5 dark:border-white/[0.04] dark:bg-white/[0.04]" role="group" aria-label={t('仓库布局', 'Repository layout')}>
+              <button
+                type="button"
+                onClick={() => setRepositoryViewMode('grid')}
+                aria-pressed={repositoryViewMode === 'grid'}
+                aria-label={t('多列卡片', 'Grid view')}
+                className={`flex h-7 w-8 items-center justify-center rounded-md transition-colors ${repositoryViewMode === 'grid' ? 'bg-white text-brand-violet shadow-sm dark:bg-white/[0.08]' : 'text-gray-500 hover:text-gray-900 dark:text-text-tertiary dark:hover:text-text-primary'}`}
+                title={t('多列卡片', 'Grid view')}
+              >
+                <LayoutGrid className="w-4 h-4" />
+              </button>
+              <button
+                type="button"
+                onClick={() => setRepositoryViewMode('list')}
+                aria-pressed={repositoryViewMode === 'list'}
+                aria-label={t('单列列表', 'List view')}
+                className={`flex h-7 w-8 items-center justify-center rounded-md transition-colors ${repositoryViewMode === 'list' ? 'bg-white text-brand-violet shadow-sm dark:bg-white/[0.08]' : 'text-gray-500 hover:text-gray-900 dark:text-text-tertiary dark:hover:text-text-primary'}`}
+                title={t('单列列表', 'List view')}
+              >
+                <List className="w-4 h-4" />
+              </button>
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
-import { Bot, ChevronDown, Pause, Play } from 'lucide-react';
+import { Bot, ChevronDown, LayoutGrid, List, Pause, Play } from 'lucide-react';
 import { RepositoryCard } from './RepositoryCard';
 import { SimilarViewBanner } from './SimilarViewBanner';
 import { BulkActionToolbar } from './BulkActionToolbar';
@@ -44,7 +44,9 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
     batchUnsubscribeReleases,
     releaseSubscriptions,
     similarView,
-    resetSimilarView
+    resetSimilarView,
+    repositoryViewMode,
+    setRepositoryViewMode
   } = useAppStore();
 
   const { toast, confirm } = useDialog();
@@ -1160,6 +1162,29 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
               </div>
             </div>
           )}
+
+          {!isLoading && (
+            <div className="flex items-center gap-1 rounded-lg border border-black/[0.06] dark:border-white/[0.04] bg-light-surface dark:bg-white/[0.04] p-0.5" role="group" aria-label={t('仓库布局', 'Repository layout')}>
+              <button
+                type="button"
+                onClick={() => setRepositoryViewMode('grid')}
+                aria-pressed={repositoryViewMode === 'grid'}
+                className={`flex items-center justify-center w-8 h-7 rounded-md transition-colors ${repositoryViewMode === 'grid' ? 'bg-white dark:bg-white/[0.08] text-brand-violet shadow-sm' : 'text-gray-500 dark:text-text-tertiary hover:text-gray-900 dark:hover:text-text-primary'}`}
+                title={t('多列卡片', 'Grid view')}
+              >
+                <LayoutGrid className="w-4 h-4" />
+              </button>
+              <button
+                type="button"
+                onClick={() => setRepositoryViewMode('list')}
+                aria-pressed={repositoryViewMode === 'list'}
+                className={`flex items-center justify-center w-8 h-7 rounded-md transition-colors ${repositoryViewMode === 'list' ? 'bg-white dark:bg-white/[0.08] text-brand-violet shadow-sm' : 'text-gray-500 dark:text-text-tertiary hover:text-gray-900 dark:hover:text-text-primary'}`}
+                title={t('单列列表', 'List view')}
+              >
+                <List className="w-4 h-4" />
+              </button>
+            </div>
+          )}
         </div>
 
         {/* Statistics */}
@@ -1201,7 +1226,9 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
 
       {/* Repository Grid with consistent card widths */}
       <div
-        className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 min-h-[200px]"
+        className={repositoryViewMode === 'list'
+          ? 'space-y-2 min-h-[200px]'
+          : 'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 min-h-[200px]'}
         onClick={handleClick}
         onDoubleClick={handleDoubleClick}
       >
@@ -1216,6 +1243,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
             selectionMode={showBulkToolbar}
             isExitingSelection={isExitingSelection}
             allCategories={allCategories}
+            viewMode={repositoryViewMode}
           />
         ))}
       </div>

--- a/src/store/useAppStore.test.ts
+++ b/src/store/useAppStore.test.ts
@@ -418,3 +418,31 @@ describe('useAppStore auth localStorage mirror (Issue #259)', () => {
     expect(normalized.githubToken).toBe('ghp_persisted');
   });
 });
+
+describe('useAppStore repository view mode', () => {
+  beforeEach(() => {
+    useAppStore.setState({ repositoryViewMode: 'grid' });
+  });
+
+  it('keeps grid as the backwards-compatible default for persisted states without a view preference', () => {
+    const normalized = normalizePersistedState({}, useAppStore.getState());
+
+    expect(normalized.repositoryViewMode).toBe('grid');
+  });
+
+  it('restores the persisted list preference', () => {
+    const normalized = normalizePersistedState({ repositoryViewMode: 'list' }, useAppStore.getState());
+
+    expect(normalized.repositoryViewMode).toBe('list');
+  });
+
+  it('updates the repository view preference without changing repository records', () => {
+    const repositories = [createRepository(1)];
+    useAppStore.setState({ repositories, repositoryViewMode: 'grid' });
+
+    useAppStore.getState().setRepositoryViewMode('list');
+
+    expect(useAppStore.getState().repositoryViewMode).toBe('list');
+    expect(useAppStore.getState().repositories).toBe(repositories);
+  });
+});

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -461,6 +461,9 @@ interface AppActions {
   // RPC Download actions
   setRpcDownloadConfig: (updates: Partial<RpcDownloadConfig>) => void;
 
+  // Repository list view actions
+  setRepositoryViewMode: (mode: 'grid' | 'list') => void;
+
   // Release Timeline View actions
   setReleaseViewMode: (mode: 'timeline' | 'repository') => void;
   setReleaseShowMode: (mode: 'all' | 'unread') => void;
@@ -566,6 +569,7 @@ type PersistedAppState = Partial<
     | 'language'
     | 'searchFilters'
     | 'isSidebarCollapsed'
+    | 'repositoryViewMode'
     | 'forks'
     | 'forkViewMode'
     | 'forkSelectedFilters'
@@ -810,6 +814,7 @@ export const normalizePersistedState = (
     releases,
     searchResults: migratedRepositories,
     releaseSubscriptions: normalizeNumberSet(safePersisted.releaseSubscriptions),
+    repositoryViewMode: safePersisted.repositoryViewMode === 'list' ? 'list' : 'grid',
     releaseSourceSettings: normalizeReleaseSourceSettings(safePersisted.releaseSourceSettings),
     readReleases: normalizeNumberSet(safePersisted.readReleases),
     readForks: normalizeNumberSet(safePersisted.readForks),
@@ -1271,6 +1276,7 @@ export const useAppStore = create<AppState & AppActions>()(
       rpcDownloadConfig: { enabled: false, host: '', port: 6800 },
       isSidebarCollapsed: false,
       readmeModalOpen: false,
+      repositoryViewMode: 'grid',
       releaseViewMode: 'timeline',
       releaseShowMode: 'all',
       releaseLatestMode: 'all',
@@ -2138,6 +2144,9 @@ export const useAppStore = create<AppState & AppActions>()(
         rpcDownloadConfig: { ...state.rpcDownloadConfig, ...updates }
       })),
 
+      // Repository list view actions
+      setRepositoryViewMode: (repositoryViewMode) => set({ repositoryViewMode }),
+
       // Release Timeline View actions
       setReleaseViewMode: (releaseViewMode) => set({ releaseViewMode }),
       setReleaseShowMode: (releaseShowMode) => set({ releaseShowMode }),
@@ -2377,6 +2386,8 @@ export const useAppStore = create<AppState & AppActions>()(
           sortOrder: state.searchFilters.sortOrder,
         },
 
+        // 持久化仓库页面视图设置
+        repositoryViewMode: state.repositoryViewMode,
         // 持久化Release页面视图设置
         releaseViewMode: state.releaseViewMode,
         releaseShowMode: state.releaseShowMode,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -402,6 +402,7 @@ export interface AppState {
   isSyncingStars: boolean;
   lastSync: string | null;
   analyzingRepositoryIds: Set<number>;
+  repositoryViewMode: 'grid' | 'list';
 
   // Gists
   gists: Gist[];


### PR DESCRIPTION
## Summary

- Add a persisted grid/list view toggle to the repositories toolbar, keeping grid as the backwards-compatible default.
- Add a compact list card layout that preserves repository metadata, exposes similar-repository search, and moves existing card actions into an accessible more-actions menu.
- Keep the existing grid card actions and bulk-selection behavior unchanged.
- Add regression coverage for state hydration, view switching, compact action menus, and grid fallback.

## Validation

- `npm run test:run` (252 tests)
- `cd server && npm test` (86 tests)
- `npx eslint` on all changed source and test files
- `npm run build:all`

> Note: the repository-wide `npm run lint` still reports two pre-existing unused-variable errors in unchanged files: `server/src/mcp/provider.ts` and `src/services/electronProxy.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added grid and list layouts for repository browsing, with grid selected by default.
  * Added compact list cards with status badges, condensed metadata, editing, actions menus, and similar-repository search.
  * Preserved grid quick actions and detailed status information.
  * Remembered the selected layout between sessions.
  * Improved keyboard interactions for card actions and menus.
  * Improved tooltip sizing to fit available screen space.

* **Tests**
  * Added coverage for layout switching, persistence, accessibility, and view-specific actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->