### PR TITLE
fix(release): align update time in repository view

### DIFF
--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -1272,7 +1272,7 @@ export const ReleaseTimeline: React.FC = () => {
                           <p className="text-xs text-gray-400 dark:text-text-tertiary truncate">
                             {t('最新:', 'Latest:')} {latestRelease.tag_name}
                           </p>
-                          <p className="text-xs text-gray-400 dark:text-text-quaternary whitespace-nowrap flex items-center gap-1">
+                          <p className="text-xs text-gray-400 dark:text-text-quaternary whitespace-nowrap flex items-center justify-end gap-1">
                             {formatDistanceToNow(new Date(latestEffectiveTime!), { addSuffix: true, locale: language === 'zh' ? zhCN : undefined })}
                             {latestAssetsUpdated && (
                               <span className="text-[10px] px-1 py-px rounded bg-brand-violet/10 text-brand-violet font-medium">


### PR DESCRIPTION
## Summary
- Align the repository view update-time row with the release count and latest tag.
- Keep the assets-updated indicator aligned on the same right edge.

## Validation
- `npm run test:run`
- `npm run lint` (0 errors; one pre-existing React Hook warning)
- `npm run build`
- `git diff --check`

Fixes the layout issue reported in #263.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Right-aligned the latest-release timestamp in the repository header for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->