### PR TITLE
fix: sync existing GitHub token to backend

### DIFF
--- a/server/tests/routes/settings.test.ts
+++ b/server/tests/routes/settings.test.ts
@@ -21,6 +21,9 @@ vi.mock('../../src/services/logger.js', () => ({
 
 const { default: configsRouter } = await import('../../src/routes/configs.js');
 
+/**
+ * Create an in-memory settings database stub for the route test.
+ */
 function createSettingsDb() {
   const values = new Map<string, string | null>();
   const statement = {
@@ -37,6 +40,9 @@ function createSettingsDb() {
   return values;
 }
 
+/**
+ * Build an Express app containing the settings route under test.
+ */
 const createTestApp = () => {
   const app = express();
   app.use(express.json());

--- a/server/tests/routes/settings.test.ts
+++ b/server/tests/routes/settings.test.ts
@@ -1,0 +1,65 @@
+import express from 'express';
+import request from 'supertest';
+import { describe, expect, it, vi } from 'vitest';
+
+const getDbMock = vi.fn();
+
+vi.mock('../../src/db/connection.js', () => ({
+  getDb: () => getDbMock(),
+}));
+vi.mock('../../src/config.js', () => ({ config: { encryptionKey: 'test-key' } }));
+vi.mock('../../src/services/crypto.js', () => ({
+  encrypt: (value: string) => `encrypted:${value}`,
+  decrypt: (value: string) => value,
+}));
+vi.mock('../../src/services/logger.js', () => ({
+  logger: {
+    warn: vi.fn(),
+    errorFromError: vi.fn(),
+  },
+}));
+
+const { default: configsRouter } = await import('../../src/routes/configs.js');
+
+function createSettingsDb() {
+  const values = new Map<string, string | null>();
+  const statement = {
+    run: (key: string, value: string | null) => {
+      values.set(key, value);
+      return { changes: 1 };
+    },
+  };
+  const db = {
+    prepare: () => statement,
+    transaction: (fn: () => void) => fn,
+  };
+  getDbMock.mockReturnValue(db);
+  return values;
+}
+
+const createTestApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use(configsRouter);
+  return app;
+};
+
+describe('PUT /api/settings', () => {
+  it('preserves the backend GitHub token across subsequent partial settings updates', async () => {
+    const values = createSettingsDb();
+    const app = createTestApp();
+
+    await request(app)
+      .put('/api/settings')
+      .send({ github_token: 'ghp-local-token' })
+      .expect(200);
+
+    await request(app)
+      .put('/api/settings')
+      .send({ activeAIConfig: 'default' })
+      .expect(200);
+
+    expect(values.get('github_token')).toBe('encrypted:ghp-local-token');
+    expect(values.get('activeAIConfig')).toBe('default');
+  });
+});

--- a/src/App.startup.test.tsx
+++ b/src/App.startup.test.tsx
@@ -1,0 +1,132 @@
+import { act, render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const storeState = {
+    isAuthenticated: true,
+    currentView: 'settings',
+    selectedCategory: 'all',
+    theme: 'light',
+    hasHydrated: true,
+    searchResults: [],
+    searchFilters: {
+      query: '',
+      tags: [],
+      languages: [],
+      platforms: [],
+      licenses: [],
+      sortBy: 'stars',
+      sortOrder: 'desc',
+    },
+    repositories: [],
+    githubToken: 'ghp-local-token',
+    setSelectedCategory: vi.fn(),
+  };
+
+  return {
+    storeState,
+    useAppStore: vi.fn((selector?: (state: typeof storeState) => unknown) =>
+      selector ? selector(storeState) : storeState,
+    ),
+    backend: {
+      init: vi.fn(),
+      isAvailable: true,
+      syncSettings: vi.fn(),
+    },
+    syncFromBackend: vi.fn(),
+    startAutoSync: vi.fn(),
+    stopAutoSync: vi.fn(),
+    tryRestoreAuthFromBackend: vi.fn(),
+    startMcpElectronBridge: vi.fn(),
+    stopMcpElectronBridge: vi.fn(),
+    refreshMcpElectronBridge: vi.fn(),
+    useAutoUpdateCheck: vi.fn(),
+  };
+});
+
+Object.assign(mocks.useAppStore, {
+  getState: vi.fn(() => mocks.storeState),
+});
+
+vi.mock('./store/useAppStore', () => ({ useAppStore: mocks.useAppStore }));
+vi.mock('./services/backendAdapter', () => ({ backend: mocks.backend }));
+vi.mock('./services/logger', () => ({
+  logger: {
+    setLevel: vi.fn(),
+    isDebugMode: vi.fn(() => false),
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    errorFromError: vi.fn(),
+  },
+}));
+vi.mock('./hooks/useAutoUpdateCheck', () => ({ useAutoUpdateCheck: mocks.useAutoUpdateCheck }));
+vi.mock('./services/mcpElectronBridge', () => ({
+  startMcpElectronBridge: mocks.startMcpElectronBridge,
+  stopMcpElectronBridge: mocks.stopMcpElectronBridge,
+  refreshMcpElectronBridge: mocks.refreshMcpElectronBridge,
+}));
+vi.mock('./services/autoSync', async () => {
+  const actual = await vi.importActual<typeof import('./services/autoSync')>('./services/autoSync');
+  return {
+    ...actual,
+    syncFromBackend: mocks.syncFromBackend,
+    startAutoSync: mocks.startAutoSync,
+    stopAutoSync: mocks.stopAutoSync,
+    tryRestoreAuthFromBackend: mocks.tryRestoreAuthFromBackend,
+  };
+});
+
+vi.mock('./components/LoginScreen', () => ({ LoginScreen: () => null }));
+vi.mock('./components/Header', () => ({ Header: () => null }));
+vi.mock('./components/SearchBar', () => ({ SearchBar: () => null }));
+vi.mock('./components/RepositoryList', () => ({ RepositoryList: () => null }));
+vi.mock('./components/CategorySidebar', () => ({ CategorySidebar: () => null }));
+vi.mock('./components/ReleaseTimeline', () => ({ ReleaseTimeline: () => null }));
+vi.mock('./components/ForkTimeline', () => ({ ForkTimeline: () => null }));
+vi.mock('./components/SettingsPanel', () => ({ SettingsPanel: () => null }));
+vi.mock('./components/DebugModeIndicator', () => ({ DebugModeIndicator: () => null }));
+vi.mock('./components/DiscoveryView', () => ({ DiscoveryView: () => null }));
+vi.mock('./components/GistView', () => ({ GistView: () => null }));
+vi.mock('./components/BackToTop', () => ({ BackToTop: () => null }));
+vi.mock('./components/ErrorBoundary', () => ({ ErrorBoundary: ({ children }: { children: unknown }) => children }));
+vi.mock('./components/SyncModeChoiceModal', () => ({ SyncModeChoiceModal: () => null }));
+vi.mock('./components/UpdateNotificationBanner', () => ({ UpdateNotificationBanner: () => null }));
+vi.mock('./components/ListsPushIndicator', () => ({ ListsPushIndicator: () => null }));
+
+import App from './App';
+
+describe('App backend initialization', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mocks.backend.isAvailable = true;
+    mocks.backend.init.mockResolvedValue(undefined);
+    mocks.tryRestoreAuthFromBackend.mockResolvedValue(false);
+    mocks.startAutoSync.mockReturnValue(vi.fn());
+    mocks.backend.syncSettings.mockImplementation(
+      (_settings: Record<string, unknown>, signal: AbortSignal) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true });
+        }),
+    );
+  });
+
+  it('continues backend loading after a pending local token sync reaches its deadline', async () => {
+    render(<App />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mocks.syncFromBackend).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    expect(mocks.backend.syncSettings).toHaveBeenCalledOnce();
+    expect(mocks.syncFromBackend).toHaveBeenCalledOnce();
+    expect(mocks.startAutoSync).toHaveBeenCalledOnce();
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,13 @@ import { logger } from './services/logger';
 import { UpdateNotificationBanner } from './components/UpdateNotificationBanner';
 import { ListsPushIndicator } from './components/ListsPushIndicator';
 import { backend } from './services/backendAdapter';
-import { syncFromBackend, startAutoSync, stopAutoSync, tryRestoreAuthFromBackend } from './services/autoSync';
+import {
+  syncFromBackend,
+  startAutoSync,
+  stopAutoSync,
+  tryRestoreAuthFromBackend,
+  syncLocalGitHubTokenToBackend,
+} from './services/autoSync';
 import {
   startMcpElectronBridge,
   stopMcpElectronBridge,
@@ -151,6 +157,8 @@ function App() {
   }, [theme]);
 
   useEffect(() => {
+    if (!hasHydrated) return;
+
     let unsubscribe: (() => void) | null = null;
     let cancelled = false;
 
@@ -163,6 +171,9 @@ function App() {
           // Run before the backend data pull so auth can complete before the
           // app decides whether to render LoginScreen.
           await tryRestoreAuthFromBackend();
+          if (!cancelled) {
+            await syncLocalGitHubTokenToBackend();
+          }
           if (!cancelled) {
             await syncFromBackend();
           }
@@ -189,7 +200,7 @@ function App() {
         stopAutoSync(unsubscribe);
       }
     };
-  }, []);
+  }, [hasHydrated]);
 
   const handleCategorySelect = useCallback((category: string) => {
     // 相似仓库视图下点击分类 = 离开相似视图并切换到该分类，避免交互歧义

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -162,6 +162,12 @@ function App() {
     let unsubscribe: (() => void) | null = null;
     let cancelled = false;
 
+    /**
+     * Initialize backend-backed features after persisted local state is ready.
+     *
+     * Token repair is intentionally bounded so an unavailable backend cannot
+     * block the initial data sync and background synchronization indefinitely.
+     */
     const initBackend = async () => {
       try {
         await backend.init();

--- a/src/components/settings/BackendPanel.test.tsx
+++ b/src/components/settings/BackendPanel.test.tsx
@@ -1,0 +1,121 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BackendPanel } from './BackendPanel';
+
+const mocks = vi.hoisted(() => {
+  const storeState = {
+    repositories: [],
+    releases: [],
+    aiConfigs: [],
+    webdavConfigs: [],
+    activeAIConfig: null,
+    activeWebDAVConfig: null,
+    hiddenDefaultCategoryIds: [],
+    categoryOrder: [],
+    customCategories: [],
+    assetFilters: {},
+    collapsedSidebarCategoryCount: 20,
+    backendApiSecret: null,
+    githubToken: 'ghp-local-token',
+    setBackendApiSecret: vi.fn(),
+    setRepositories: vi.fn(),
+    setReleases: vi.fn(),
+    setAIConfigs: vi.fn(),
+    setWebDAVConfigs: vi.fn(),
+    showDefaultCategory: vi.fn(),
+    hideDefaultCategory: vi.fn(),
+  };
+
+  return {
+    storeState,
+    useAppStore: vi.fn(() => storeState),
+    backend: {
+      init: vi.fn(),
+      checkHealth: vi.fn(),
+      verifyAuth: vi.fn(),
+      isAvailable: true,
+      syncRepositories: vi.fn(),
+      syncReleases: vi.fn(),
+      syncAIConfigs: vi.fn(),
+      syncWebDAVConfigs: vi.fn(),
+      syncSettings: vi.fn(),
+      fetchRepositories: vi.fn(),
+      fetchReleases: vi.fn(),
+      fetchAIConfigs: vi.fn(),
+      fetchWebDAVConfigs: vi.fn(),
+      fetchSettings: vi.fn(),
+    },
+    tryRestoreAuthFromBackend: vi.fn(),
+    syncLocalGitHubTokenToBackend: vi.fn(),
+    toast: vi.fn(),
+    confirm: vi.fn(),
+  };
+});
+
+vi.mock('../../store/useAppStore', () => ({ useAppStore: mocks.useAppStore }));
+vi.mock('../../services/backendAdapter', () => ({ backend: mocks.backend }));
+vi.mock('../../services/autoSync', () => ({
+  tryRestoreAuthFromBackend: mocks.tryRestoreAuthFromBackend,
+  syncLocalGitHubTokenToBackend: mocks.syncLocalGitHubTokenToBackend,
+}));
+vi.mock('../../hooks/useDialog', () => ({
+  useDialog: () => ({ toast: mocks.toast, confirm: mocks.confirm }),
+}));
+
+const health = { version: '0.1.0', timestamp: '2026-08-19T00:00:00Z' };
+const t = (zh: string, en: string) => en;
+
+describe('BackendPanel token synchronization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.backend.init.mockResolvedValue(undefined);
+    mocks.backend.verifyAuth.mockResolvedValue(true);
+    mocks.syncLocalGitHubTokenToBackend.mockResolvedValue(true);
+    mocks.tryRestoreAuthFromBackend.mockResolvedValue(false);
+  });
+
+  it('syncs the local GitHub token when the backend becomes reachable on panel mount', async () => {
+    mocks.backend.checkHealth.mockResolvedValue(health);
+
+    render(<BackendPanel t={t} />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mocks.syncLocalGitHubTokenToBackend).toHaveBeenCalledOnce();
+    expect(screen.getByText('Connected')).toBeTruthy();
+  });
+
+  it('syncs the local GitHub token after a successful manual test connection', async () => {
+    mocks.backend.checkHealth.mockResolvedValueOnce(null).mockResolvedValue(health);
+
+    render(<BackendPanel t={t} />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mocks.syncLocalGitHubTokenToBackend).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText('Test Connection'));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mocks.syncLocalGitHubTokenToBackend).toHaveBeenCalledOnce();
+  });
+
+  it('does not sync the token when the backend is unreachable', async () => {
+    mocks.backend.checkHealth.mockResolvedValue(null);
+
+    render(<BackendPanel t={t} />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mocks.syncLocalGitHubTokenToBackend).not.toHaveBeenCalled();
+    expect(screen.getByText('Not Connected')).toBeTruthy();
+  });
+});

--- a/src/components/settings/BackendPanel.tsx
+++ b/src/components/settings/BackendPanel.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Server, TestTube, RefreshCw, Upload, Download, CheckCircle, AlertCircle } from 'lucide-react';
 import { useAppStore } from '../../store/useAppStore';
 import { backend } from '../../services/backendAdapter';
-import { tryRestoreAuthFromBackend } from '../../services/autoSync';
+import { tryRestoreAuthFromBackend, syncLocalGitHubTokenToBackend } from '../../services/autoSync';
 import { useDialog } from '../../hooks/useDialog';
 
 interface BackendPanelProps {
@@ -49,6 +49,9 @@ export const BackendPanel: React.FC<BackendPanelProps> = ({ t }) => {
         if (healthData) {
           setStatus('connected');
           setHealth({ version: healthData.version, timestamp: healthData.timestamp });
+          // Issue #276: backend became reachable after app startup, so push the
+          // local GitHub token now instead of waiting for the next app launch.
+          void syncLocalGitHubTokenToBackend();
         } else {
           setStatus('disconnected');
           setHealth(null);
@@ -75,6 +78,9 @@ export const BackendPanel: React.FC<BackendPanelProps> = ({ t }) => {
         // Issue #259: after the one-time secret bootstrap succeeds on a fresh
         // browser/device, try to recover the stored GitHub session.
         void tryRestoreAuthFromBackend();
+        // Issue #276: sync the local GitHub token so proxy features (e.g. GitHub
+        // Lists) work when the backend was enabled after the local session.
+        void syncLocalGitHubTokenToBackend();
       } else {
         setStatus('disconnected');
         setHealth(null);

--- a/src/services/autoSync.githubToken.test.ts
+++ b/src/services/autoSync.githubToken.test.ts
@@ -1,0 +1,70 @@
+import { syncLocalGitHubTokenToBackend } from './autoSync';
+import { backend } from './backendAdapter';
+import { useAppStore } from '../store/useAppStore';
+
+vi.mock('./backendAdapter', () => ({
+  backend: {
+    isAvailable: true,
+    syncSettings: vi.fn(),
+  },
+}));
+
+vi.mock('../store/useAppStore', () => ({
+  useAppStore: {
+    getState: vi.fn(),
+  },
+}));
+
+type MockBackend = {
+  isAvailable: boolean;
+  syncSettings: ReturnType<typeof vi.fn>;
+};
+
+type MockStore = {
+  getState: ReturnType<typeof vi.fn>;
+};
+
+const mockBackend = backend as unknown as MockBackend;
+const mockStore = useAppStore as unknown as MockStore;
+
+describe('syncLocalGitHubTokenToBackend', () => {
+  beforeEach(() => {
+    mockBackend.isAvailable = true;
+    mockBackend.syncSettings.mockReset();
+    mockBackend.syncSettings.mockResolvedValue(undefined);
+    mockStore.getState.mockReset();
+  });
+
+  it('writes an existing local GitHub token to backend settings', async () => {
+    mockStore.getState.mockReturnValue({ githubToken: 'ghp-local-token' });
+
+    await expect(syncLocalGitHubTokenToBackend()).resolves.toBe(true);
+
+    expect(mockBackend.syncSettings).toHaveBeenCalledOnce();
+    expect(mockBackend.syncSettings).toHaveBeenCalledWith({ github_token: 'ghp-local-token' });
+  });
+
+  it('does not write settings when there is no local token', async () => {
+    mockStore.getState.mockReturnValue({ githubToken: null });
+
+    await expect(syncLocalGitHubTokenToBackend()).resolves.toBe(false);
+
+    expect(mockBackend.syncSettings).not.toHaveBeenCalled();
+  });
+
+  it('does not write settings when the backend is unavailable', async () => {
+    mockBackend.isAvailable = false;
+    mockStore.getState.mockReturnValue({ githubToken: 'ghp-local-token' });
+
+    await expect(syncLocalGitHubTokenToBackend()).resolves.toBe(false);
+
+    expect(mockBackend.syncSettings).not.toHaveBeenCalled();
+  });
+
+  it('keeps app startup non-blocking when backend token sync fails', async () => {
+    mockStore.getState.mockReturnValue({ githubToken: 'ghp-local-token' });
+    mockBackend.syncSettings.mockRejectedValue(new Error('backend unavailable'));
+
+    await expect(syncLocalGitHubTokenToBackend()).resolves.toBe(false);
+  });
+});

--- a/src/services/autoSync.githubToken.test.ts
+++ b/src/services/autoSync.githubToken.test.ts
@@ -41,7 +41,10 @@ describe('syncLocalGitHubTokenToBackend', () => {
     await expect(syncLocalGitHubTokenToBackend()).resolves.toBe(true);
 
     expect(mockBackend.syncSettings).toHaveBeenCalledOnce();
-    expect(mockBackend.syncSettings).toHaveBeenCalledWith({ github_token: 'ghp-local-token' });
+    expect(mockBackend.syncSettings).toHaveBeenCalledWith(
+      { github_token: 'ghp-local-token' },
+      expect.any(AbortSignal),
+    );
   });
 
   it('does not write settings when there is no local token', async () => {
@@ -66,5 +69,18 @@ describe('syncLocalGitHubTokenToBackend', () => {
     mockBackend.syncSettings.mockRejectedValue(new Error('backend unavailable'));
 
     await expect(syncLocalGitHubTokenToBackend()).resolves.toBe(false);
+  });
+
+  it('aborts a pending backend token sync after the startup deadline', async () => {
+    mockStore.getState.mockReturnValue({ githubToken: 'ghp-local-token' });
+    mockBackend.syncSettings.mockImplementation(
+      (_settings: Record<string, unknown>, signal: AbortSignal) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true });
+        }),
+    );
+
+    await expect(syncLocalGitHubTokenToBackend(10)).resolves.toBe(false);
+    expect(mockBackend.syncSettings).toHaveBeenCalledOnce();
   });
 });

--- a/src/services/autoSync.ts
+++ b/src/services/autoSync.ts
@@ -167,14 +167,21 @@ export async function tryRestoreAuthFromBackend(): Promise<boolean> {
  * sync failed). Keep this repair separate from session restoration so it never
  * overwrites the local account with backend auth data.
  */
-export async function syncLocalGitHubTokenToBackend(): Promise<boolean> {
+const LOCAL_TOKEN_SYNC_TIMEOUT_MS = 5000;
+
+export async function syncLocalGitHubTokenToBackend(
+  timeoutMs = LOCAL_TOKEN_SYNC_TIMEOUT_MS,
+): Promise<boolean> {
   if (!backend.isAvailable) return false;
 
   const { githubToken } = useAppStore.getState();
   if (!githubToken) return false;
 
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
   try {
-    await backend.syncSettings({ github_token: githubToken });
+    await backend.syncSettings({ github_token: githubToken }, controller.signal);
     logger.info('sync.githubToken', 'Synchronized local GitHub token to backend');
     return true;
   } catch (err) {
@@ -182,6 +189,8 @@ export async function syncLocalGitHubTokenToBackend(): Promise<boolean> {
       error: err instanceof Error ? err.message : String(err),
     });
     return false;
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 

--- a/src/services/autoSync.ts
+++ b/src/services/autoSync.ts
@@ -158,6 +158,34 @@ export async function tryRestoreAuthFromBackend(): Promise<boolean> {
 }
 
 /**
+ * Repair the backend copy of an already authenticated local GitHub token.
+ *
+ * Lists GraphQL requests use the backend proxy, which reads the encrypted token
+ * from backend settings instead of receiving the frontend token. Existing local
+ * sessions can therefore have a working token while the backend copy is absent
+ * (for example, when the backend was enabled after login or a previous settings
+ * sync failed). Keep this repair separate from session restoration so it never
+ * overwrites the local account with backend auth data.
+ */
+export async function syncLocalGitHubTokenToBackend(): Promise<boolean> {
+  if (!backend.isAvailable) return false;
+
+  const { githubToken } = useAppStore.getState();
+  if (!githubToken) return false;
+
+  try {
+    await backend.syncSettings({ github_token: githubToken });
+    logger.info('sync.githubToken', 'Synchronized local GitHub token to backend');
+    return true;
+  } catch (err) {
+    logger.warn('sync.githubToken', 'Failed to synchronize local GitHub token to backend', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+}
+
+/**
  * Pull all data from backend and update local store.
  * Backend-first strategy: backend data overwrites local data.
  * Silent: errors logged to console only.

--- a/src/services/backendAdapter.ts
+++ b/src/services/backendAdapter.ts
@@ -689,13 +689,14 @@ class BackendAdapter {
 
   // === Settings (active selections) ===
 
-  async syncSettings(settings: Record<string, unknown>): Promise<void> {
+  async syncSettings(settings: Record<string, unknown>, signal?: AbortSignal): Promise<void> {
     if (!this._backendUrl) return;
 
     const res = await this.fetchWithTimeout(`${this._backendUrl}/settings`, {
       method: 'PUT',
       headers: this.getAuthHeaders(),
-      body: JSON.stringify(settings)
+      body: JSON.stringify(settings),
+      signal,
     });
     if (!res.ok) await this.throwTranslatedError(res, 'Sync settings error');
   }

--- a/src/services/backendAdapter.ts
+++ b/src/services/backendAdapter.ts
@@ -689,6 +689,12 @@ class BackendAdapter {
 
   // === Settings (active selections) ===
 
+  /**
+   * Upsert frontend settings in the backend.
+   *
+   * An optional signal lets startup-only synchronization stop without delaying
+   * the rest of application initialization when the backend is unreachable.
+   */
   async syncSettings(settings: Record<string, unknown>, signal?: AbortSignal): Promise<void> {
     if (!this._backendUrl) return;
 


### PR DESCRIPTION
## Summary

- Fix issue #276 by syncing an existing local GitHub token to the Docker backend after persisted app state hydration.
- Keep token repair separate from backend auth restoration and avoid requiring users to log in again.
- Add regression coverage for successful sync, missing token, unavailable backend, and non-blocking sync failures.

## Root cause

Regular GitHub operations use the token held by the frontend, while GitHub Lists GraphQL requests use the backend proxy. The proxy reads `settings.github_token` from the backend database. Existing local sessions could therefore have a valid frontend token while the backend copy was missing, producing `GITHUB_TOKEN_NOT_CONFIGURED` as HTTP 400.

## Fix

After local Zustand state hydration completes and the backend is available, the app now idempotently calls the existing settings endpoint with the local token before pulling backend data and starting auto-sync. The operation is best-effort and never blocks application startup or overwrites the local session.

The backend initialization effect now waits for hydration, preventing a premature read of the initial null token.

## Validation

- `git diff --check`
- `npm run lint` (0 errors; one pre-existing warning in `VectorSearchSettings.tsx`)
- `npm run test:run` (25 files, 289 tests passed)
- `cd server && npm test -- --run` (79 passed, 7 skipped)
- `npm run build:all`

Fixes #276


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatically synchronizes an existing GitHub token with the backend during startup.
  - Synchronizes the token when backend connectivity becomes available through settings.
  - Restores authentication and local state before syncing backend data.
  - Ensures delayed synchronization cannot block startup beyond the configured deadline.

- **Bug Fixes**
  - Improves startup sequencing for settings and background synchronization.
  - Handles interrupted or timed-out settings requests more gracefully.

- **Tests**
  - Added coverage for synchronization, startup continuation, timeouts, skipped scenarios, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->