### PR TITLE
feat: add OrcaRouter as a named AI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ The app supports multiple AI providers. Configure yours in the Settings panel:
 - **OpenAI**: GPT-3.5 / GPT-4
 - **Anthropic**: Claude
 - **Ollama**: local models with no API key needed
+- **[OrcaRouter](https://www.orcarouter.ai)**: unified OpenAI-compatible gateway with 100+ models and gateway-level security
 - **Any OpenAI-compatible API**: custom endpoint + key
 
 Steps: open Settings, add an AI config, enter your endpoint and key, pick a model, then test the connection.

--- a/README_zh.md
+++ b/README_zh.md
@@ -233,6 +233,7 @@ npm run build
 - **OpenAI**: GPT-3.5/GPT-4
 - **Anthropic**: Claude
 - **本地部署**: Ollama等本地AI服务
+- **[OrcaRouter](https://www.orcarouter.ai)**: 统一 OpenAI 兼容网关，100+ 模型，网关级安全防护
 - **其他**: 任何兼容OpenAI API的服务
 
 在设置页面中配置您的AI服务：

--- a/server/src/routes/proxy.ts
+++ b/server/src/routes/proxy.ts
@@ -289,7 +289,7 @@ router.post('/api/proxy/ai', async (req, res) => {
       'Accept': 'application/json',
     };
 
-    if (apiType === 'openai' || apiType === 'openai-responses' || apiType === 'openai-compatible' || apiType === 'deepseek' || apiType === 'mimo') {
+    if (apiType === 'openai' || apiType === 'openai-responses' || apiType === 'openai-compatible' || apiType === 'deepseek' || apiType === 'mimo' || apiType === 'orcarouter') {
       // openai-compatible 类型直接使用 baseUrl 作为完整地址
       targetUrl = apiType === 'openai-compatible'
         ? baseUrl.replace(/\/$/, '')
@@ -317,7 +317,7 @@ router.post('/api/proxy/ai', async (req, res) => {
       && !isDeepSeekReasoner
       && typeof requestBody === 'object'
       && requestBody !== null
-      && (apiType === 'openai' || apiType === 'openai-responses' || apiType === 'openai-compatible' || apiType === 'deepseek' || apiType === 'mimo')
+      && (apiType === 'openai' || apiType === 'openai-responses' || apiType === 'openai-compatible' || apiType === 'deepseek' || apiType === 'mimo' || apiType === 'orcarouter')
       && !('reasoning' in requestBody)
     )
       ? { ...requestBody, reasoning: { effort: reasoningEffort } }

--- a/src/components/settings/AIConfigPanel.tsx
+++ b/src/components/settings/AIConfigPanel.tsx
@@ -36,6 +36,7 @@ const DEFAULT_API_ENDPOINTS: Record<AIApiType, string> = {
   gemini: 'https://generativelanguage.googleapis.com/v1beta',
   deepseek: 'https://api.deepseek.com',
   mimo: MIMO_PLAN_ENDPOINTS.api,
+  orcarouter: 'https://api.orcarouter.ai/v1',
   'openai-compatible': '',
 };
 
@@ -50,6 +51,8 @@ function getEndpointPlaceholder(apiType: AIApiType, mimoPlan: MiMoPlan): string 
       return 'https://api.deepseek.com';
     case 'mimo':
       return MIMO_PLAN_ENDPOINTS[mimoPlan];
+    case 'orcarouter':
+      return 'https://api.orcarouter.ai/v1';
     case 'openai-compatible':
       return 'https://integrate.api.nvidia.com/v1/chat/completions';
     default:
@@ -67,6 +70,8 @@ function getEndpointHelpText(apiType: AIApiType, t: (zh: string, en: string) => 
       return t('填写到域名即可（如 https://api.deepseek.com），路径会自动生成', 'Only include the domain (e.g. https://api.deepseek.com), the path will be generated automatically');
     case 'mimo':
       return t('填写到 /v1 即可（如 https://api.xiaomimimo.com/v1），路径会自动生成', 'Only include up to /v1 (e.g. https://api.xiaomimimo.com/v1), the path will be generated automatically');
+    case 'orcarouter':
+      return t('填写到 /v1 即可（如 https://api.orcarouter.ai/v1），路径会自动生成', 'Only include up to /v1 (e.g. https://api.orcarouter.ai/v1), the path will be generated automatically');
     default:
       return t('只填到版本号即可（如 .../v1 或 .../v1beta），不要包含 /chat/completions、/responses、/messages', 'Only include the version prefix (e.g. .../v1 or .../v1beta). Do not include /chat/completions, /responses, or /messages.');
   }
@@ -456,6 +461,7 @@ Repository information:
                 <option value="gemini">Gemini</option>
                 <option value="deepseek">DeepSeek</option>
                 <option value="mimo">Xiaomi MiMo</option>
+                <option value="orcarouter">OrcaRouter</option>
                 <option value="openai-compatible">OpenAI Compatible (Custom Endpoint)</option>
               </select>
             </div>

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -240,7 +240,7 @@ export class AIService {
     const configId = this.config.id;
     const reasoning = this.getOpenAIReasoningPayload();
 
-    if (apiType === 'openai' || apiType === 'openai-responses' || apiType === 'openai-compatible' || apiType === 'deepseek' || apiType === 'mimo') {
+    if (apiType === 'openai' || apiType === 'openai-responses' || apiType === 'openai-compatible' || apiType === 'deepseek' || apiType === 'mimo' || apiType === 'orcarouter') {
       const messages = [
         ...(options.system.trim()
           ? [{ role: 'system', content: options.system }]

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -210,7 +210,7 @@ export interface GistSearchFilters {
   isAnalyzed?: boolean;
 }
 
-export type AIApiType = 'openai' | 'openai-responses' | 'claude' | 'gemini' | 'deepseek' | 'mimo' | 'openai-compatible';
+export type AIApiType = 'openai' | 'openai-responses' | 'claude' | 'gemini' | 'deepseek' | 'mimo' | 'orcarouter' | 'openai-compatible';
 
 // Embedding 提供商类型
 export type EmbeddingApiType = 'openai' | 'openai-compatible' | 'gemini' | 'cohere' | 'ollama' | 'siliconflow';


### PR DESCRIPTION
## Add [OrcaRouter](https://www.orcarouter.ai) as a named AI provider

Adds **OrcaRouter** — an OpenAI-compatible gateway — as a first-class, selectable AI provider in the Settings panel, mirroring how DeepSeek and Xiaomi MiMo are wired today. Users can pick "OrcaRouter" directly instead of configuring a generic OpenAI-compatible endpoint by hand.

### Changes
- `src/types/index.ts`: add `orcarouter` to the `AIApiType` union
- `src/components/settings/AIConfigPanel.tsx`: new dropdown option with default endpoint `https://api.orcarouter.ai/v1`, placeholder, and bilingual help text
- `src/services/aiService.ts`: route `orcarouter` through the Chat Completions path (Bearer auth), same as OpenAI/DeepSeek
- `server/src/routes/proxy.ts`: route `orcarouter` through the backend proxy's Chat Completions path (Bearer auth) and apply the reasoning-effort passthrough
- `README.md` / `README_zh.md`: document OrcaRouter as a supported provider

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### Verification
- `vite build` ✓
- `server npm run build` (tsc) ✓
- frontend `vitest run`: 294 passed / 27 files ✓
- server `vitest run`: 87 passed / 13 files ✓
- eslint clean on all changed files ✓
- Live check against `https://api.orcarouter.ai/v1`: `GET /models` → 200 (205 models), `POST /chat/completions` (model `orcarouter/auto`) → 200

Disclosure: I'm an engineer on the OrcaRouter team.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OrcaRouter as a supported AI provider.
  * Added configuration options, default endpoint guidance, and localized setup instructions.
  * Enabled OpenAI-compatible requests, authorization, and reasoning controls for OrcaRouter.
  * Updated English and Chinese documentation with OrcaRouter details, including support for 100+ models and gateway-level security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->