### PR TITLE
fix(release): hide asset update indicator after marking read

### DIFF
--- a/src/components/ReleaseCard.tsx
+++ b/src/components/ReleaseCard.tsx
@@ -7,7 +7,10 @@ import { useAppStore } from '../store/useAppStore';
 import { useDialog } from '../hooks/useDialog';
 import { sendToRpcDownload } from '../services/rpcDownloadService';
 import { AIService } from '../services/aiService';
-import { effectiveReleaseTime } from '../utils/releaseAssets';
+import {
+  effectiveReleaseTime,
+  shouldShowAssetsUpdatedIndicator,
+} from '../utils/releaseAssets';
 
 type SummaryState = {
   status: 'idle' | 'loading' | 'done' | 'error';
@@ -63,7 +66,7 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
   const t = useCallback((zh: string, en: string) => language === 'zh' ? zh : en, [language]);
 
   const effectiveTime = effectiveReleaseTime(release);
-  const assetsUpdatedAfterPublish = effectiveTime > release.published_at;
+  const showAssetsUpdatedIndicator = shouldShowAssetsUpdatedIndicator(release, isUnread);
 
   // RPC download support — use refs to avoid stale closure in async handler
   const { rpcDownloadConfig, backendApiSecret, aiConfigs, activeAIConfig } = useAppStore();
@@ -224,7 +227,7 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
               <div className="flex items-center gap-1.5">
                 <Calendar className="w-3.5 h-3.5" />
                 <span>{formatDistanceToNow(new Date(effectiveTime), { addSuffix: true })}</span>
-                {assetsUpdatedAfterPublish && (
+                {showAssetsUpdatedIndicator && (
                   <span className="text-[10px] px-1 py-px rounded bg-brand-violet/10 text-brand-violet font-medium">
                     {t('资产已更新', 'Assets updated')}
                   </span>

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -22,7 +22,11 @@ import {
   releaseBelongsToResolvedSources,
   resolveReleaseSources,
 } from '../utils/releaseSources';
-import { assetsFingerprint, effectiveReleaseTime } from '../utils/releaseAssets';
+import {
+  assetsFingerprint,
+  effectiveReleaseTime,
+  shouldShowAssetsUpdatedIndicator,
+} from '../utils/releaseAssets';
 
 export const ReleaseTimeline: React.FC = () => {
   const {
@@ -1235,7 +1239,9 @@ export const ReleaseTimeline: React.FC = () => {
             const isExpanded = expandedRepositories.has(repository.id);
             const hasUnread = releases.some(({ release }) => isReleaseUnread(release.id));
             const latestEffectiveTime = latestRelease ? effectiveReleaseTime(latestRelease) : null;
-            const latestAssetsUpdated = latestEffectiveTime !== null && latestEffectiveTime > latestRelease.published_at;
+            const latestAssetsUpdated = latestRelease !== null
+              && latestEffectiveTime !== null
+              && shouldShowAssetsUpdatedIndicator(latestRelease, isReleaseUnread(latestRelease.id));
 
             return (
               <div key={repository.id} className="ui-card overflow-hidden">

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -23,8 +23,8 @@ import {
   resolveReleaseSources,
 } from '../utils/releaseSources';
 import {
-  assetsFingerprint,
   effectiveReleaseTime,
+  findReleasesWithChangedAssets,
   shouldShowAssetsUpdatedIndicator,
 } from '../utils/releaseAssets';
 
@@ -454,13 +454,10 @@ export const ReleaseTimeline: React.FC = () => {
 
       // 只比每仓最新 1 条资产指纹：对已存在的最新 Release，若资产发生变化则按 id 合并更新，
       // 内容变化后由 upsertReleases 自动重置为未读（is_read=false 并从 readReleases 移除）。
-      const currentReleases = useAppStore.getState().releases;
-      const updatedReleases = (latestReleases || []).filter(latest => {
-        const local = currentReleases.find(r => r.id === latest.id);
-        // 本地不存在（即为新增，已在上方 addReleases 处理）或资产未变化时跳过
-        if (!local) return false;
-        return assetsFingerprint(local.assets) !== assetsFingerprint(latest.assets);
-      });
+      const updatedReleases = findReleasesWithChangedAssets(
+        latestReleases,
+        useAppStore.getState().releases
+      );
       const updatedCount = updatedReleases.length;
 
       if (updatedReleases.length > 0) {

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -1240,7 +1240,6 @@ export const ReleaseTimeline: React.FC = () => {
             const hasUnread = releases.some(({ release }) => isReleaseUnread(release.id));
             const latestEffectiveTime = latestRelease ? effectiveReleaseTime(latestRelease) : null;
             const latestAssetsUpdated = latestRelease !== null
-              && latestEffectiveTime !== null
               && shouldShowAssetsUpdatedIndicator(latestRelease, isReleaseUnread(latestRelease.id));
 
             return (

--- a/src/store/useAppStore.test.ts
+++ b/src/store/useAppStore.test.ts
@@ -2,7 +2,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { EmbeddingConfig, Release, Repository, VectorSearchConfig, VectorSearchStatus, defaultReleaseSourceSettings } from '../types';
 import { EMBEDDING_FORMAT_VERSION, indexAllRepos } from '../services/vectorSearchService';
 import { CUSTOM_RELEASE_SOURCE_ID, createCustomReleaseRepository } from '../utils/releaseSources';
-import { assetsFingerprint, shouldShowAssetsUpdatedIndicator } from '../utils/releaseAssets';
+import { findReleasesWithChangedAssets, shouldShowAssetsUpdatedIndicator } from '../utils/releaseAssets';
 
 let useAppStore: typeof import('./useAppStore').useAppStore;
 let normalizePersistedState: typeof import('./useAppStore').normalizePersistedState;
@@ -161,11 +161,8 @@ describe('useAppStore release add/upsert actions', () => {
       assets: [{ ...assetAtPublish, updated_at: '2026-01-05T00:00:00.000Z' }],
     });
 
-    // 复刻 handleRefresh 的指纹比对与合并逻辑（不依赖已读状态）
-    const updatedReleases = [latest].filter(incoming => {
-      const local = useAppStore.getState().releases.find(r => r.id === incoming.id);
-      return !!local && assetsFingerprint(local.assets) !== assetsFingerprint(incoming.assets);
-    });
+    // 复用 handleRefresh 的共享筛选逻辑（findReleasesWithChangedAssets），不依赖已读状态
+    const updatedReleases = findReleasesWithChangedAssets([latest], useAppStore.getState().releases);
     expect(updatedReleases).toHaveLength(1);
     useAppStore.getState().upsertReleases(updatedReleases);
 

--- a/src/store/useAppStore.test.ts
+++ b/src/store/useAppStore.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { EmbeddingConfig, Release, Repository, VectorSearchConfig, VectorSearchStatus, defaultReleaseSourceSettings } from '../types';
 import { EMBEDDING_FORMAT_VERSION, indexAllRepos } from '../services/vectorSearchService';
 import { CUSTOM_RELEASE_SOURCE_ID, createCustomReleaseRepository } from '../utils/releaseSources';
+import { assetsFingerprint, shouldShowAssetsUpdatedIndicator } from '../utils/releaseAssets';
 
 let useAppStore: typeof import('./useAppStore').useAppStore;
 let normalizePersistedState: typeof import('./useAppStore').normalizePersistedState;
@@ -140,6 +141,44 @@ describe('useAppStore release add/upsert actions', () => {
     useAppStore.getState().addReleases([makeRelease(1)]);
     useAppStore.getState().upsertReleases([makeRelease(99)]);
     expect(useAppStore.getState().releases.map(r => r.id)).toEqual([1]);
+  });
+
+  it('regression: asset update resets read state and gates the "Assets updated" indicator until marked read', () => {
+    const publishedAt = '2026-01-01T00:00:00.000Z';
+    const assetAtPublish = { ...makeRelease(1).assets[0], updated_at: publishedAt };
+
+    // 初始：已同步的 release，用户已标记为已读
+    useAppStore.getState().addReleases([makeRelease(1, {
+      published_at: publishedAt,
+      assets: [assetAtPublish],
+    })]);
+    useAppStore.getState().markReleaseAsRead(1);
+    const isUnread = () => !useAppStore.getState().readReleases.has(1);
+
+    // 刷新：GitHub 返回同 id 但资产已被替换（updated_at 晚于 published_at）
+    const latest = makeRelease(1, {
+      published_at: publishedAt,
+      assets: [{ ...assetAtPublish, updated_at: '2026-01-05T00:00:00.000Z' }],
+    });
+
+    // 复刻 handleRefresh 的指纹比对与合并逻辑（不依赖已读状态）
+    const updatedReleases = [latest].filter(incoming => {
+      const local = useAppStore.getState().releases.find(r => r.id === incoming.id);
+      return !!local && assetsFingerprint(local.assets) !== assetsFingerprint(incoming.assets);
+    });
+    expect(updatedReleases).toHaveLength(1);
+    useAppStore.getState().upsertReleases(updatedReleases);
+
+    // 资产更新后：无论之前是否已读，都重置为未读并展示"资产已更新"
+    const merged = useAppStore.getState().releases.find(r => r.id === 1)!;
+    expect(merged.is_read).toBe(false);
+    expect(isUnread()).toBe(true);
+    expect(shouldShowAssetsUpdatedIndicator(merged, isUnread())).toBe(true);
+
+    // 用户再次点击该条 release → 已读，"资产已更新"消失
+    useAppStore.getState().markReleaseAsRead(1);
+    expect(isUnread()).toBe(false);
+    expect(shouldShowAssetsUpdatedIndicator(merged, isUnread())).toBe(false);
   });
 });
 

--- a/src/utils/releaseAssets.test.ts
+++ b/src/utils/releaseAssets.test.ts
@@ -167,6 +167,21 @@ describe('hasAssetsUpdatedAfterPublish', () => {
     }))).toBe(false);
     expect(hasAssetsUpdatedAfterPublish(makeRelease())).toBe(false);
   });
+
+  it('treats missing or invalid timestamps as unchanged', () => {
+    expect(hasAssetsUpdatedAfterPublish(makeRelease({
+      published_at: 'not-a-date',
+      assets: [makeAsset({ updated_at: '2026-01-02T00:00:00Z' })],
+    }))).toBe(false);
+    expect(hasAssetsUpdatedAfterPublish(makeRelease({
+      published_at: '2026-01-01T00:00:00Z',
+      assets: [makeAsset({ updated_at: 'not-a-date' })],
+    }))).toBe(false);
+  });
+
+  it('returns false when assets are missing', () => {
+    expect(hasAssetsUpdatedAfterPublish(makeRelease({ assets: undefined }))).toBe(false);
+  });
 });
 
 describe('shouldShowAssetsUpdatedIndicator', () => {
@@ -184,6 +199,17 @@ describe('shouldShowAssetsUpdatedIndicator', () => {
     expect(shouldShowAssetsUpdatedIndicator({
       published_at: '2026-01-01T00:00:00Z',
       assets: [makeAsset({ updated_at: '2026-01-01T00:00:00Z' })],
+    }, true)).toBe(false);
+  });
+
+  it('does not show the indicator when timestamps are invalid', () => {
+    expect(shouldShowAssetsUpdatedIndicator({
+      published_at: 'not-a-date',
+      assets: [makeAsset({ updated_at: '2026-01-02T00:00:00Z' })],
+    }, true)).toBe(false);
+    expect(shouldShowAssetsUpdatedIndicator({
+      published_at: '2026-01-01T00:00:00Z',
+      assets: [makeAsset({ updated_at: 'not-a-date' })],
     }, true)).toBe(false);
   });
 });

--- a/src/utils/releaseAssets.test.ts
+++ b/src/utils/releaseAssets.test.ts
@@ -5,6 +5,8 @@ import {
   assetsFingerprint,
   effectiveReleaseTime,
   hasAssetsChanged,
+  hasAssetsUpdatedAfterPublish,
+  shouldShowAssetsUpdatedIndicator,
 } from './releaseAssets';
 
 const makeAsset = (overrides: Partial<ReleaseAsset> = {}): ReleaseAsset => ({
@@ -130,5 +132,58 @@ describe('effectiveReleaseTime', () => {
       ],
     });
     expect(effectiveReleaseTime(release)).toBe('2026-01-10T00:00:00.000Z');
+  });
+});
+
+describe('hasAssetsUpdatedAfterPublish', () => {
+  const makeRelease = (overrides: Partial<Release> = {}): Release => ({
+    id: 1,
+    tag_name: 'v1',
+    name: 'Release 1',
+    body: null,
+    published_at: '2026-01-01T00:00:00Z',
+    html_url: 'https://github.com/owner/repo/releases/tag/v1',
+    assets: [],
+    repository: { id: 1, full_name: 'owner/repo', name: 'repo' },
+    ...overrides,
+  });
+
+  it('returns true when an asset is updated after publication', () => {
+    expect(hasAssetsUpdatedAfterPublish(makeRelease({
+      assets: [makeAsset({ updated_at: '2026-01-01T00:00:00.001Z' })],
+    }))).toBe(true);
+  });
+
+  it('compares timestamps by time value across equivalent formats', () => {
+    expect(hasAssetsUpdatedAfterPublish(makeRelease({
+      published_at: '2026-01-01T08:00:00+08:00',
+      assets: [makeAsset({ updated_at: '2026-01-01T00:00:00Z' })],
+    }))).toBe(false);
+  });
+
+  it('returns false when assets are unchanged or updated at publication time', () => {
+    expect(hasAssetsUpdatedAfterPublish(makeRelease({
+      assets: [makeAsset({ updated_at: '2026-01-01T00:00:00Z' })],
+    }))).toBe(false);
+    expect(hasAssetsUpdatedAfterPublish(makeRelease())).toBe(false);
+  });
+});
+
+describe('shouldShowAssetsUpdatedIndicator', () => {
+  const release: Pick<Release, 'published_at' | 'assets'> = {
+    published_at: '2026-01-01T00:00:00Z',
+    assets: [makeAsset({ updated_at: '2026-01-02T00:00:00Z' })],
+  };
+
+  it('shows the indicator only while the release is unread', () => {
+    expect(shouldShowAssetsUpdatedIndicator(release, true)).toBe(true);
+    expect(shouldShowAssetsUpdatedIndicator(release, false)).toBe(false);
+  });
+
+  it('does not show the indicator when no asset was updated after publication', () => {
+    expect(shouldShowAssetsUpdatedIndicator({
+      published_at: '2026-01-01T00:00:00Z',
+      assets: [makeAsset({ updated_at: '2026-01-01T00:00:00Z' })],
+    }, true)).toBe(false);
   });
 });

--- a/src/utils/releaseAssets.test.ts
+++ b/src/utils/releaseAssets.test.ts
@@ -4,6 +4,7 @@ import {
   assetFingerprint,
   assetsFingerprint,
   effectiveReleaseTime,
+  findReleasesWithChangedAssets,
   hasAssetsChanged,
   hasAssetsUpdatedAfterPublish,
   shouldShowAssetsUpdatedIndicator,
@@ -91,6 +92,44 @@ describe('hasAssetsChanged', () => {
     const before = [makeAsset({ id: 1, download_count: 0 })];
     const after = [makeAsset({ id: 1, download_count: 12345 })];
     expect(hasAssetsChanged(before, after)).toBe(false);
+  });
+});
+
+describe('findReleasesWithChangedAssets', () => {
+  const makeRelease = (overrides: Partial<Release> = {}): Release => ({
+    id: 1,
+    tag_name: 'v1',
+    name: 'Release 1',
+    body: null,
+    published_at: '2026-01-01T00:00:00.000Z',
+    html_url: 'https://github.com/owner/repo/releases/tag/v1',
+    assets: [makeAsset()],
+    repository: { id: 1, full_name: 'owner/repo', name: 'repo' },
+    ...overrides,
+  });
+
+  it('returns releases whose assets fingerprint changed against local', () => {
+    const local = [makeRelease({ id: 1, assets: [makeAsset({ updated_at: '2026-01-01T00:00:00.000Z' })] })];
+    const incoming = [makeRelease({ id: 1, assets: [makeAsset({ updated_at: '2026-01-05T00:00:00.000Z' })] })];
+    expect(findReleasesWithChangedAssets(incoming, local).map(r => r.id)).toEqual([1]);
+  });
+
+  it('skips releases with unchanged assets', () => {
+    const local = [makeRelease({ id: 1, assets: [makeAsset({ updated_at: '2026-01-05T00:00:00.000Z' })] })];
+    const incoming = [makeRelease({ id: 1, assets: [makeAsset({ updated_at: '2026-01-05T00:00:00.000Z' })] })];
+    expect(findReleasesWithChangedAssets(incoming, local)).toHaveLength(0);
+  });
+
+  it('skips releases not present locally (new releases handled by addReleases)', () => {
+    const local = [makeRelease({ id: 1 })];
+    const incoming = [makeRelease({ id: 2 })];
+    expect(findReleasesWithChangedAssets(incoming, local)).toHaveLength(0);
+  });
+
+  it('returns empty when no latest releases are provided', () => {
+    const local = [makeRelease({ id: 1 })];
+    expect(findReleasesWithChangedAssets(undefined, local)).toHaveLength(0);
+    expect(findReleasesWithChangedAssets([], local)).toHaveLength(0);
   });
 });
 

--- a/src/utils/releaseAssets.ts
+++ b/src/utils/releaseAssets.ts
@@ -54,3 +54,29 @@ export function effectiveReleaseTime(release: Pick<Release, 'published_at' | 'as
   }
   return new Date(latest).toISOString();
 }
+
+/**
+ * 判断是否存在发布时间之后更新过的资产。
+ * 使用时间值比较，而不是比较不同格式的时间字符串，避免时区或毫秒精度差异造成误判。
+ */
+export function hasAssetsUpdatedAfterPublish(
+  release: Pick<Release, 'published_at' | 'assets'>
+): boolean {
+  const publishedTime = new Date(release.published_at).getTime();
+  if (Number.isNaN(publishedTime) || !Array.isArray(release.assets)) return false;
+
+  return release.assets.some((asset) => {
+    const assetTime = new Date(asset.updated_at).getTime();
+    return !Number.isNaN(assetTime) && assetTime > publishedTime;
+  });
+}
+
+/**
+ * “资产已更新”是未读更新提示的一部分；Release 被标记为已读后应立即隐藏该提示。
+ */
+export function shouldShowAssetsUpdatedIndicator(
+  release: Pick<Release, 'published_at' | 'assets'>,
+  isUnread: boolean
+): boolean {
+  return isUnread && hasAssetsUpdatedAfterPublish(release);
+}

--- a/src/utils/releaseAssets.ts
+++ b/src/utils/releaseAssets.ts
@@ -36,6 +36,24 @@ export function hasAssetsChanged(
 }
 
 /**
+ * 从最新拉取的 Release 中筛出“资产相对本地已变化”的条目。
+ * 只比对本地已存在 id 的 Release（新增条目由调用方 addReleases 处理）；
+ * 资产指纹未变化则跳过，保证幂等，避免重复触发 store/后端写入。
+ * 供刷新入口（ReleaseTimeline.handleRefresh）与测试复用。
+ */
+export function findReleasesWithChangedAssets(
+  latestReleases: Release[] | undefined,
+  currentReleases: Release[]
+): Release[] {
+  const byId = new Map(currentReleases.map(r => [r.id, r]));
+  return (latestReleases || []).filter((latest) => {
+    const local = byId.get(latest.id);
+    if (!local) return false;
+    return assetsFingerprint(local.assets) !== assetsFingerprint(latest.assets);
+  });
+}
+
+/**
  * 计算 Release 的有效展示时间。
  * GitHub 的 Release 对象没有 updated_at，资产变更时 published_at 不会变化；
  * 资产更新时间已包含在 assets[].updated_at 中（每次替换/重传都会更新）。


### PR DESCRIPTION
## 背景

当 Release 的资产发生更新时，条目会被标记为未读并显示“资产已更新”。用户再次点击条目将其标记为已读后，该提示也应随未读徽标一起消失。

## 实现

- 让 Release 卡片中的“资产已更新”提示同时依赖资产更新时间和当前 Release 的未读状态。
- 让仓库分组头部中的同类提示遵循最新 Release 的未读状态。
- 新增统一的时间值判定辅助函数，避免不同时间戳格式导致比较误判。
- 增加未读/已读状态、时间格式、无效时间戳和发布时间边界的回归测试。

## 验证

- `npm run test:run`：24 个测试文件、全部测试通过。
- `npm run lint`：无错误；保留 1 条仓库既有的 React Hook 依赖警告（`src/components/settings/VectorSearchSettings.tsx:263`）。
- `npm run build`：构建成功。
- `npx tsc --noEmit`：通过。

跟进 #263 的反馈：#263 的资产增量刷新与合并已在 v0.7.4（PR #272）中完成，本 PR 只补充其反馈中的展示逻辑——让“资产已更新”提示随未读/已读状态显隐，不涉及资产/日志刷新逻辑。

请勿合并此 PR；等待 CodeRabbit 审计完成后再处理反馈。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy of the “Assets updated” indicator by detecting asset changes and updates made after publication.
  * The indicator now appears only for unread releases and is cleared when a release is marked as read.
  * New releases are handled correctly during refreshes, while missing or invalid timestamp data is treated as unchanged.

* **Tests**
  * Added coverage for asset changes, refresh behavior, timestamp boundaries, missing data, and read-state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
