### PR TITLE
fix(release): 资产变更后重置已读状态并展示资产更新时间

### DIFF
--- a/src/components/ReleaseCard.tsx
+++ b/src/components/ReleaseCard.tsx
@@ -7,6 +7,7 @@ import { useAppStore } from '../store/useAppStore';
 import { useDialog } from '../hooks/useDialog';
 import { sendToRpcDownload } from '../services/rpcDownloadService';
 import { AIService } from '../services/aiService';
+import { effectiveReleaseTime } from '../utils/releaseAssets';
 
 type SummaryState = {
   status: 'idle' | 'loading' | 'done' | 'error';
@@ -60,6 +61,9 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
   formatFileSize,
 }) => {
   const t = useCallback((zh: string, en: string) => language === 'zh' ? zh : en, [language]);
+
+  const effectiveTime = effectiveReleaseTime(release);
+  const assetsUpdatedAfterPublish = effectiveTime > release.published_at;
 
   // RPC download support — use refs to avoid stale closure in async handler
   const { rpcDownloadConfig, backendApiSecret, aiConfigs, activeAIConfig } = useAppStore();
@@ -219,7 +223,12 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
             <div className="hidden md:flex min-w-[140px] flex-col justify-center gap-2 text-xs text-gray-500 dark:text-text-tertiary">
               <div className="flex items-center gap-1.5">
                 <Calendar className="w-3.5 h-3.5" />
-                <span>{formatDistanceToNow(new Date(release.published_at), { addSuffix: true })}</span>
+                <span>{formatDistanceToNow(new Date(effectiveTime), { addSuffix: true })}</span>
+                {assetsUpdatedAfterPublish && (
+                  <span className="text-[10px] px-1 py-px rounded bg-brand-violet/10 text-brand-violet font-medium">
+                    {t('资产已更新', 'Assets updated')}
+                  </span>
+                )}
               </div>
               {downloadLinks.length > 0 && (
                 <div className="flex items-center gap-1.5">

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -22,7 +22,7 @@ import {
   releaseBelongsToResolvedSources,
   resolveReleaseSources,
 } from '../utils/releaseSources';
-import { assetsFingerprint } from '../utils/releaseAssets';
+import { assetsFingerprint, effectiveReleaseTime } from '../utils/releaseAssets';
 
 export const ReleaseTimeline: React.FC = () => {
   const {
@@ -449,7 +449,7 @@ export const ReleaseTimeline: React.FC = () => {
       }
 
       // 只比每仓最新 1 条资产指纹：对已存在的最新 Release，若资产发生变化则按 id 合并更新，
-      // 保留已读状态（is_read 由 upsertReleases 合并逻辑保证）。
+      // 内容变化后由 upsertReleases 自动重置为未读（is_read=false 并从 readReleases 移除）。
       const currentReleases = useAppStore.getState().releases;
       const updatedReleases = (latestReleases || []).filter(latest => {
         const local = currentReleases.find(r => r.id === latest.id);
@@ -1234,6 +1234,8 @@ export const ReleaseTimeline: React.FC = () => {
           paginatedRepositoryGroups.map(({ repository, releases, latestRelease }) => {
             const isExpanded = expandedRepositories.has(repository.id);
             const hasUnread = releases.some(({ release }) => isReleaseUnread(release.id));
+            const latestEffectiveTime = latestRelease ? effectiveReleaseTime(latestRelease) : null;
+            const latestAssetsUpdated = latestEffectiveTime !== null && latestEffectiveTime > latestRelease.published_at;
 
             return (
               <div key={repository.id} className="ui-card overflow-hidden">
@@ -1268,8 +1270,13 @@ export const ReleaseTimeline: React.FC = () => {
                           <p className="text-xs text-gray-400 dark:text-text-tertiary truncate">
                             {t('最新:', 'Latest:')} {latestRelease.tag_name}
                           </p>
-                          <p className="text-xs text-gray-400 dark:text-text-quaternary whitespace-nowrap">
-                            {formatDistanceToNow(new Date(latestRelease.published_at), { addSuffix: true, locale: language === 'zh' ? zhCN : undefined })}
+                          <p className="text-xs text-gray-400 dark:text-text-quaternary whitespace-nowrap flex items-center gap-1">
+                            {formatDistanceToNow(new Date(latestEffectiveTime!), { addSuffix: true, locale: language === 'zh' ? zhCN : undefined })}
+                            {latestAssetsUpdated && (
+                              <span className="text-[10px] px-1 py-px rounded bg-brand-violet/10 text-brand-violet font-medium">
+                                {t('资产已更新', 'Assets updated')}
+                              </span>
+                            )}
                           </p>
                         </>
                       )}

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -103,7 +103,7 @@ export interface MultipleReleasesResult {
   releases: Release[];
   /**
    * 已同步仓库“最新一条”Release（仅当 refreshExistingAssets 开启时收集）。
-   * 用于调用方与本地存储做资产指纹比对，指纹变化则合并更新资产，保留 is_read。
+   * 用于调用方与本地存储做资产指纹比对，指纹变化则合并更新资产并重置为未读。
    */
   latestReleases?: Release[];
   failedRepos: { repoId: number; full_name: string; error: string }[];

--- a/src/store/useAppStore.test.ts
+++ b/src/store/useAppStore.test.ts
@@ -107,8 +107,9 @@ describe('useAppStore release add/upsert actions', () => {
     expect(useAppStore.getState().releases.map(r => r.id)).toEqual([1, 2, 3]);
   });
 
-  it('upsertReleases updates assets/metadata but preserves is_read', () => {
+  it('upsertReleases updates assets/metadata and resets read state', () => {
     useAppStore.getState().addReleases([makeRelease(1, { is_read: true })]);
+    useAppStore.getState().markReleaseAsRead(1);
 
     const updated = makeRelease(1, {
       name: 'Updated name',
@@ -119,7 +120,20 @@ describe('useAppStore release add/upsert actions', () => {
     const result = useAppStore.getState().releases[0];
     expect(result.name).toBe('Updated name');
     expect(result.assets[0].size).toBe(9999);
-    expect(result.is_read).toBe(true);
+    expect(result.is_read).toBe(false);
+    expect(useAppStore.getState().readReleases.has(1)).toBe(false);
+  });
+
+  it('upsertReleases keeps read state of unaffected releases', () => {
+    useAppStore.getState().addReleases([makeRelease(1), makeRelease(2)]);
+    useAppStore.getState().markReleaseAsRead(2);
+
+    useAppStore.getState().upsertReleases([makeRelease(1, {
+      assets: [{ ...makeRelease(1).assets[0], size: 8888 }],
+    })]);
+
+    expect(useAppStore.getState().readReleases.has(1)).toBe(false);
+    expect(useAppStore.getState().readReleases.has(2)).toBe(true);
   });
 
   it('upsertReleases ignores ids not present in store', () => {

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -390,7 +390,7 @@ interface AppActions {
   // Release actions
   setReleases: (releases: Release[]) => void;
   addReleases: (releases: Release[]) => void;
-  /** 按 id 合并更新已存在 Release 的资产/元数据，保留 is_read 等已读状态 */
+  /** 按 id 合并更新已存在 Release 的资产/元数据；内容变化后重置为未读（is_read=false 并从 readReleases 移除） */
   upsertReleases: (releases: Release[]) => void;
   toggleReleaseSubscription: (repoId: number) => void;
   batchUnsubscribeReleases: (repoIds: number[]) => void;
@@ -1737,16 +1737,21 @@ export const useAppStore = create<AppState & AppActions>()(
       }),
       upsertReleases: (updates) => set((state) => {
         const byId = new Map(updates.map(r => [r.id, r]));
+        const updatedIds = new Set<number>();
         const merged = state.releases.map(r => {
           const update = byId.get(r.id);
           if (!update) return r;
-          // 保留已读状态，仅覆盖资产与元数据字段
+          updatedIds.add(r.id);
+          // 内容已变化（资产等），重置为未读，让用户注意到本次更新
           return {
             ...update,
-            is_read: r.is_read,
+            is_read: false,
           };
         });
-        return { releases: merged };
+        const nextReadReleases = new Set(
+          Array.from(state.readReleases).filter(releaseId => !updatedIds.has(releaseId))
+        );
+        return { releases: merged, readReleases: nextReadReleases };
       }),
       toggleReleaseSubscription: (repoId) => set((state) => {
         const newSubscriptions = new Set(state.releaseSubscriptions);

--- a/src/utils/releaseAssets.test.ts
+++ b/src/utils/releaseAssets.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import type { ReleaseAsset } from '../types';
+import type { Release, ReleaseAsset } from '../types';
 import {
   assetFingerprint,
   assetsFingerprint,
+  effectiveReleaseTime,
   hasAssetsChanged,
 } from './releaseAssets';
 
@@ -88,5 +89,46 @@ describe('hasAssetsChanged', () => {
     const before = [makeAsset({ id: 1, download_count: 0 })];
     const after = [makeAsset({ id: 1, download_count: 12345 })];
     expect(hasAssetsChanged(before, after)).toBe(false);
+  });
+});
+
+describe('effectiveReleaseTime', () => {
+  const makeRelease = (overrides: Partial<Release> = {}): Release => ({
+    id: 1,
+    tag_name: 'v1',
+    name: 'Release 1',
+    body: null,
+    published_at: '2026-01-01T00:00:00.000Z',
+    html_url: 'https://github.com/owner/repo/releases/tag/v1',
+    assets: [],
+    repository: { id: 1, full_name: 'owner/repo', name: 'repo' },
+    ...overrides,
+  });
+
+  it('falls back to published_at when there are no assets', () => {
+    expect(effectiveReleaseTime(makeRelease())).toBe('2026-01-01T00:00:00.000Z');
+    expect(effectiveReleaseTime(makeRelease({ assets: undefined }))).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('normalizes timestamps without millisecond precision', () => {
+    const release = makeRelease({ published_at: '2026-01-01T00:00:00Z' });
+    expect(effectiveReleaseTime(release)).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('uses published_at when assets were updated at or before publish time', () => {
+    const release = makeRelease({
+      assets: [makeAsset({ updated_at: '2026-01-01T00:00:00.000Z' })],
+    });
+    expect(effectiveReleaseTime(release)).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('returns the latest asset updated_at when it is newer than published_at', () => {
+    const release = makeRelease({
+      assets: [
+        makeAsset({ id: 1, updated_at: '2026-01-05T00:00:00.000Z' }),
+        makeAsset({ id: 2, updated_at: '2026-01-10T00:00:00.000Z' }),
+      ],
+    });
+    expect(effectiveReleaseTime(release)).toBe('2026-01-10T00:00:00.000Z');
   });
 });

--- a/src/utils/releaseAssets.ts
+++ b/src/utils/releaseAssets.ts
@@ -1,4 +1,4 @@
-import type { ReleaseAsset } from '../types';
+import type { Release, ReleaseAsset } from '../types';
 
 /**
  * 计算单个资产的指纹。
@@ -33,4 +33,24 @@ export function hasAssetsChanged(
   incoming: ReleaseAsset[] | undefined
 ): boolean {
   return assetsFingerprint(current) !== assetsFingerprint(incoming);
+}
+
+/**
+ * 计算 Release 的有效展示时间。
+ * GitHub 的 Release 对象没有 updated_at，资产变更时 published_at 不会变化；
+ * 资产更新时间已包含在 assets[].updated_at 中（每次替换/重传都会更新）。
+ * 取 published_at 与所有资产 updated_at 中的较新者，作为用户可见的更新时间。
+ * 返回标准化 ISO 字符串（toISOString），保证不同时间戳格式（含/不含毫秒）可稳定比较。
+ */
+export function effectiveReleaseTime(release: Pick<Release, 'published_at' | 'assets'>): string {
+  let latest = new Date(release.published_at).getTime();
+  if (Array.isArray(release.assets)) {
+    for (const asset of release.assets) {
+      const assetTime = new Date(asset.updated_at).getTime();
+      if (!Number.isNaN(assetTime) && assetTime > latest) {
+        latest = assetTime;
+      }
+    }
+  }
+  return new Date(latest).toISOString();
 }


### PR DESCRIPTION
## 背景

用户反馈（issue #263 评论）：Release 拉取完成后，如果最新 Release 的资产被维护者重新上传/变更，再次刷新时已读状态不会变回未读，展示时间也不会更新为资产更新时间。

## 根因

1. **已读状态不重置**：`upsertReleases`（`src/store/useAppStore.ts`）检测到资产变化后合并更新资产，但显式保留 `is_read`，且从不触碰 UI 未读判断的真实数据源 `readReleases` Set，导致已读状态无法被重置。
2. **时间不更新**：UI 展示时间固定取 `release.published_at`。GitHub 的 Release 对象没有 `updated_at`，资产变更时 `published_at` 不会变化；资产更新时间只存在于 `assets[].updated_at` 中。

## 修复内容

- `src/store/useAppStore.ts`：`upsertReleases` 对发生变更的 Release 重置为未读 —— 设置 `is_read: false` 并从 `readReleases` 移除该 id（`readReleases` 才是 UI 未读依据）。
- `src/utils/releaseAssets.ts`：新增 `effectiveReleaseTime(release)`，取 `published_at` 与所有资产 `updated_at` 的较新者作为有效展示时间，输出标准化 ISO 字符串以保证不同时间戳格式可稳定比较。
- `src/components/ReleaseCard.tsx` / `ReleaseTimeline.tsx`：卡片与仓库分组头部改用有效时间展示；当资产更新时间晚于发布时间时显示"资产已更新"标签。
- `src/services/githubApi.ts`：更新 `latestReleases` 注释以匹配新行为。
- 测试：更新 `upsertReleases` 用例断言已读状态被重置、未变更 Release 的已读状态保留；新增 `effectiveReleaseTime` 计算与时间戳标准化用例。

## 验证

- `npx vitest run`：267 通过（唯一失败为预存在的 `RepositoryCard.test.tsx` 缺少 `@testing-library/user-event` 依赖，与本改动无关）
- `npx tsc --noEmit`：通过
- `npx eslint`（触达文件）：通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release timestamps now reflect the latest asset update.
  - Releases show an “Assets updated” indicator when applicable.
- **Bug Fixes**
  - Releases with updated assets are correctly marked as unread.
  - Unaffected releases retain their existing read status.
- **Tests**
  - Added coverage for release timestamp selection, normalization, and asset update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->