### PR TITLE
fix: resolve lint and normalize persisted vector status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules
 dist
 
 dist-ssr
+*.tsbuildinfo
 *.local
 
 # Editor directories and files

--- a/server/src/mcp/provider.ts
+++ b/server/src/mcp/provider.ts
@@ -318,7 +318,7 @@ export async function vectorSearch(
   if (vs.auth_token_encrypted) {
     try {
       workerToken = decrypt(String(vs.auth_token_encrypted), config.encryptionKey);
-    } catch (err) {
+    } catch {
       logger.warn('mcp.vector', 'Failed to decrypt worker auth token');
       return { available: false, reason: 'worker_token_decrypt_failed' };
     }

--- a/src/components/RepositoryCard.test.tsx
+++ b/src/components/RepositoryCard.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -496,10 +496,8 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
         dimensions: activeConfig.dimensions,
       });
       const vectorService = new VectorSearchService({
-        enabled: true,
         workerUrl: vectorSearchConfig.workerUrl,
         authToken: vectorSearchConfig.authToken,
-        embeddingConfigId: activeEmbeddingConfig || '',
       });
 
       const similar = await findSimilarRepositories(repository, {

--- a/src/components/RepositoryList.test.tsx
+++ b/src/components/RepositoryList.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RepositoryList } from './RepositoryList';

--- a/src/components/SearchBar.test.tsx
+++ b/src/components/SearchBar.test.tsx
@@ -81,7 +81,7 @@ const createStoreState = (overrides: Partial<ReturnType<typeof baseStoreState>> 
 
 const baseStoreState = () => ({
   searchFilters: { ...defaultSearchFilters },
-  repositories: [],
+  repositories: [] as Repository[],
   releaseSubscriptions: new Set<number>(),
   aiConfigs: [],
   activeAIConfig: null,

--- a/src/components/settings/VectorSearchSettings.tsx
+++ b/src/components/settings/VectorSearchSettings.tsx
@@ -199,10 +199,8 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
     setWorkerTestResult(null);
     try {
       const service = new VectorSearchService({
-        enabled: true,
         workerUrl: formWorkerUrl,
         authToken: formAuthToken,
-        embeddingConfigId: '',
       });
       const result = await service.testConnection();
       setWorkerTestResult(result);
@@ -252,10 +250,8 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
       dimensions: formDimensions,
     });
     const vectorService = new VectorSearchService({
-      enabled: true,
       workerUrl: formWorkerUrl,
       authToken: formAuthToken,
-      embeddingConfigId: activeEmbeddingConfig || '',
     });
     // 复用单个 GitHubApiService 实例，保留 rate-limit state
     const githubApi = githubToken ? new GitHubApiService(githubToken) : null;
@@ -362,12 +358,13 @@ export const VectorSearchSettings: React.FC<VectorSearchSettingsProps> = ({ t })
     const controller = new AbortController();
     setAbortController(controller);
     setVectorIndexingState({ isIndexing: true, phase: null, phaseDone: 0, phaseTotal: 0, result: null });
+    let currentEmbeddingFormatVersion = LEGACY_EMBEDDING_FORMAT_VERSION;
 
     try {
       // 每次点击时读取最新的 repositories / vectorSearchConfig，避免闭包捕获过期数据
       const currentState = useAppStore.getState();
       const currentRepos = currentState.repositories;
-      const currentEmbeddingFormatVersion = isKnownEmbeddingFormatVersion(currentState.vectorSearchConfig.embeddingFormatVersion)
+      currentEmbeddingFormatVersion = isKnownEmbeddingFormatVersion(currentState.vectorSearchConfig.embeddingFormatVersion)
         ? currentState.vectorSearchConfig.embeddingFormatVersion
         : LEGACY_EMBEDDING_FORMAT_VERSION;
 

--- a/src/services/electronProxy.ts
+++ b/src/services/electronProxy.ts
@@ -2,7 +2,6 @@ import type {
   ProxyConfig,
   Repository,
   Category,
-  VectorSearchConfig,
   EmbeddingConfig,
   McpServiceConfig,
 } from '../types';

--- a/src/services/vectorSearchService.test.ts
+++ b/src/services/vectorSearchService.test.ts
@@ -13,7 +13,10 @@ import {
 // Signature mirrors EmbeddingClient.embed; helpers only pass the args they use.
 const makeClient = (
   embedImpl: (texts: string[]) => Promise<number[][]>,
-) => ({ embed: vi.fn(embedImpl) }) as unknown as Parameters<typeof embedWithFallback>[1];
+) => {
+  const embed = vi.fn(embedImpl);
+  return { embed } as Parameters<typeof embedWithFallback>[1] & { embed: typeof embed };
+};
 
 const vec = (n: number) => [n, n + 1, n + 2];
 

--- a/src/services/vectorSearchService.ts
+++ b/src/services/vectorSearchService.ts
@@ -214,11 +214,13 @@ export interface VectorizeStatus {
   indexName?: string;
 }
 
+type VectorSearchServiceConfig = Pick<VectorSearchConfig, 'workerUrl' | 'authToken'>;
+
 export class VectorSearchService {
   private workerUrl: string;
   private authToken: string;
 
-  constructor(config: VectorSearchConfig) {
+  constructor(config: VectorSearchServiceConfig) {
     this.workerUrl = config.workerUrl.replace(/\/+$/, '');
     this.authToken = config.authToken;
   }

--- a/src/store/useAppStore.test.ts
+++ b/src/store/useAppStore.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { EmbeddingConfig, Release, Repository, VectorSearchConfig, defaultReleaseSourceSettings } from '../types';
+import { EmbeddingConfig, Release, Repository, VectorSearchConfig, VectorSearchStatus, defaultReleaseSourceSettings } from '../types';
 import { EMBEDDING_FORMAT_VERSION, indexAllRepos } from '../services/vectorSearchService';
 import { CUSTOM_RELEASE_SOURCE_ID, createCustomReleaseRepository } from '../utils/releaseSources';
 
@@ -298,6 +298,44 @@ describe('useAppStore vector search config normalization', () => {
 
     expect(indexedIds).toEqual([3]);
     expect(result.indexedRepoIds).toEqual([3]);
+  });
+
+  it('sanitizes corrupt persisted vector search status before hydration', () => {
+    const normalized = normalizePersistedState({
+      vectorSearchStatus: {
+        connected: 'yes',
+        vectorCount: -1,
+        dimensions: Number.NaN,
+        lastSyncAt: 123,
+        error: { message: 'invalid' },
+      } as unknown as VectorSearchStatus,
+    }, useAppStore.getState());
+
+    expect(normalized.vectorSearchStatus).toEqual({
+      connected: false,
+      vectorCount: 0,
+      dimensions: 0,
+    });
+  });
+
+  it('preserves valid persisted vector search status during hydration', () => {
+    const normalized = normalizePersistedState({
+      vectorSearchStatus: {
+        connected: true,
+        vectorCount: 42,
+        dimensions: 1536,
+        lastSyncAt: '2026-08-15T00:00:00.000Z',
+        error: 'stale error',
+      },
+    }, useAppStore.getState());
+
+    expect(normalized.vectorSearchStatus).toEqual({
+      connected: true,
+      vectorCount: 42,
+      dimensions: 1536,
+      lastSyncAt: '2026-08-15T00:00:00.000Z',
+      error: 'stale error',
+    });
   });
 });
 

--- a/src/store/useAppStore.test.ts
+++ b/src/store/useAppStore.test.ts
@@ -318,6 +318,23 @@ describe('useAppStore vector search config normalization', () => {
     });
   });
 
+  it('omits invalid persisted vector search status timestamps during hydration', () => {
+    const normalized = normalizePersistedState({
+      vectorSearchStatus: {
+        connected: true,
+        vectorCount: 42,
+        dimensions: 1536,
+        lastSyncAt: 'not-a-date',
+      },
+    }, useAppStore.getState());
+
+    expect(normalized.vectorSearchStatus).toEqual({
+      connected: true,
+      vectorCount: 42,
+      dimensions: 1536,
+    });
+  });
+
   it('preserves valid persisted vector search status during hydration', () => {
     const normalized = normalizePersistedState({
       vectorSearchStatus: {

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -669,7 +669,9 @@ const normalizeVectorSearchStatus = (raw: unknown): VectorSearchStatus => {
     connected: status.connected === true,
     vectorCount,
     dimensions,
-    ...(typeof status.lastSyncAt === 'string' ? { lastSyncAt: status.lastSyncAt } : {}),
+    ...(typeof status.lastSyncAt === 'string' && Number.isFinite(Date.parse(status.lastSyncAt))
+      ? { lastSyncAt: status.lastSyncAt }
+      : {}),
     ...(typeof status.error === 'string' ? { error: status.error } : {}),
   };
 };

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -551,6 +551,10 @@ type PersistedAppState = Partial<
     | 'lastSync'
     | 'aiConfigs'
     | 'activeAIConfig'
+    | 'embeddingConfigs'
+    | 'activeEmbeddingConfig'
+    | 'vectorSearchConfig'
+    | 'vectorSearchStatus'
     | 'webdavConfigs'
     | 'activeWebDAVConfig'
     | 'lastBackup'
@@ -600,6 +604,7 @@ type PersistedAppState = Partial<
     | 'subscriptionIsLoading'
     | 'subscriptionChannels'
     | 'headerMenuConfig'
+    | 'mcpConfig'
   >
 > & {
   releaseSubscriptions?: unknown;
@@ -635,6 +640,38 @@ const defaultVectorSearchConfig: VectorSearchConfig = {
   enableHyDE: true,
   enableReranking: true,
   embeddingFormatVersion: EMBEDDING_FORMAT_VERSION,
+};
+
+const defaultVectorSearchStatus: VectorSearchStatus = {
+  connected: false,
+  vectorCount: 0,
+  dimensions: 0,
+};
+
+const normalizeVectorSearchStatus = (raw: unknown): VectorSearchStatus => {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ...defaultVectorSearchStatus };
+  }
+
+  const status = raw as Record<string, unknown>;
+  const vectorCount = typeof status.vectorCount === 'number'
+    && Number.isInteger(status.vectorCount)
+    && status.vectorCount >= 0
+    ? status.vectorCount
+    : defaultVectorSearchStatus.vectorCount;
+  const dimensions = typeof status.dimensions === 'number'
+    && Number.isInteger(status.dimensions)
+    && status.dimensions >= 0
+    ? status.dimensions
+    : defaultVectorSearchStatus.dimensions;
+
+  return {
+    connected: status.connected === true,
+    vectorCount,
+    dimensions,
+    ...(typeof status.lastSyncAt === 'string' ? { lastSyncAt: status.lastSyncAt } : {}),
+    ...(typeof status.error === 'string' ? { error: status.error } : {}),
+  };
 };
 
 export const defaultMcpConfig: McpServiceConfig = {
@@ -727,7 +764,7 @@ const mergeVectorSearchConfig = (
 ): VectorSearchConfig => {
   const currentVersion = isKnownEmbeddingFormatVersion(current.embeddingFormatVersion)
     ? current.embeddingFormatVersion
-    : defaultVectorSearchConfig.embeddingFormatVersion;
+    : EMBEDDING_FORMAT_VERSION;
   const patchVersion = patch.embeddingFormatVersion;
   const embeddingFormatVersion = isKnownEmbeddingFormatVersion(patchVersion)
     ? Math.max(currentVersion, patchVersion)
@@ -843,6 +880,9 @@ export const normalizePersistedState = (
     vectorSearchConfig: normalizeVectorSearchConfig(
       safePersisted.vectorSearchConfig,
       safePersisted.embeddingConfigs
+    ),
+    vectorSearchStatus: normalizeVectorSearchStatus(
+      safePersisted.vectorSearchStatus ?? currentState.vectorSearchStatus
     ),
 // Persist full mcpConfig including token so Agent configs stay stable across restarts
     // unless the user explicitly resets the token.
@@ -1244,7 +1284,7 @@ export const useAppStore = create<AppState & AppActions>()(
       embeddingConfigs: [],
       activeEmbeddingConfig: null,
       vectorSearchConfig: { ...defaultVectorSearchConfig },
-      vectorSearchStatus: { connected: false, vectorCount: 0, dimensions: 0 },
+      vectorSearchStatus: { ...defaultVectorSearchStatus },
       vectorIndexingState: { isIndexing: false, phase: null, phaseDone: 0, phaseTotal: 0, result: null },
       mcpConfig: { ...defaultMcpConfig },
       similarView: null,
@@ -1420,7 +1460,7 @@ export const useAppStore = create<AppState & AppActions>()(
           : applyPatches(state.searchResults);
         const similarResultsResult = state.similarView
           ? applyPatches(state.similarView.similarResults)
-          : { repositories: state.similarView?.similarResults ?? [], changed: false };
+          : { repositories: [], changed: false };
 
         if (!repositoriesResult.changed && !searchResultsResult.changed && !similarResultsResult.changed) {
           return state;
@@ -2468,9 +2508,8 @@ export const useAppStore = create<AppState & AppActions>()(
         }
 
         // 从旧版本升级时，确保 vectorSearchStatus 字段存在（vectorCount 等）
-        if (state && !state.vectorSearchStatus) {
-          console.log('Migrating from old version: initializing vectorSearchStatus');
-          state.vectorSearchStatus = { connected: false, vectorCount: 0, dimensions: 0 };
+        if (state) {
+          state.vectorSearchStatus = normalizeVectorSearchStatus(state.vectorSearchStatus);
         }
 
         // Additive: MCP config defaults when missing (upgrade). Old builds ignore this key on downgrade.


### PR DESCRIPTION
## Summary

This PR resolves the repository lint failures and related TypeScript safety issues discovered during validation and audit.

- Removes unused imports and exception bindings that failed ESLint.
- Aligns persisted app-state typing with the fields used by hydration, migration, and partial persistence.
- Narrows `VectorSearchService` construction to the Worker connection fields it actually consumes.
- Normalizes persisted vector-search status at runtime to prevent malformed IndexedDB data from overriding application state.
- Adds regression coverage for corrupt and valid persisted vector-search status.
- Ignores local TypeScript build-info artifacts.

## Validation

- `npm run lint`
- `npx tsc -b`
- `npm run test:run` — 23 test files / 257 tests passed
- `npm run build`
- `cd server && npm run build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Vector search status now persists reliably between sessions.
  * Invalid saved vector-search data is safely corrected without disrupting other settings.
  * Indexing progress and failure counts now reflect embedding format changes more accurately.
  * Similar-repository results no longer display fabricated entries when no matches are available.

* **Tests**
  * Added coverage for restoring valid vector-search settings and handling corrupted saved status data.

* **Chores**
  * Removed unused configuration and test code for improved maintainability.
  * Improved build artifact handling and type safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->