### PR TITLE
fix(github-lists): fall back to direct connection when backend proxy fails (#276)

### DIFF
--- a/src/services/githubListsApi.test.ts
+++ b/src/services/githubListsApi.test.ts
@@ -149,4 +149,22 @@ describe('GitHubListsApiService 后端代理回退直连', () => {
 
     await expect(api.createUserList('t')).rejects.toThrow(/后端代理：BAD_GATEWAY：getaddrinfo ENOTFOUND/);
   });
+
+  it('5xx 的 errors 分支也透传 code/details 诊断', async () => {
+    const api = makeService(BACKEND_URL);
+    vi.mocked(window.fetch)
+      .mockResolvedValueOnce(makeJsonResponse(502, { data: null, errors: [{ message: 'Something went wrong' }], code: 'BAD_GATEWAY', details: 'getaddrinfo ENOTFOUND' }, 'Bad Gateway'))
+      .mockResolvedValue(makeJsonResponse(502, { data: null, errors: [{ message: 'Something went wrong' }], code: 'BAD_GATEWAY', details: 'getaddrinfo ENOTFOUND' }, 'Bad Gateway'));
+
+    await expect(api.createUserList('t')).rejects.toThrow(/Something went wrong.*后端代理：BAD_GATEWAY：getaddrinfo ENOTFOUND/);
+  });
+
+  it('5xx 仅有 details 无 code 时也透传诊断', async () => {
+    const api = makeService(BACKEND_URL);
+    vi.mocked(window.fetch)
+      .mockResolvedValueOnce(makeJsonResponse(502, { error: 'Bad Gateway', details: 'ECONNREFUSED' }, 'Bad Gateway'))
+      .mockResolvedValue(makeJsonResponse(502, { error: 'Bad Gateway', details: 'ECONNREFUSED' }, 'Bad Gateway'));
+
+    await expect(api.createUserList('t')).rejects.toThrow(/后端代理：ECONNREFUSED/);
+  });
 });

--- a/src/services/githubListsApi.test.ts
+++ b/src/services/githubListsApi.test.ts
@@ -1,13 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { GitHubListsApiService } from './githubListsApi';
 
-function makeJsonResponse(status: number, body: unknown, statusText = ''): Response {
+function makeJsonResponse(status: number, body: unknown, statusText = '', headers: Record<string, string> = {}): Response {
   return {
     ok: status >= 200 && status < 300,
     status,
     statusText,
     json: async () => body,
-    headers: { get: () => null },
+    headers: { get: (name: string) => headers[name.toLowerCase()] ?? null },
   } as unknown as Response;
 }
 
@@ -128,7 +128,7 @@ describe('GitHubListsApiService 后端代理回退直连', () => {
     expect(vi.mocked(window.fetch).mock.calls).toHaveLength(1);
   });
 
-  it('5xx 错误文本含鉴权关键词时仍走重试回退，而非误判权限不足', async () => {
+  it('5xx 错误文本含鉴权关键词时仍按瞬时错误走代理重试，而非误判权限不足', async () => {
     const api = makeService(BACKEND_URL);
     vi.mocked(window.fetch)
       .mockResolvedValueOnce(makeJsonResponse(502, { data: null, errors: [{ message: 'Something went wrong while processing a permission-authorized request' }] }, 'Bad Gateway'))
@@ -139,8 +139,39 @@ describe('GitHubListsApiService 后端代理回退直连', () => {
     expect(summaries).toHaveLength(1);
     const calls = vi.mocked(window.fetch).mock.calls;
     expect(calls).toHaveLength(2);
+    // 该 502 无后端 code/details（健康代理透明转发），不切直连，重试仍走代理
     expect(String(calls[0][0])).toBe(PROXY_URL);
-    expect(String(calls[1][0])).toBe(DIRECT_URL);
+    expect(String(calls[1][0])).toBe(PROXY_URL);
+  });
+
+  it('代理透传上游 GitHub 5xx（无 code/details）时不切直连，走代理重试', async () => {
+    const api = makeService(BACKEND_URL);
+    vi.mocked(window.fetch)
+      .mockResolvedValueOnce(makeJsonResponse(502, { data: null, errors: [{ message: 'Something went wrong' }] }, 'Bad Gateway'))
+      .mockResolvedValueOnce(makeJsonResponse(200, LIST_SUMMARIES_DATA));
+
+    const summaries = await api.getUserListSummaries('cgy141514');
+
+    expect(summaries).toHaveLength(1);
+    const calls = vi.mocked(window.fetch).mock.calls;
+    expect(calls).toHaveLength(2);
+    expect(String(calls[0][0])).toBe(PROXY_URL);
+    expect(String(calls[1][0])).toBe(PROXY_URL);
+  });
+
+  it('代理透传 GitHub 限流（403 x-ratelimit-remaining=0）时不切直连，走代理重试', async () => {
+    const api = makeService(BACKEND_URL);
+    vi.mocked(window.fetch)
+      .mockResolvedValueOnce(makeJsonResponse(403, { data: null, errors: [{ message: 'rate limit' }] }, 'Forbidden', { 'x-ratelimit-remaining': '0' }))
+      .mockResolvedValueOnce(makeJsonResponse(200, LIST_SUMMARIES_DATA));
+
+    const summaries = await api.getUserListSummaries('cgy141514');
+
+    expect(summaries).toHaveLength(1);
+    const calls = vi.mocked(window.fetch).mock.calls;
+    expect(calls).toHaveLength(2);
+    expect(String(calls[0][0])).toBe(PROXY_URL);
+    expect(String(calls[1][0])).toBe(PROXY_URL);
   });
 
   it('mutation（createUserList）代理 502 未知结果时抛错，不自动重放直连', async () => {

--- a/src/services/githubListsApi.test.ts
+++ b/src/services/githubListsApi.test.ts
@@ -107,6 +107,21 @@ describe('GitHubListsApiService 后端代理回退直连', () => {
     expect(vi.mocked(window.fetch).mock.calls).toHaveLength(1);
   });
 
+  it('5xx 错误文本含鉴权关键词时仍走重试回退，而非误判权限不足', async () => {
+    const api = makeService(BACKEND_URL);
+    vi.mocked(window.fetch)
+      .mockResolvedValueOnce(makeJsonResponse(502, { data: null, errors: [{ message: 'Something went wrong while processing a permission-authorized request' }] }, 'Bad Gateway'))
+      .mockResolvedValueOnce(makeJsonResponse(200, SUCCESS_DATA));
+
+    const id = await api.createUserList('t');
+
+    expect(id).toBe('L_1');
+    const calls = vi.mocked(window.fetch).mock.calls;
+    expect(calls).toHaveLength(2);
+    expect(String(calls[0][0])).toBe(PROXY_URL);
+    expect(String(calls[1][0])).toBe(DIRECT_URL);
+  });
+
   it('未配置后端时直接直连', async () => {
     const api = makeService(null);
     vi.mocked(window.fetch).mockResolvedValueOnce(makeJsonResponse(200, SUCCESS_DATA));

--- a/src/services/githubListsApi.test.ts
+++ b/src/services/githubListsApi.test.ts
@@ -122,6 +122,34 @@ describe('GitHubListsApiService 后端代理回退直连', () => {
     expect(String(calls[1][0])).toBe(DIRECT_URL);
   });
 
+  it('代理请求内部超时（AbortError）后回退直连并成功', async () => {
+    const api = makeService(BACKEND_URL);
+    vi.mocked(window.fetch)
+      .mockRejectedValueOnce(new DOMException('The operation was aborted.', 'AbortError'))
+      .mockResolvedValueOnce(makeJsonResponse(200, SUCCESS_DATA));
+
+    const id = await api.createUserList('t');
+
+    expect(id).toBe('L_1');
+    const calls = vi.mocked(window.fetch).mock.calls;
+    expect(calls).toHaveLength(2);
+    expect(String(calls[0][0])).toBe(PROXY_URL);
+    expect(String(calls[1][0])).toBe(DIRECT_URL);
+  });
+
+  it('调用方取消（父信号中止）时传播 AbortError，不重试不回退', async () => {
+    const api = makeService(BACKEND_URL);
+    const controller = new AbortController();
+    // 模拟请求进行中调用方取消：先中止父信号，fetch 随即以 AbortError 失败
+    vi.mocked(window.fetch).mockImplementationOnce(() => {
+      controller.abort();
+      return Promise.reject(new DOMException('The operation was aborted.', 'AbortError'));
+    });
+
+    await expect(api.getUserListSummaries('cgy141514', controller.signal)).rejects.toMatchObject({ name: 'AbortError' });
+    expect(vi.mocked(window.fetch).mock.calls).toHaveLength(1);
+  });
+
   it('未配置后端时直接直连', async () => {
     const api = makeService(null);
     vi.mocked(window.fetch).mockResolvedValueOnce(makeJsonResponse(200, SUCCESS_DATA));

--- a/src/services/githubListsApi.test.ts
+++ b/src/services/githubListsApi.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GitHubListsApiService } from './githubListsApi';
+
+function makeJsonResponse(status: number, body: unknown, statusText = ''): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText,
+    json: async () => body,
+    headers: { get: () => null },
+  } as unknown as Response;
+}
+
+const DIRECT_URL = 'https://api.github.com/graphql';
+const PROXY_URL = 'http://backend.test/api/proxy/github/graphql';
+const BACKEND_URL = 'http://backend.test/api';
+
+const SUCCESS_DATA = {
+  data: { createUserList: { list: { id: 'L_1', name: 't' } } },
+};
+
+function makeService(backendUrl: string | null = null): GitHubListsApiService {
+  const api = new GitHubListsApiService('gh_token');
+  if (backendUrl) {
+    api.setBackendUrl(backendUrl);
+    api.setBackendAuthToken('backend_secret');
+  }
+  return api;
+}
+
+describe('GitHubListsApiService 后端代理回退直连', () => {
+  beforeEach(() => {
+    // 退避等待直接完成，避免测试被 1→2→4s 背压拖慢
+    vi.spyOn(GitHubListsApiService.prototype, 'sleep' as never).mockResolvedValue(undefined as never);
+  });
+
+  afterEach(() => {
+    vi.mocked(window.fetch).mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it('代理 502 后回退直连并成功', async () => {
+    const api = makeService(BACKEND_URL);
+    vi.mocked(window.fetch)
+      .mockResolvedValueOnce(makeJsonResponse(502, { error: 'Bad Gateway', code: 'BAD_GATEWAY', details: 'getaddrinfo ENOTFOUND api.github.com' }, 'Bad Gateway'))
+      .mockResolvedValueOnce(makeJsonResponse(200, SUCCESS_DATA));
+
+    const id = await api.createUserList('t');
+
+    expect(id).toBe('L_1');
+    const calls = vi.mocked(window.fetch).mock.calls;
+    expect(calls).toHaveLength(2);
+    expect(String(calls[0][0])).toBe(PROXY_URL);
+    expect(String(calls[1][0])).toBe(DIRECT_URL);
+  });
+
+  it('代理 400 GITHUB_TOKEN_NOT_CONFIGURED 后回退直连并成功（无需退避）', async () => {
+    const api = makeService(BACKEND_URL);
+    vi.mocked(window.fetch)
+      .mockResolvedValueOnce(makeJsonResponse(400, { error: 'GitHub token not configured', code: 'GITHUB_TOKEN_NOT_CONFIGURED' }))
+      .mockResolvedValueOnce(makeJsonResponse(200, SUCCESS_DATA));
+
+    const id = await api.createUserList('t');
+
+    expect(id).toBe('L_1');
+    const calls = vi.mocked(window.fetch).mock.calls;
+    expect(calls).toHaveLength(2);
+    expect(String(calls[0][0])).toBe(PROXY_URL);
+    expect(String(calls[1][0])).toBe(DIRECT_URL);
+  });
+
+  it('代理成功时保持代理，不发起直连', async () => {
+    const api = makeService(BACKEND_URL);
+    vi.mocked(window.fetch).mockResolvedValueOnce(makeJsonResponse(200, SUCCESS_DATA));
+
+    const id = await api.createUserList('t');
+
+    expect(id).toBe('L_1');
+    const calls = vi.mocked(window.fetch).mock.calls;
+    expect(calls).toHaveLength(1);
+    expect(String(calls[0][0])).toBe(PROXY_URL);
+  });
+
+  it('回退后同实例后续请求直接直连，不再撞击代理', async () => {
+    const api = makeService(BACKEND_URL);
+    vi.mocked(window.fetch)
+      .mockResolvedValueOnce(makeJsonResponse(502, { error: 'Bad Gateway', code: 'BAD_GATEWAY' }, 'Bad Gateway'))
+      .mockResolvedValue(makeJsonResponse(200, SUCCESS_DATA));
+
+    await api.createUserList('first');
+    await api.createUserList('second');
+
+    const calls = vi.mocked(window.fetch).mock.calls;
+    expect(calls).toHaveLength(3);
+    expect(String(calls[0][0])).toBe(PROXY_URL);
+    expect(String(calls[1][0])).toBe(DIRECT_URL);
+    expect(String(calls[2][0])).toBe(DIRECT_URL);
+  });
+
+  it('代理返回 401 时抛权限错误，不触发回退直连', async () => {
+    const api = makeService(BACKEND_URL);
+    vi.mocked(window.fetch).mockResolvedValueOnce(
+      makeJsonResponse(401, { data: null, errors: [{ message: '401 Unauthorized' }] })
+    );
+
+    await expect(api.createUserList('t')).rejects.toThrow(/缺少操作星标列表/);
+    expect(vi.mocked(window.fetch).mock.calls).toHaveLength(1);
+  });
+
+  it('未配置后端时直接直连', async () => {
+    const api = makeService(null);
+    vi.mocked(window.fetch).mockResolvedValueOnce(makeJsonResponse(200, SUCCESS_DATA));
+
+    const id = await api.createUserList('t');
+
+    expect(id).toBe('L_1');
+    expect(String(vi.mocked(window.fetch).mock.calls[0][0])).toBe(DIRECT_URL);
+  });
+
+  it('代理与直连都持续 5xx 时，重试耗尽后抛出', async () => {
+    const api = makeService(BACKEND_URL);
+    vi.mocked(window.fetch)
+      .mockResolvedValueOnce(makeJsonResponse(502, { error: 'Bad Gateway', code: 'BAD_GATEWAY' }, 'Bad Gateway'))
+      .mockResolvedValue(makeJsonResponse(502, { data: null, errors: [{ message: 'Something went wrong' }] }, 'Bad Gateway'));
+
+    await expect(api.createUserList('t')).rejects.toThrow(/Something went wrong/);
+  });
+
+  it('透传后端代理错误 code/details 到错误信息', async () => {
+    const api = makeService(BACKEND_URL);
+    vi.mocked(window.fetch)
+      .mockResolvedValueOnce(makeJsonResponse(502, { error: 'Bad Gateway', code: 'BAD_GATEWAY', details: 'getaddrinfo ENOTFOUND api.github.com' }, 'Bad Gateway'))
+      .mockResolvedValue(makeJsonResponse(502, { error: 'Bad Gateway', code: 'BAD_GATEWAY', details: 'getaddrinfo ENOTFOUND api.github.com' }, 'Bad Gateway'));
+
+    await expect(api.createUserList('t')).rejects.toThrow(/后端代理：BAD_GATEWAY：getaddrinfo ENOTFOUND/);
+  });
+});

--- a/src/services/githubListsApi.test.ts
+++ b/src/services/githubListsApi.test.ts
@@ -152,7 +152,13 @@ describe('GitHubListsApiService 后端代理回退直连', () => {
 
     await expect(api.createUserList('t')).rejects.toThrow(/后端代理：BAD_GATEWAY/);
     expect(String(vi.mocked(window.fetch).mock.calls[0][0])).toBe(PROXY_URL);
-    expect(vi.mocked(window.fetch).mock.calls.some(c => String(c[0]) === DIRECT_URL && String(c[1]).includes('createUserList'))).toBe(false);
+    // 检测直连路径是否重放了 createUserList mutation（读 body 而非 String(c[1])）
+    expect(
+      vi.mocked(window.fetch).mock.calls.some(
+        c => String(c[0]) === DIRECT_URL &&
+          String((c[1] as RequestInit)?.body ?? '').includes('createUserList')
+      )
+    ).toBe(false);
   });
 
   it('mutation（createUserList）代理网络失败后按名核对复用已有 list，不重复创建', async () => {

--- a/src/services/githubListsApi.test.ts
+++ b/src/services/githubListsApi.test.ts
@@ -19,6 +19,26 @@ const SUCCESS_DATA = {
   data: { createUserList: { list: { id: 'L_1', name: 't' } } },
 };
 
+const LIST_SUMMARIES_DATA = {
+  data: {
+    user: {
+      lists: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [{ id: 'L_1', name: 't' }] },
+    },
+  },
+};
+
+const UPDATE_ITEM_DATA = {
+  data: { updateUserListsForItem: { clientMutationId: 'c1' } },
+};
+
+const VIEWER_LISTS_DATA = {
+  data: {
+    viewer: {
+      lists: { pageInfo: { hasNextPage: false, endCursor: null }, nodes: [{ id: 'L_99', name: 't' }] },
+    },
+  },
+};
+
 function makeService(backendUrl: string | null = null): GitHubListsApiService {
   const api = new GitHubListsApiService('gh_token');
   if (backendUrl) {
@@ -39,22 +59,23 @@ describe('GitHubListsApiService 后端代理回退直连', () => {
     vi.restoreAllMocks();
   });
 
-  it('代理 502 后回退直连并成功', async () => {
+  it('查询（getUserListSummaries）代理 502 后回退直连并成功', async () => {
     const api = makeService(BACKEND_URL);
     vi.mocked(window.fetch)
       .mockResolvedValueOnce(makeJsonResponse(502, { error: 'Bad Gateway', code: 'BAD_GATEWAY', details: 'getaddrinfo ENOTFOUND api.github.com' }, 'Bad Gateway'))
-      .mockResolvedValueOnce(makeJsonResponse(200, SUCCESS_DATA));
+      .mockResolvedValueOnce(makeJsonResponse(200, LIST_SUMMARIES_DATA));
 
-    const id = await api.createUserList('t');
+    const summaries = await api.getUserListSummaries('cgy141514');
 
-    expect(id).toBe('L_1');
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0].id).toBe('L_1');
     const calls = vi.mocked(window.fetch).mock.calls;
     expect(calls).toHaveLength(2);
     expect(String(calls[0][0])).toBe(PROXY_URL);
     expect(String(calls[1][0])).toBe(DIRECT_URL);
   });
 
-  it('代理 400 GITHUB_TOKEN_NOT_CONFIGURED 后回退直连并成功（无需退避）', async () => {
+  it('代理 400 GITHUB_TOKEN_NOT_CONFIGURED 后回退直连并成功（无需退避，mutation 确定未执行）', async () => {
     const api = makeService(BACKEND_URL);
     vi.mocked(window.fetch)
       .mockResolvedValueOnce(makeJsonResponse(400, { error: 'GitHub token not configured', code: 'GITHUB_TOKEN_NOT_CONFIGURED' }))
@@ -81,14 +102,14 @@ describe('GitHubListsApiService 后端代理回退直连', () => {
     expect(String(calls[0][0])).toBe(PROXY_URL);
   });
 
-  it('回退后同实例后续请求直接直连，不再撞击代理', async () => {
+  it('回退后同实例后续查询请求直接直连，不再撞击代理', async () => {
     const api = makeService(BACKEND_URL);
     vi.mocked(window.fetch)
       .mockResolvedValueOnce(makeJsonResponse(502, { error: 'Bad Gateway', code: 'BAD_GATEWAY' }, 'Bad Gateway'))
-      .mockResolvedValue(makeJsonResponse(200, SUCCESS_DATA));
+      .mockResolvedValue(makeJsonResponse(200, LIST_SUMMARIES_DATA));
 
-    await api.createUserList('first');
-    await api.createUserList('second');
+    await api.getUserListSummaries('first');
+    await api.getUserListSummaries('second');
 
     const calls = vi.mocked(window.fetch).mock.calls;
     expect(calls).toHaveLength(3);
@@ -111,11 +132,56 @@ describe('GitHubListsApiService 后端代理回退直连', () => {
     const api = makeService(BACKEND_URL);
     vi.mocked(window.fetch)
       .mockResolvedValueOnce(makeJsonResponse(502, { data: null, errors: [{ message: 'Something went wrong while processing a permission-authorized request' }] }, 'Bad Gateway'))
-      .mockResolvedValueOnce(makeJsonResponse(200, SUCCESS_DATA));
+      .mockResolvedValueOnce(makeJsonResponse(200, LIST_SUMMARIES_DATA));
+
+    const summaries = await api.getUserListSummaries('cgy141514');
+
+    expect(summaries).toHaveLength(1);
+    const calls = vi.mocked(window.fetch).mock.calls;
+    expect(calls).toHaveLength(2);
+    expect(String(calls[0][0])).toBe(PROXY_URL);
+    expect(String(calls[1][0])).toBe(DIRECT_URL);
+  });
+
+  it('mutation（createUserList）代理 502 未知结果时抛错，不自动重放直连', async () => {
+    const api = makeService(BACKEND_URL);
+    vi.mocked(window.fetch)
+      .mockResolvedValueOnce(makeJsonResponse(502, { error: 'Bad Gateway', code: 'BAD_GATEWAY', details: 'getaddrinfo ENOTFOUND api.github.com' }, 'Bad Gateway'))
+      // 核对查询（viewer）失败时保留原始错误
+      .mockResolvedValue(makeJsonResponse(502, { data: null, errors: [{ message: 'Something went wrong' }] }, 'Bad Gateway'));
+
+    await expect(api.createUserList('t')).rejects.toThrow(/后端代理：BAD_GATEWAY/);
+    expect(String(vi.mocked(window.fetch).mock.calls[0][0])).toBe(PROXY_URL);
+    expect(vi.mocked(window.fetch).mock.calls.some(c => String(c[0]) === DIRECT_URL && String(c[1]).includes('createUserList'))).toBe(false);
+  });
+
+  it('mutation（createUserList）代理网络失败后按名核对复用已有 list，不重复创建', async () => {
+    const api = makeService(BACKEND_URL);
+    vi.mocked(window.fetch)
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce(makeJsonResponse(200, VIEWER_LISTS_DATA));
 
     const id = await api.createUserList('t');
 
-    expect(id).toBe('L_1');
+    expect(id).toBe('L_99');
+    const calls = vi.mocked(window.fetch).mock.calls;
+    expect(calls).toHaveLength(2);
+    expect(String(calls[0][0])).toBe(PROXY_URL);
+    expect(String(calls[1][0])).toBe(DIRECT_URL);
+    // 第二次是 viewer 核对查询，而非重放 createUserList mutation
+    const secondBody = String((calls[1][1] as RequestInit).body ?? '');
+    expect(secondBody).toContain('viewer');
+    expect(secondBody).not.toContain('createUserList');
+  });
+
+  it('mutation（updateUserListsForItem）整集替换语义幂等，代理 502 后回退直连并成功', async () => {
+    const api = makeService(BACKEND_URL);
+    vi.mocked(window.fetch)
+      .mockResolvedValueOnce(makeJsonResponse(502, { error: 'Bad Gateway', code: 'BAD_GATEWAY' }, 'Bad Gateway'))
+      .mockResolvedValueOnce(makeJsonResponse(200, UPDATE_ITEM_DATA));
+
+    await api.updateUserListsForItem('node_1', ['L_1', 'L_2']);
+
     const calls = vi.mocked(window.fetch).mock.calls;
     expect(calls).toHaveLength(2);
     expect(String(calls[0][0])).toBe(PROXY_URL);
@@ -126,15 +192,31 @@ describe('GitHubListsApiService 后端代理回退直连', () => {
     const api = makeService(BACKEND_URL);
     vi.mocked(window.fetch)
       .mockRejectedValueOnce(new DOMException('The operation was aborted.', 'AbortError'))
-      .mockResolvedValueOnce(makeJsonResponse(200, SUCCESS_DATA));
+      .mockResolvedValueOnce(makeJsonResponse(200, LIST_SUMMARIES_DATA));
 
-    const id = await api.createUserList('t');
+    const summaries = await api.getUserListSummaries('cgy141514');
 
-    expect(id).toBe('L_1');
+    expect(summaries).toHaveLength(1);
     const calls = vi.mocked(window.fetch).mock.calls;
     expect(calls).toHaveLength(2);
     expect(String(calls[0][0])).toBe(PROXY_URL);
     expect(String(calls[1][0])).toBe(DIRECT_URL);
+  });
+
+  it('mutation 内部超时（AbortError）未知结果时抛错，不自动重放', async () => {
+    const api = makeService(BACKEND_URL);
+    vi.mocked(window.fetch)
+      .mockRejectedValueOnce(new DOMException('The operation was aborted.', 'AbortError'))
+      .mockResolvedValueOnce(makeJsonResponse(200, SUCCESS_DATA));
+
+    await expect(api.createUserList('t')).rejects.toThrow(/请求超时/);
+    const calls = vi.mocked(window.fetch).mock.calls;
+    // mutation 超时后做了一次 viewer 核对查询（非重放），随后抛出原始超时错误
+    expect(calls).toHaveLength(2);
+    expect(String(calls[0][0])).toBe(PROXY_URL);
+    const secondBody = String((calls[1][1] as RequestInit).body ?? '');
+    expect(secondBody).toContain('viewer');
+    expect(secondBody).not.toContain('createUserList');
   });
 
   it('调用方取消（父信号中止）时传播 AbortError，不重试不回退', async () => {
@@ -160,13 +242,13 @@ describe('GitHubListsApiService 后端代理回退直连', () => {
     expect(String(vi.mocked(window.fetch).mock.calls[0][0])).toBe(DIRECT_URL);
   });
 
-  it('代理与直连都持续 5xx 时，重试耗尽后抛出', async () => {
+  it('代理与直连都持续 5xx 时，查询重试耗尽后抛出', async () => {
     const api = makeService(BACKEND_URL);
     vi.mocked(window.fetch)
       .mockResolvedValueOnce(makeJsonResponse(502, { error: 'Bad Gateway', code: 'BAD_GATEWAY' }, 'Bad Gateway'))
       .mockResolvedValue(makeJsonResponse(502, { data: null, errors: [{ message: 'Something went wrong' }] }, 'Bad Gateway'));
 
-    await expect(api.createUserList('t')).rejects.toThrow(/Something went wrong/);
+    await expect(api.getUserListSummaries('cgy141514')).rejects.toThrow(/Something went wrong/);
   });
 
   it('透传后端代理错误 code/details 到错误信息', async () => {

--- a/src/services/githubListsApi.ts
+++ b/src/services/githubListsApi.ts
@@ -115,6 +115,15 @@ interface BackendProxyErrorBody {
   details?: string;
 }
 
+/** 从响应体提取后端代理诊断信息（code/details 任一存在即输出；无则空串）。 */
+function buildProxyDiagnostics(payload: unknown): string {
+  const proxyErr = payload as Partial<BackendProxyErrorBody>;
+  const parts: string[] = [];
+  if (proxyErr.code) parts.push(proxyErr.code);
+  if (typeof proxyErr.details === 'string' && proxyErr.details) parts.push(proxyErr.details);
+  return parts.length > 0 ? `（后端代理：${parts.join('：')}）` : '';
+}
+
 /**
  * GitHub Lists（星标列表）GraphQL 客户端。
  *
@@ -344,8 +353,9 @@ export class GitHubListsApiService {
       const message = error.message || 'GitHub GraphQL 请求失败';
       // 上游 5xx 无条件视为瞬时错误：即使错误文本疑似鉴权（如 502 网关错误里出现
       // "authorized"/"permission"），也应走重试/切直连，而非误判为权限不足。
+      // 若载荷同时携带后端 code/details 诊断，一并透传。
       if (response.status >= 500 && response.status <= 599) {
-        throw new RetriableError(message, this.parseRetryAfterMs(response));
+        throw new RetriableError(`${message}${buildProxyDiagnostics(payload)}`, this.parseRetryAfterMs(response));
       }
       // 鉴权类错误：GraphQL 通常返回 "401 Unauthorized" 或错误信息包含 scope/权限相关字眼。
       // 无论是否容忍部分失败，鉴权错误都必须抛出，不能静默吞掉。
@@ -378,11 +388,8 @@ export class GitHubListsApiService {
     // 5xx（502/503/504）：GitHub 过载/网关超时，或后端代理自身不可达，瞬时性错误，可重试。
     // 后端代理失败时透传其 code/details，便于区分"后端容器连不上 GitHub"与"GitHub 本身 5xx"。
     if (response.status >= 500 && response.status <= 599) {
-      const proxyErr = payload as unknown as Partial<BackendProxyErrorBody>;
-      const details = typeof proxyErr.details === 'string' && proxyErr.details ? `：${proxyErr.details}` : '';
-      const diagnostics = proxyErr.code ? `（后端代理：${proxyErr.code}${details}）` : '';
       throw new RetriableError(
-        `GitHub GraphQL 请求失败：${response.status} ${response.statusText}${diagnostics}`,
+        `GitHub GraphQL 请求失败：${response.status} ${response.statusText}${buildProxyDiagnostics(payload)}`,
         this.parseRetryAfterMs(response)
       );
     }

--- a/src/services/githubListsApi.ts
+++ b/src/services/githubListsApi.ts
@@ -180,14 +180,20 @@ export class GitHubListsApiService {
    * @param toleratePartialErrors 为 true 时，若响应为 200 且包含部分 data，
    *   即使 errors 数组非空也不抛错（用于批量解析场景：个别字段失败不应丢弃已成功的结果）。
    *   鉴权类错误（401/403 scope 不足）无论何种模式都会抛出。
+   * @param replayableMutation 仅对 mutation 生效。未知结果（网络/5xx/超时）下默认不自动重放，
+   *   因为代理可能已提交成功但响应丢失，重放会重复执行（如重复创建 list）。
+   *   仅当该 mutation 具备服务端幂等语义（如整集替换）时才可设为 true。
    */
   private async request<T>(
     query: string,
     variables: Record<string, unknown> = {},
-    options: { toleratePartialErrors?: boolean; signal?: AbortSignal; timeoutMs?: number } = {}
+    options: { toleratePartialErrors?: boolean; signal?: AbortSignal; timeoutMs?: number; replayableMutation?: boolean } = {}
   ): Promise<T> {
     const body = JSON.stringify({ query, variables });
     const parentSignal = options.signal;
+    // mutation 的未知结果不允许自动重放；query 永远可安全重放。
+    const isMutation = query.trim().startsWith('mutation');
+    const mayReplay = !isMutation || options.replayableMutation === true;
 
     const MAX_ATTEMPTS = 4;
     let lastError: unknown;
@@ -208,6 +214,15 @@ export class GitHubListsApiService {
       } catch (e) {
         if (e instanceof RetriableError) {
           lastError = e;
+          // mutation 未知结果（代理可能已提交成功但响应丢失）：不自动重放，
+          // 交由上层核对目标状态，避免重复执行（如重复创建 list）。
+          if (!mayReplay) {
+            if (this.backendUrl && !this.proxyFailed) {
+              this.proxyFailed = true;
+              logger.warn('githubLists', 'Mutation outcome unknown, not auto-replaying', { error: e.message });
+            }
+            break;
+          }
           // 后端代理瞬时失败（5xx/网络/限流）：切直连后继续按原退避重试同一查询；
           // 直连模式失败则按正常退避序列重试（不再改模式）。
           if (this.backendUrl && !this.proxyFailed) {
@@ -222,6 +237,7 @@ export class GitHubListsApiService {
         }
         if (e instanceof BackendTokenMissingError) {
           // 后端未配置 token（如首次同步前尚未同步成功），前端持有 token，直连即可，无需退避。
+          // 400 在转发到 GitHub 前返回，mutation 确定未执行，可安全重放。
           lastError = e;
           this.proxyFailed = true;
           logger.warn('githubLists', 'Backend token missing, falling back to direct connection');
@@ -229,9 +245,16 @@ export class GitHubListsApiService {
         }
         // 单次尝试的内部超时（如代理请求停滞）会中止组合 controller，fetch 以 AbortError 失败。
         // 调用方取消（parentSignal 已中止）应原样传播；内部超时属瞬时错误，
-        // 切直连后按退避重试，而不是直接抛给用户。
+        // query 切直连后按退避重试；mutation 未知结果不自动重放。
         if (e instanceof Error && e.name === 'AbortError' && !parentSignal?.aborted) {
           lastError = new RetriableError('GitHub GraphQL 请求超时。');
+          if (!mayReplay) {
+            if (this.backendUrl && !this.proxyFailed) {
+              this.proxyFailed = true;
+              logger.warn('githubLists', 'Mutation timeout, not auto-replaying');
+            }
+            break;
+          }
           if (this.backendUrl && !this.proxyFailed) {
             this.proxyFailed = true;
             logger.warn('githubLists', 'Request timeout, falling back to direct connection');
@@ -609,19 +632,82 @@ export class GitHubListsApiService {
     return summaries;
   }
 
-  /** 创建新 List，返回其 id。 */
+  /**
+   * 创建新 List，返回其 id。
+   * 创建属非幂等 mutation：未知结果（网络/5xx/超时）下 request 不会自动重放，
+   * 而是先按名称核对当前用户的 lists —— 若已存在同名 list，说明首次请求已生效但响应
+   * 丢失，直接复用其 id，避免重复创建。
+   */
   async createUserList(name: string, isPrivate = true, description?: string): Promise<string> {
-    const data = await this.request<{
-      createUserList: { list: { id: string; name: string } };
-    }>(
-      `mutation($name: String!, $isPrivate: Boolean!, $description: String) {
+    try {
+      const data = await this.request<{
+        createUserList: { list: { id: string; name: string } };
+      }>(
+        `mutation($name: String!, $isPrivate: Boolean!, $description: String) {
         createUserList(input: { name: $name, isPrivate: $isPrivate, description: $description }) {
           list { id name }
         }
       }`,
-      { name, isPrivate, description: description ?? null }
-    );
-    return data.createUserList.list.id;
+        { name, isPrivate, description: description ?? null }
+      );
+      return data.createUserList.list.id;
+    } catch (error) {
+      // 仅在未知结果（RetriableError）时核对；核对失败时保留原始错误，避免掩盖根因。
+      if (error instanceof RetriableError) {
+        try {
+          const existingId = await this.findListIdByName(name);
+          if (existingId !== null) return existingId;
+        } catch {
+          // 忽略核对查询自身失败，保留原始错误。
+        }
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * 按名称在当前用户的 lists 中查找 id（用于非幂等 mutation 未知结果后的状态核对）。
+   * 通过 viewer 分页拉取，返回首个同名（不区分大小写）list 的 id，未找到返回 null。
+   */
+  private async findListIdByName(name: string): Promise<string | null> {
+    const target = name.toLowerCase();
+    let cursor: string | null = null;
+    // 分页防御：lists 数量通常很少，10 页（1000 个）足以覆盖极端情况并防止死循环。
+    for (let i = 0; i < 10; i++) {
+      // 显式注解避免隐式 any 的环形推断（该文件既有 TS7022 模式）
+      const data: {
+        viewer: {
+          lists: {
+            pageInfo: { hasNextPage: boolean; endCursor: string | null };
+            nodes: Array<{ id: string; name: string }>;
+          };
+        } | null;
+      } = await this.request(
+        `query($cursor: String) {
+          viewer {
+            lists(first: 100, after: $cursor) {
+              pageInfo { hasNextPage endCursor }
+              nodes { id name }
+            }
+          }
+        }`,
+        { cursor }
+      );
+      const lists: {
+        pageInfo: { hasNextPage: boolean; endCursor: string | null };
+        nodes: Array<{ id: string; name: string }>;
+      } | undefined = data.viewer?.lists;
+      if (!lists) return null;
+      for (const list of lists.nodes) {
+        if (list.name.toLowerCase() === target) return list.id;
+      }
+      if (!lists.pageInfo.hasNextPage) return null;
+      const nextCursor: string | null = lists.pageInfo.endCursor;
+      // 防御：hasNextPage 为 true 但游标为空或未前进，终止避免死循环
+      if (!nextCursor || nextCursor === cursor) return null;
+      cursor = nextCursor;
+    }
+    return null;
   }
 
   /** 删除 List。 */
@@ -648,7 +734,10 @@ export class GitHubListsApiService {
           clientMutationId
         }
       }`,
-      { itemId, listIds }
+      { itemId, listIds },
+      // 整集替换语义（服务端按集合去重）：无论重放多少次，最终成员集合相同，
+      // 因此未知结果后可安全重放，与 query 一致。
+      { replayableMutation: true }
     );
   }
 

--- a/src/services/githubListsApi.ts
+++ b/src/services/githubListsApi.ts
@@ -78,6 +78,17 @@ class RetriableError extends Error {
   }
 }
 
+/**
+ * 后端代理返回"未配置 GitHub token"（400 GITHUB_TOKEN_NOT_CONFIGURED）。
+ * 前端始终持有 token，此时应切换到直连模式重试，无需退避等待。
+ */
+class BackendTokenMissingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BackendTokenMissingError';
+  }
+}
+
 export interface GitHubList {
   id: string;
   name: string;
@@ -97,6 +108,13 @@ interface GraphQLResponse<T> {
   errors?: Array<{ message?: string; type?: string; extensions?: { code?: string } }>;
 }
 
+/** 后端代理 /api/proxy/github/* 失败时的响应体（proxyService 兜底与上游错误透传）。 */
+interface BackendProxyErrorBody {
+  error?: string;
+  code?: string;
+  details?: string;
+}
+
 /**
  * GitHub Lists（星标列表）GraphQL 客户端。
  *
@@ -104,12 +122,17 @@ interface GraphQLResponse<T> {
  * - 有后端代理：POST {backendUrl}/proxy/github/graphql，由服务端读取加密的 token 并转发；
  * - 直连模式：POST https://api.github.com/graphql，携带传入的 token。
  *
+ * 后端代理路径一旦失败（网络/5xx/token 缺失），自动切换到直连模式并保持到本次同步结束，
+ * 避免同一批次的每个查询都先撞击一次失败的代理。直连要求浏览器能直接访问 GitHub。
+ *
  * GraphQL 操作星标列表需要经典 PAT 的 `user` scope（或含 star lists 权限的 token）。
  */
 export class GitHubListsApiService {
   private token: string;
   private backendUrl: string | null = null;
   private backendAuthToken: string | null = null;
+  /** 后端代理路径失败后置位，本实例剩余请求走直连（幂等切换，不重复尝试代理）。 */
+  private proxyFailed = false;
 
   constructor(token: string) {
     this.token = token;
@@ -142,6 +165,9 @@ export class GitHubListsApiService {
    * 重试尊重 Retry-After 头，最多 4 次，退避 1→2→4→8s（与 Retry-After 取较大者）。
    * 鉴权类错误（401/403 scope 不足）、业务错误（GraphQL errors）、4xx 不重试。
    *
+   * 后端代理模式下，代理路径一旦失败（网络/5xx/token 缺失）即切换到直连重试并保持到
+   * 本次同步结束；直连模式失败则按正常退避序列重试。
+   *
    * @param toleratePartialErrors 为 true 时，若响应为 200 且包含部分 data，
    *   即使 errors 数组非空也不抛错（用于批量解析场景：个别字段失败不应丢弃已成功的结果）。
    *   鉴权类错误（401/403 scope 不足）无论何种模式都会抛出。
@@ -166,14 +192,30 @@ export class GitHubListsApiService {
       //（否则 sleep 抛出 AbortError，掩盖最终的 RetriableError）。退避只受 parentSignal 控制。
       const controller = createCombinedAbortController(parentSignal, options.timeoutMs ?? 30_000);
       try {
-        return await this.attemptRequest<T>(query, body, controller.signal, options);
+        // 后端代理路径一旦失败（网络/5xx/token 缺失）即切直连，并保持到本次同步结束：
+        // 避免同一批次的每个查询都先撞击一次失败的代理。
+        const useProxy = this.backendUrl !== null && !this.proxyFailed;
+        return await this.attemptRequest<T>(query, body, controller.signal, options, useProxy);
       } catch (e) {
         if (e instanceof RetriableError) {
           lastError = e;
+          // 后端代理瞬时失败（5xx/网络/限流）：切直连后继续按原退避重试同一查询；
+          // 直连模式失败则按正常退避序列重试（不再改模式）。
+          if (this.backendUrl && !this.proxyFailed) {
+            this.proxyFailed = true;
+            logger.warn('githubLists', 'Backend proxy failed, falling back to direct connection', { error: e.message });
+          }
           // 最后一次不再等待，直接抛出
           if (attempt === MAX_ATTEMPTS - 1) break;
           const backoffMs = e.retryAfterMs ?? (1000 * Math.pow(2, attempt));
           await this.sleep(backoffMs, parentSignal);
+          continue;
+        }
+        if (e instanceof BackendTokenMissingError) {
+          // 后端未配置 token（如首次同步前尚未同步成功），前端持有 token，直连即可，无需退避。
+          lastError = e;
+          this.proxyFailed = true;
+          logger.warn('githubLists', 'Backend token missing, falling back to direct connection');
           continue;
         }
         // 不可重试（鉴权/业务/AbortError 等），直接抛
@@ -213,16 +255,18 @@ export class GitHubListsApiService {
   /**
    * 单次 GraphQL 请求尝试。瞬时错误抛 RetriableError 供外层重试，
    * 永久错误（鉴权/业务/缺 data）直接抛出。
+   * @param useProxy true 走后端代理；false 走直连（浏览器 token 直连 GitHub）。
    */
   private async attemptRequest<T>(
     query: string,
     body: string,
     signal: AbortSignal,
-    options: { toleratePartialErrors?: boolean }
+    options: { toleratePartialErrors?: boolean },
+    useProxy: boolean
   ): Promise<T> {
     let response: Response;
     try {
-      if (this.backendUrl) {
+      if (useProxy && this.backendUrl) {
         const proxyUrl = `${this.backendUrl}/proxy/github/graphql`;
         response = await fetch(proxyUrl, {
           method: 'POST',
@@ -274,6 +318,12 @@ export class GitHubListsApiService {
       throw new Error('GitHub GraphQL 响应解析失败（非 JSON）。');
     }
 
+    // 后端未配置 token（400 GITHUB_TOKEN_NOT_CONFIGURED）：前端持有 token，直连即可。
+    // 抛专用错误由 request 切到直连模式重试（无需退避）。
+    if (useProxy && response.status === 400 && (payload as unknown as BackendProxyErrorBody).code === 'GITHUB_TOKEN_NOT_CONFIGURED') {
+      throw new BackendTokenMissingError('后端未配置 GitHub token，切换到直连模式重试。');
+    }
+
     // 速率限制：403 既可能是 scope 不足，也可能是主/次速率限制。
     // 需在鉴权分类之前判断，避免把限流误报为"缺少权限"。
     const isRateLimited =
@@ -304,9 +354,12 @@ export class GitHubListsApiService {
         );
       }
       // 非鉴权错误：若允许部分失败且响应 200 且存在部分 data，则保留部分结果继续；
-      // 否则抛出。
+      // 否则抛出。上游 5xx（如 GitHub GraphQL 502 + errors 体）属瞬时错误，可重试/切直连。
       if (options.toleratePartialErrors && response.status === 200 && payload.data) {
         return payload.data;
+      }
+      if (response.status >= 500 && response.status <= 599) {
+        throw new RetriableError(message, this.parseRetryAfterMs(response));
       }
       throw new Error(message);
     }
@@ -321,10 +374,14 @@ export class GitHubListsApiService {
       );
     }
 
-    // 5xx（502/503/504）：GitHub 过载或网关超时，瞬时性错误，可重试
+    // 5xx（502/503/504）：GitHub 过载/网关超时，或后端代理自身不可达，瞬时性错误，可重试。
+    // 后端代理失败时透传其 code/details，便于区分"后端容器连不上 GitHub"与"GitHub 本身 5xx"。
     if (response.status >= 500 && response.status <= 599) {
+      const proxyErr = payload as unknown as Partial<BackendProxyErrorBody>;
+      const details = typeof proxyErr.details === 'string' && proxyErr.details ? `：${proxyErr.details}` : '';
+      const diagnostics = proxyErr.code ? `（后端代理：${proxyErr.code}${details}）` : '';
       throw new RetriableError(
-        `GitHub GraphQL 请求失败：${response.status} ${response.statusText}`,
+        `GitHub GraphQL 请求失败：${response.status} ${response.statusText}${diagnostics}`,
         this.parseRetryAfterMs(response)
       );
     }

--- a/src/services/githubListsApi.ts
+++ b/src/services/githubListsApi.ts
@@ -342,6 +342,11 @@ export class GitHubListsApiService {
     if (payload.errors && payload.errors.length > 0) {
       const error = payload.errors[0];
       const message = error.message || 'GitHub GraphQL 请求失败';
+      // 上游 5xx 无条件视为瞬时错误：即使错误文本疑似鉴权（如 502 网关错误里出现
+      // "authorized"/"permission"），也应走重试/切直连，而非误判为权限不足。
+      if (response.status >= 500 && response.status <= 599) {
+        throw new RetriableError(message, this.parseRetryAfterMs(response));
+      }
       // 鉴权类错误：GraphQL 通常返回 "401 Unauthorized" 或错误信息包含 scope/权限相关字眼。
       // 无论是否容忍部分失败，鉴权错误都必须抛出，不能静默吞掉。
       if (response.status === 401 || response.status === 403 || /scope|permission|authorized|not granted/i.test(message)) {
@@ -353,13 +358,9 @@ export class GitHubListsApiService {
           '· 或改用含 star lists 权限的 token 重新登录。'
         );
       }
-      // 非鉴权错误：若允许部分失败且响应 200 且存在部分 data，则保留部分结果继续；
-      // 否则抛出。上游 5xx（如 GitHub GraphQL 502 + errors 体）属瞬时错误，可重试/切直连。
+      // 非鉴权错误：若允许部分失败且响应 200 且存在部分 data，则保留部分结果继续；否则抛出。
       if (options.toleratePartialErrors && response.status === 200 && payload.data) {
         return payload.data;
-      }
-      if (response.status >= 500 && response.status <= 599) {
-        throw new RetriableError(message, this.parseRetryAfterMs(response));
       }
       throw new Error(message);
     }

--- a/src/services/githubListsApi.ts
+++ b/src/services/githubListsApi.ts
@@ -227,6 +227,20 @@ export class GitHubListsApiService {
           logger.warn('githubLists', 'Backend token missing, falling back to direct connection');
           continue;
         }
+        // 单次尝试的内部超时（如代理请求停滞）会中止组合 controller，fetch 以 AbortError 失败。
+        // 调用方取消（parentSignal 已中止）应原样传播；内部超时属瞬时错误，
+        // 切直连后按退避重试，而不是直接抛给用户。
+        if (e instanceof Error && e.name === 'AbortError' && !parentSignal?.aborted) {
+          lastError = new RetriableError('GitHub GraphQL 请求超时。');
+          if (this.backendUrl && !this.proxyFailed) {
+            this.proxyFailed = true;
+            logger.warn('githubLists', 'Request timeout, falling back to direct connection');
+          }
+          if (attempt === MAX_ATTEMPTS - 1) break;
+          const backoffMs = 1000 * Math.pow(2, attempt);
+          await this.sleep(backoffMs, parentSignal);
+          continue;
+        }
         // 不可重试（鉴权/业务/AbortError 等），直接抛
         throw e;
       }

--- a/src/services/githubListsApi.ts
+++ b/src/services/githubListsApi.ts
@@ -71,10 +71,15 @@ function createCombinedAbortController(parentSignal: AbortSignal | undefined, ti
  */
 class RetriableError extends Error {
   readonly retryAfterMs?: number;
-  constructor(message: string, retryAfterMs?: number) {
+  /** 是否为代理层自身失败（代理网络异常/非 JSON 5xx/带后端 code/details 的 5xx），
+   *  而非 GitHub 侧转发的瞬时错误（限流、上游 5xx）。仅代理层失败才应切 sticky 直连：
+   *  健康代理转发的 GitHub 瞬时错误，直连同样会命中，不应因此永久绕过代理。 */
+  readonly proxyLayerFailure: boolean;
+  constructor(message: string, retryAfterMs?: number, proxyLayerFailure = false) {
     super(message);
     this.name = 'RetriableError';
     this.retryAfterMs = retryAfterMs;
+    this.proxyLayerFailure = proxyLayerFailure;
   }
 }
 
@@ -206,10 +211,10 @@ export class GitHubListsApiService {
       // 每次尝试独立超时：超时上限不被重试+退避消耗，也不会中止退避等待
       //（否则 sleep 抛出 AbortError，掩盖最终的 RetriableError）。退避只受 parentSignal 控制。
       const controller = createCombinedAbortController(parentSignal, options.timeoutMs ?? 30_000);
+      // 后端代理路径一旦失败（网络/5xx/token 缺失）即切直连，并保持到本次同步结束：
+      // 避免同一批次的每个查询都先撞击一次失败的代理。
+      const useProxy = this.backendUrl !== null && !this.proxyFailed;
       try {
-        // 后端代理路径一旦失败（网络/5xx/token 缺失）即切直连，并保持到本次同步结束：
-        // 避免同一批次的每个查询都先撞击一次失败的代理。
-        const useProxy = this.backendUrl !== null && !this.proxyFailed;
         return await this.attemptRequest<T>(query, body, controller.signal, options, useProxy);
       } catch (e) {
         if (e instanceof RetriableError) {
@@ -217,15 +222,15 @@ export class GitHubListsApiService {
           // mutation 未知结果（代理可能已提交成功但响应丢失）：不自动重放，
           // 交由上层核对目标状态，避免重复执行（如重复创建 list）。
           if (!mayReplay) {
-            if (this.backendUrl && !this.proxyFailed) {
+            if (e.proxyLayerFailure && this.backendUrl && !this.proxyFailed) {
               this.proxyFailed = true;
               logger.warn('githubLists', 'Mutation outcome unknown, not auto-replaying', { error: e.message });
             }
             break;
           }
-          // 后端代理瞬时失败（5xx/网络/限流）：切直连后继续按原退避重试同一查询；
-          // 直连模式失败则按正常退避序列重试（不再改模式）。
-          if (this.backendUrl && !this.proxyFailed) {
+          // 仅代理层自身失败才切 sticky 直连（网络/非 JSON 5xx/带后端 code/details 的 5xx）；
+          // 健康代理转发的 GitHub 瞬时错误（限流、上游 5xx）保持走代理按退避重试。
+          if (e.proxyLayerFailure && this.backendUrl && !this.proxyFailed) {
             this.proxyFailed = true;
             logger.warn('githubLists', 'Backend proxy failed, falling back to direct connection', { error: e.message });
           }
@@ -249,13 +254,14 @@ export class GitHubListsApiService {
         if (e instanceof Error && e.name === 'AbortError' && !parentSignal?.aborted) {
           lastError = new RetriableError('GitHub GraphQL 请求超时。');
           if (!mayReplay) {
-            if (this.backendUrl && !this.proxyFailed) {
+            if (useProxy && this.backendUrl && !this.proxyFailed) {
               this.proxyFailed = true;
               logger.warn('githubLists', 'Mutation timeout, not auto-replaying');
             }
             break;
           }
-          if (this.backendUrl && !this.proxyFailed) {
+          // 仅当超时发生在这步的代理请求上才切直连（直连超时无可切对象）。
+          if (useProxy && this.backendUrl && !this.proxyFailed) {
             this.proxyFailed = true;
             logger.warn('githubLists', 'Request timeout, falling back to direct connection');
           }
@@ -346,7 +352,8 @@ export class GitHubListsApiService {
       }
       throw new RetriableError(
         `GitHub GraphQL 网络请求失败：${e instanceof Error ? e.message : String(e)}`,
-        undefined
+        undefined,
+        useProxy
       );
     }
 
@@ -358,7 +365,8 @@ export class GitHubListsApiService {
       if (response.status >= 500 && response.status <= 599) {
         throw new RetriableError(
           `GitHub GraphQL 响应解析失败（HTTP ${response.status}）。`,
-          this.parseRetryAfterMs(response)
+          this.parseRetryAfterMs(response),
+          useProxy
         );
       }
       throw new Error('GitHub GraphQL 响应解析失败（非 JSON）。');
@@ -390,9 +398,14 @@ export class GitHubListsApiService {
       const message = error.message || 'GitHub GraphQL 请求失败';
       // 上游 5xx 无条件视为瞬时错误：即使错误文本疑似鉴权（如 502 网关错误里出现
       // "authorized"/"permission"），也应走重试/切直连，而非误判为权限不足。
-      // 若载荷同时携带后端 code/details 诊断，一并透传。
+      // 若载荷同时携带后端 code/details 诊断（proxyLayerFailure=true），一并透传并视为代理层失败。
       if (response.status >= 500 && response.status <= 599) {
-        throw new RetriableError(`${message}${buildProxyDiagnostics(payload)}`, this.parseRetryAfterMs(response));
+        const diagnostics = buildProxyDiagnostics(payload);
+        throw new RetriableError(
+          `${message}${diagnostics}`,
+          this.parseRetryAfterMs(response),
+          useProxy && diagnostics !== ''
+        );
       }
       // 鉴权类错误：GraphQL 通常返回 "401 Unauthorized" 或错误信息包含 scope/权限相关字眼。
       // 无论是否容忍部分失败，鉴权错误都必须抛出，不能静默吞掉。
@@ -423,11 +436,14 @@ export class GitHubListsApiService {
     }
 
     // 5xx（502/503/504）：GitHub 过载/网关超时，或后端代理自身不可达，瞬时性错误，可重试。
-    // 后端代理失败时透传其 code/details，便于区分"后端容器连不上 GitHub"与"GitHub 本身 5xx"。
+    // 后端代理失败时透传其 code/details，便于区分"后端容器连不上 GitHub"（proxyLayerFailure）
+    // 与"GitHub 本身 5xx"（健康代理透明转发，不应切 sticky 直连）。
     if (response.status >= 500 && response.status <= 599) {
+      const diagnostics = buildProxyDiagnostics(payload);
       throw new RetriableError(
-        `GitHub GraphQL 请求失败：${response.status} ${response.statusText}${buildProxyDiagnostics(payload)}`,
-        this.parseRetryAfterMs(response)
+        `GitHub GraphQL 请求失败：${response.status} ${response.statusText}${diagnostics}`,
+        this.parseRetryAfterMs(response),
+        useProxy && diagnostics !== ''
       );
     }
 
@@ -718,7 +734,9 @@ export class GitHubListsApiService {
           clientMutationId
         }
       }`,
-      { listId }
+      { listId },
+      // 按 node id 删除具备幂等语义：重放至多命中"已删除"，不会造成额外副作用。
+      { replayableMutation: true }
     );
   }
 


### PR DESCRIPTION
## Summary

后端代理是唯一真正经过 Docker 后端的 GitHub 请求路径。当后端容器无法访问 api.github.com（例如容器内未配置代理）时，每个 lists GraphQL 请求都会报 502，而 REST 星标同步（浏览器直连）始终正常——这正是 #276 修复后仍报 `GitHub GraphQL 请求失败：502 Bad Gateway` 的原因。

### 改动

- **代理失败自动回退直连**：后端代理路径一旦失败（网络异常 / 5xx / token 缺失），`GitHubListsApiService` 切换为直连模式（浏览器 token 直连 `api.github.com/graphql`）重试同一查询，并在本次同步运行内保持粘性，避免每个查询都重复撞击失败的代理。
- **识别 400 GITHUB_TOKEN_NOT_CONFIGURED**：后端未配置 token 时直接切直连重试（无需退避），前端始终持有 token。
- **修复 5xx + errors 体被当永久错误**：GitHub 透传的 502/504（带 GraphQL errors 体）此前会被当作不可重试错误抛出，现改为可重试并触发回退。
- **透传后端错误详情**：5xx 错误信息带上后端返回的 `code`/`details`（如 `BAD_GATEWAY`、`ECONNREFUSED`），便于区分"后端容器连不上 GitHub"与"GitHub 本身 5xx"。

### 验证

- 新增 `src/services/githubListsApi.test.ts`（8 个用例）：502 回退直连、400 token 缺失回退、代理成功保持代理、回退后粘性直连、401 不回退、无后端直连、持续 5xx 抛错、错误详情透传。
- 全量测试通过：`vitest run` 28 个测试文件 / 302 个用例全绿。
- ESLint 0 错误（仅 1 个既有 warning）。

### 根因背景

星标同步（`SearchBar.tsx` 直连 `new GitHubApiService`）与 lists 同步（工厂 `createGitHubListsApiService` 挂后端代理）实现不一致：lists 是唯一经过后端容器的操作。桌面端直连正常、浏览器直连正常，只有后端代理路径失败，因此该回退让 lists 与 REST 行为对齐，同时保留后端代理能力（代理可用时仍优先后端）。

Closes #276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when connecting through the backend proxy by switching to direct access after service, network, timeout, authorization, or missing-credential failures.
  * Added retries for temporary server errors while preserving diagnostic details.
  * Prevented unsafe duplicate mutations and verified list creation after uncertain outcomes.
  * Caller-cancelled requests now stop promptly without unnecessary retries or fallback.

* **Tests**
  * Expanded coverage for proxy behavior, fallback, retries, cancellations, mutations, authorization, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->