### PR TITLE
fix: preserve release asset update markers

### DIFF
--- a/server/src/db/migrations.ts
+++ b/server/src/db/migrations.ts
@@ -1,10 +1,13 @@
 import type Database from 'better-sqlite3';
-import { initializeSchema } from './schema.js';
+import { addColumnIfMissing, initializeSchema } from './schema.js';
 import { logger } from '../services/logger.js';
 
 const migrations: Record<number, (db: Database.Database) => void> = {
   1: (db) => {
     initializeSchema(db);
+  },
+  2: (db) => {
+    addColumnIfMissing(db, 'releases', 'updated_asset_ids', "TEXT NOT NULL DEFAULT '[]'");
   },
 };
 

--- a/server/src/db/schema.ts
+++ b/server/src/db/schema.ts
@@ -1,6 +1,6 @@
 import type Database from 'better-sqlite3';
 
-function addColumnIfMissing(db: Database.Database, table: string, column: string, definition: string): void {
+export function addColumnIfMissing(db: Database.Database, table: string, column: string, definition: string): void {
   const columns = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
   if (!columns.some((col) => col.name === column)) {
     db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
@@ -56,6 +56,7 @@ export function initializeSchema(db: Database.Database): void {
       prerelease INTEGER DEFAULT 0,
       draft INTEGER DEFAULT 0,
       is_read INTEGER DEFAULT 0,
+      updated_asset_ids TEXT NOT NULL DEFAULT '[]',
       zipball_url TEXT,
       tarball_url TEXT
     );
@@ -146,6 +147,7 @@ export function initializeSchema(db: Database.Database): void {
   addColumnIfMissing(db, 'ai_configs', 'reasoning_effort', 'TEXT');
   addColumnIfMissing(db, 'ai_configs', 'mimo_plan', 'TEXT');
   addColumnIfMissing(db, 'repositories', 'category_locked', 'INTEGER DEFAULT 0');
+  addColumnIfMissing(db, 'releases', 'updated_asset_ids', "TEXT NOT NULL DEFAULT '[]'");
   addColumnIfMissing(db, 'releases', 'zipball_url', 'TEXT');
   addColumnIfMissing(db, 'releases', 'tarball_url', 'TEXT');
   addColumnIfMissing(db, 'categories', 'description', 'TEXT');

--- a/server/src/routes/releases.ts
+++ b/server/src/routes/releases.ts
@@ -113,7 +113,7 @@ router.put('/api/releases', (req, res) => {
         draft = excluded.draft,
         is_read = releases.is_read,
         assets = excluded.assets,
-        updated_asset_ids = excluded.updated_asset_ids,
+        updated_asset_ids = CASE WHEN ? = 1 THEN excluded.updated_asset_ids ELSE releases.updated_asset_ids END,
         repo_id = excluded.repo_id,
         repo_full_name = excluded.repo_full_name,
         repo_name = excluded.repo_name,
@@ -137,7 +137,7 @@ router.put('/api/releases', (req, res) => {
         draft = excluded.draft,
         is_read = excluded.is_read,
         assets = excluded.assets,
-        updated_asset_ids = excluded.updated_asset_ids,
+        updated_asset_ids = CASE WHEN ? = 1 THEN excluded.updated_asset_ids ELSE releases.updated_asset_ids END,
         repo_id = excluded.repo_id,
         repo_full_name = excluded.repo_full_name,
         repo_name = excluded.repo_name,
@@ -152,6 +152,7 @@ router.put('/api/releases', (req, res) => {
         // 合并 UPSERT：仅更新数据列，保留库中已有的 is_read 已读状态，避免整行替换把已读清空。
         // 仅当请求显式携带 is_read（如导入/同步完整快照）时才覆盖已读状态。
         const hasExplicitIsRead = typeof release.is_read === 'boolean';
+        const hasExplicitUpdatedAssetIds = Object.hasOwn(release, 'updated_asset_ids');
         const stmt = hasExplicitIsRead ? stmtOverwriteIsRead : stmtPreserveIsRead;
         stmt.run(
           release.id,
@@ -169,7 +170,8 @@ router.put('/api/releases', (req, res) => {
           repository?.full_name ?? release.repo_full_name ?? null,
           repository?.name ?? release.repo_name ?? null,
           release.zipball_url ?? null,
-          release.tarball_url ?? null
+          release.tarball_url ?? null,
+          hasExplicitUpdatedAssetIds ? 1 : 0
         );
         count++;
       }

--- a/server/src/routes/releases.ts
+++ b/server/src/routes/releases.ts
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import { getDb } from '../db/connection.js';
+import { parseUpdatedAssetIds, serializeUpdatedAssetIds } from '../services/releaseAssets.js';
 
 const router = Router();
 
@@ -20,6 +21,7 @@ function transformRelease(row: Record<string, unknown>) {
     draft: !!row.draft,
     is_read: !!row.is_read,
     assets: parseJsonColumn(row.assets),
+    updated_asset_ids: parseUpdatedAssetIds(row.updated_asset_ids),
     zipball_url: row.zipball_url ?? undefined,
     tarball_url: row.tarball_url ?? undefined,
     repository: {
@@ -97,10 +99,10 @@ router.put('/api/releases', (req, res) => {
     const stmtPreserveIsRead = db.prepare(`
       INSERT INTO releases (
         id, tag_name, name, body, html_url, published_at,
-        prerelease, draft, is_read, assets,
+        prerelease, draft, is_read, assets, updated_asset_ids,
         repo_id, repo_full_name, repo_name,
         zipball_url, tarball_url
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         tag_name = excluded.tag_name,
         name = excluded.name,
@@ -111,6 +113,7 @@ router.put('/api/releases', (req, res) => {
         draft = excluded.draft,
         is_read = releases.is_read,
         assets = excluded.assets,
+        updated_asset_ids = excluded.updated_asset_ids,
         repo_id = excluded.repo_id,
         repo_full_name = excluded.repo_full_name,
         repo_name = excluded.repo_name,
@@ -120,10 +123,10 @@ router.put('/api/releases', (req, res) => {
     const stmtOverwriteIsRead = db.prepare(`
       INSERT INTO releases (
         id, tag_name, name, body, html_url, published_at,
-        prerelease, draft, is_read, assets,
+        prerelease, draft, is_read, assets, updated_asset_ids,
         repo_id, repo_full_name, repo_name,
         zipball_url, tarball_url
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         tag_name = excluded.tag_name,
         name = excluded.name,
@@ -134,6 +137,7 @@ router.put('/api/releases', (req, res) => {
         draft = excluded.draft,
         is_read = excluded.is_read,
         assets = excluded.assets,
+        updated_asset_ids = excluded.updated_asset_ids,
         repo_id = excluded.repo_id,
         repo_full_name = excluded.repo_full_name,
         repo_name = excluded.repo_name,
@@ -160,6 +164,7 @@ router.put('/api/releases', (req, res) => {
           release.draft ? 1 : 0,
           hasExplicitIsRead ? (release.is_read ? 1 : 0) : 0,
           JSON.stringify(release.assets ?? []),
+          serializeUpdatedAssetIds(release.updated_asset_ids),
           repository?.id ?? release.repo_id ?? null,
           repository?.full_name ?? release.repo_full_name ?? null,
           repository?.name ?? release.repo_name ?? null,

--- a/server/src/routes/sync.ts
+++ b/server/src/routes/sync.ts
@@ -238,7 +238,7 @@ router.post('/api/sync/import', (req, res) => {
             draft = excluded.draft,
             is_read = releases.is_read,
             assets = excluded.assets,
-            updated_asset_ids = excluded.updated_asset_ids,
+            updated_asset_ids = CASE WHEN ? = 1 THEN excluded.updated_asset_ids ELSE releases.updated_asset_ids END,
             repo_id = excluded.repo_id,
             repo_full_name = excluded.repo_full_name,
             repo_name = excluded.repo_name,
@@ -262,7 +262,7 @@ router.post('/api/sync/import', (req, res) => {
             draft = excluded.draft,
             is_read = excluded.is_read,
             assets = excluded.assets,
-            updated_asset_ids = excluded.updated_asset_ids,
+            updated_asset_ids = CASE WHEN ? = 1 THEN excluded.updated_asset_ids ELSE releases.updated_asset_ids END,
             repo_id = excluded.repo_id,
             repo_full_name = excluded.repo_full_name,
             repo_name = excluded.repo_name,
@@ -272,6 +272,7 @@ router.post('/api/sync/import', (req, res) => {
         for (const r of rels) {
           const repository = r.repository as { id?: number; full_name?: string; name?: string } | undefined;
           const hasExplicitIsRead = typeof r.is_read === 'boolean';
+          const hasExplicitUpdatedAssetIds = Object.hasOwn(r, 'updated_asset_ids');
           const relStmt = hasExplicitIsRead ? relStmtOverwriteIsRead : relStmtPreserveIsRead;
           relStmt.run(
             r.id, r.tag_name ?? null, r.name ?? null, r.body ?? null,
@@ -286,7 +287,8 @@ router.post('/api/sync/import', (req, res) => {
             r.repo_full_name ?? repository?.full_name ?? null,
             r.repo_name ?? repository?.name ?? null,
             r.zipball_url ?? null,
-            r.tarball_url ?? null
+            r.tarball_url ?? null,
+            hasExplicitUpdatedAssetIds ? 1 : 0
           );
         }
         counts.releases = rels.length;

--- a/server/src/routes/sync.ts
+++ b/server/src/routes/sync.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { getDb } from '../db/connection.js';
 import { encrypt, decrypt } from '../services/crypto.js';
 import { config } from '../config.js';
+import { serializeUpdatedAssetIds } from '../services/releaseAssets.js';
 
 const router = Router();
 
@@ -223,10 +224,10 @@ router.post('/api/sync/import', (req, res) => {
         const relStmtPreserveIsRead = db.prepare(`
           INSERT INTO releases (
             id, tag_name, name, body, html_url, published_at,
-            prerelease, draft, is_read, assets,
+            prerelease, draft, is_read, assets, updated_asset_ids,
             repo_id, repo_full_name, repo_name,
             zipball_url, tarball_url
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
           ON CONFLICT(id) DO UPDATE SET
             tag_name = excluded.tag_name,
             name = excluded.name,
@@ -237,6 +238,7 @@ router.post('/api/sync/import', (req, res) => {
             draft = excluded.draft,
             is_read = releases.is_read,
             assets = excluded.assets,
+            updated_asset_ids = excluded.updated_asset_ids,
             repo_id = excluded.repo_id,
             repo_full_name = excluded.repo_full_name,
             repo_name = excluded.repo_name,
@@ -246,10 +248,10 @@ router.post('/api/sync/import', (req, res) => {
         const relStmtOverwriteIsRead = db.prepare(`
           INSERT INTO releases (
             id, tag_name, name, body, html_url, published_at,
-            prerelease, draft, is_read, assets,
+            prerelease, draft, is_read, assets, updated_asset_ids,
             repo_id, repo_full_name, repo_name,
             zipball_url, tarball_url
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
           ON CONFLICT(id) DO UPDATE SET
             tag_name = excluded.tag_name,
             name = excluded.name,
@@ -260,6 +262,7 @@ router.post('/api/sync/import', (req, res) => {
             draft = excluded.draft,
             is_read = excluded.is_read,
             assets = excluded.assets,
+            updated_asset_ids = excluded.updated_asset_ids,
             repo_id = excluded.repo_id,
             repo_full_name = excluded.repo_full_name,
             repo_name = excluded.repo_name,
@@ -278,6 +281,7 @@ router.post('/api/sync/import', (req, res) => {
             // 避免新导入行写入 NULL 导致 unread 过滤（is_read = 0）漏行。
             hasExplicitIsRead ? (r.is_read ? 1 : 0) : 0,
             typeof r.assets === 'string' ? r.assets : JSON.stringify(r.assets ?? []),
+            serializeUpdatedAssetIds(r.updated_asset_ids),
             r.repo_id ?? repository?.id ?? null,
             r.repo_full_name ?? repository?.full_name ?? null,
             r.repo_name ?? repository?.name ?? null,

--- a/server/src/services/releaseAssets.ts
+++ b/server/src/services/releaseAssets.ts
@@ -1,0 +1,28 @@
+const isPositiveInteger = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isInteger(value) && value > 0;
+
+export function serializeUpdatedAssetIds(value: unknown): string {
+  let candidate: unknown = value;
+  if (typeof value === 'string') {
+    try {
+      candidate = JSON.parse(value);
+    } catch {
+      candidate = [];
+    }
+  }
+  if (!Array.isArray(candidate)) return '[]';
+
+  const ids = candidate.filter(isPositiveInteger);
+  return JSON.stringify([...new Set(ids)]);
+}
+
+export function parseUpdatedAssetIds(value: unknown): number[] {
+  if (typeof value !== 'string' || !value) return [];
+
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter(isPositiveInteger) : [];
+  } catch {
+    return [];
+  }
+}

--- a/server/src/types/api.ts
+++ b/server/src/types/api.ts
@@ -40,6 +40,7 @@ export interface ReleaseRow {
   prerelease: number;
   draft: number;
   is_read: number;
+  updated_asset_ids: string;
   zipball_url: string | null;
   tarball_url: string | null;
 }

--- a/server/tests/db/migrations.test.ts
+++ b/server/tests/db/migrations.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+async function loadDatabase() {
+  try {
+    return (await import('better-sqlite3')).default;
+  } catch {
+    return null;
+  }
+}
+
+describe('database migrations', () => {
+  it('adds updated_asset_ids when upgrading an existing v1 database', async () => {
+    const Database = await loadDatabase();
+    if (!Database) return;
+
+    const { runMigrations } = await import('../../src/db/migrations.js');
+    const db = new Database(':memory:');
+    db.exec(`
+      CREATE TABLE schema_version (
+        version INTEGER PRIMARY KEY,
+        applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      INSERT INTO schema_version (version) VALUES (1);
+      CREATE TABLE releases (id INTEGER PRIMARY KEY);
+    `);
+
+    try {
+      runMigrations(db);
+
+      const columns = db.prepare('PRAGMA table_info(releases)').all() as Array<{
+        name: string;
+        dflt_value: string | null;
+      }>;
+      const updatedAssetIds = columns.find((column) => column.name === 'updated_asset_ids');
+
+      expect(updatedAssetIds).toBeDefined();
+      expect(updatedAssetIds?.dflt_value).toBe("'[]'");
+      expect(db.prepare('SELECT MAX(version) AS version FROM schema_version').get()).toEqual({ version: 2 });
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/server/tests/routes/releasesUpsert.test.ts
+++ b/server/tests/routes/releasesUpsert.test.ts
@@ -20,6 +20,33 @@ const createTestApp = () => {
 /**
  * Mock DB 只记录 prepare 收到的 SQL 与每次 run 的参数，便于断言合并 UPSERT 的行为。
  */
+async function createReleaseDb() {
+  const Database = (await import('better-sqlite3')).default;
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE releases (
+      id INTEGER PRIMARY KEY,
+      tag_name TEXT NOT NULL,
+      name TEXT,
+      body TEXT,
+      html_url TEXT,
+      published_at TEXT,
+      prerelease INTEGER DEFAULT 0,
+      draft INTEGER DEFAULT 0,
+      is_read INTEGER DEFAULT 0,
+      assets TEXT,
+      updated_asset_ids TEXT NOT NULL DEFAULT '[]',
+      repo_id INTEGER NOT NULL,
+      repo_full_name TEXT NOT NULL,
+      repo_name TEXT NOT NULL,
+      zipball_url TEXT,
+      tarball_url TEXT
+    )
+  `);
+  getDbMock.mockReturnValue(db);
+  return db;
+}
+
 function captureStatements() {
   const statements: { sql: string; params: unknown[][] }[] = [];
   const exec: Record<string, unknown> = {};
@@ -69,6 +96,8 @@ describe('PUT /api/releases merge upsert', () => {
     expect(sql).not.toContain('is_read = excluded.is_read');
     // 新插入时 is_read 传入 0（默认未读）
     expect(statements[0].params[8]).toBe(0);
+    expect(statements[0].params[16]).toBe(0);
+    expect(sql).toContain('updated_asset_ids = CASE WHEN ? = 1 THEN excluded.updated_asset_ids ELSE releases.updated_asset_ids END');
   });
 
   it('overwrites is_read when the release carries it explicitly', async () => {
@@ -81,6 +110,7 @@ describe('PUT /api/releases merge upsert', () => {
     const sql = statements[0].sql;
     expect(sql).toContain('is_read = excluded.is_read');
     expect(statements[0].params[8]).toBe(1);
+    expect(statements[0].params[16]).toBe(0);
   });
 
   it('persists updated_asset_ids with release data', async () => {
@@ -91,8 +121,39 @@ describe('PUT /api/releases merge upsert', () => {
       .expect(200);
 
     const sql = statements[0].sql;
-    expect(sql).toContain('updated_asset_ids = excluded.updated_asset_ids');
+    expect(sql).toContain('updated_asset_ids = CASE WHEN ? = 1 THEN excluded.updated_asset_ids ELSE releases.updated_asset_ids END');
     expect(statements[0].params[10]).toBe('[100,101]');
+    expect(statements[0].params[16]).toBe(1);
+  });
+
+  it('preserves stored asset markers when the update omits updated_asset_ids', async () => {
+    const db = await createReleaseDb();
+    try {
+      db.prepare(`
+        INSERT INTO releases (
+          id, tag_name, name, body, html_url, published_at,
+          prerelease, draft, is_read, assets, updated_asset_ids,
+          repo_id, repo_full_name, repo_name, zipball_url, tarball_url
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        1, 'v0', 'Old release', null, 'https://example.com/old', null,
+        0, 0, 1, '[]', '[100,101]', 10, 'owner/repo', 'repo', null, null
+      );
+
+      await request(createTestApp())
+        .put('/api/releases')
+        .send({ releases: [sampleRelease({ name: 'New release' })] })
+        .expect(200);
+
+      const row = db.prepare('SELECT updated_asset_ids, name FROM releases WHERE id = 1').get() as {
+        updated_asset_ids: string;
+        name: string;
+      };
+      expect(row.updated_asset_ids).toBe('[100,101]');
+      expect(row.name).toBe('New release');
+    } finally {
+      db.close();
+    }
   });
 
   it('updates data columns while preserving is_read on conflict', async () => {

--- a/server/tests/routes/releasesUpsert.test.ts
+++ b/server/tests/routes/releasesUpsert.test.ts
@@ -83,6 +83,18 @@ describe('PUT /api/releases merge upsert', () => {
     expect(statements[0].params[8]).toBe(1);
   });
 
+  it('persists updated_asset_ids with release data', async () => {
+    const { statements } = captureStatements();
+    await request(createTestApp())
+      .put('/api/releases')
+      .send({ releases: [sampleRelease({ updated_asset_ids: [100, 101] })] })
+      .expect(200);
+
+    const sql = statements[0].sql;
+    expect(sql).toContain('updated_asset_ids = excluded.updated_asset_ids');
+    expect(statements[0].params[10]).toBe('[100,101]');
+  });
+
   it('updates data columns while preserving is_read on conflict', async () => {
     const { statements } = captureStatements();
     await request(createTestApp())

--- a/server/tests/routes/syncUpsert.test.ts
+++ b/server/tests/routes/syncUpsert.test.ts
@@ -140,10 +140,10 @@ describe('POST /api/sync/import release upsert is_read semantics', () => {
 
     const idx = releasePreserveIndex(statements);
     expect(idx).toBeGreaterThan(-1);
-    // repo_id / full_name / name 位于 is_read(8)、assets(9) 之后
-    expect(statements[idx].params[10]).toBe(20);
-    expect(statements[idx].params[11]).toBe('owner/other');
-    expect(statements[idx].params[12]).toBe('other');
+    // repo_id / full_name / name 位于 is_read(8)、assets(9)、updated_asset_ids(10) 之后
+    expect(statements[idx].params[11]).toBe(20);
+    expect(statements[idx].params[12]).toBe('owner/other');
+    expect(statements[idx].params[13]).toBe('other');
   });
 
   it('rejects decimal release id with 400 (must be integer)', async () => {
@@ -157,6 +157,37 @@ describe('POST /api/sync/import release upsert is_read semantics', () => {
       .expect(400);
 
     expect(res.body.code).toBe('RELEASE_ID_REQUIRED');
+  });
+
+  it('persists updated_asset_ids on import UPSERT', async () => {
+    const { statements } = captureStatements();
+    await request(createTestApp())
+      .post('/api/sync/import')
+      .send({
+        repositories: [],
+        releases: [validRelease({ updated_asset_ids: [100, 101] })],
+      })
+      .expect(200);
+
+    const idx = releasePreserveIndex(statements);
+    expect(idx).toBeGreaterThan(-1);
+    expect(statements[idx].sql).toContain('updated_asset_ids = excluded.updated_asset_ids');
+    expect(statements[idx].params[10]).toBe('[100,101]');
+  });
+
+  it('preserves exported JSON string form of updated_asset_ids', async () => {
+    const { statements } = captureStatements();
+    await request(createTestApp())
+      .post('/api/sync/import')
+      .send({
+        repositories: [],
+        releases: [validRelease({ updated_asset_ids: '[100,101]' })],
+      })
+      .expect(200);
+
+    const idx = releasePreserveIndex(statements);
+    expect(idx).toBeGreaterThan(-1);
+    expect(statements[idx].params[10]).toBe('[100,101]');
   });
 
   it('persists zipball_url and tarball_url on import UPSERT', async () => {
@@ -176,9 +207,9 @@ describe('POST /api/sync/import release upsert is_read semantics', () => {
     expect(idx).toBeGreaterThan(-1);
     expect(statements[idx].sql).toContain('zipball_url = excluded.zipball_url');
     expect(statements[idx].sql).toContain('tarball_url = excluded.tarball_url');
-    // zipball/tarball 位于 repo_name(12) 之后
-    expect(statements[idx].params[13]).toBe('https://example.com/zip');
-    expect(statements[idx].params[14]).toBe('https://example.com/tar');
+    // zipball/tarball 位于 repo_name(13) 之后
+    expect(statements[idx].params[14]).toBe('https://example.com/zip');
+    expect(statements[idx].params[15]).toBe('https://example.com/tar');
   });
 
   it('persists archive URLs on overwrite path as well', async () => {
@@ -201,7 +232,7 @@ describe('POST /api/sync/import release upsert is_read semantics', () => {
     expect(statements[idx].sql).toContain('tarball_url = excluded.tarball_url');
     // is_read: false → 覆盖分支绑定 0
     expect(statements[idx].params[8]).toBe(0);
-    expect(statements[idx].params[13]).toBe('https://example.com/z2');
-    expect(statements[idx].params[14]).toBe('https://example.com/t2');
+    expect(statements[idx].params[14]).toBe('https://example.com/z2');
+    expect(statements[idx].params[15]).toBe('https://example.com/t2');
   });
 });

--- a/server/tests/routes/syncUpsert.test.ts
+++ b/server/tests/routes/syncUpsert.test.ts
@@ -23,6 +23,33 @@ const createTestApp = () => {
 /**
  * Mock DB：只记录 prepare 收到的 SQL 与每次 run 的参数，便于断言导入合并 UPSERT 的 is_read 语义。
  */
+async function createReleaseDb() {
+  const Database = (await import('better-sqlite3')).default;
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE releases (
+      id INTEGER PRIMARY KEY,
+      tag_name TEXT NOT NULL,
+      name TEXT,
+      body TEXT,
+      html_url TEXT,
+      published_at TEXT,
+      prerelease INTEGER DEFAULT 0,
+      draft INTEGER DEFAULT 0,
+      is_read INTEGER DEFAULT 0,
+      assets TEXT,
+      updated_asset_ids TEXT NOT NULL DEFAULT '[]',
+      repo_id INTEGER NOT NULL,
+      repo_full_name TEXT NOT NULL,
+      repo_name TEXT NOT NULL,
+      zipball_url TEXT,
+      tarball_url TEXT
+    )
+  `);
+  getDbMock.mockReturnValue(db);
+  return db;
+}
+
 function captureStatements() {
   const statements: { sql: string; params: unknown[][] }[] = [];
   const exec: Record<string, unknown> = {};
@@ -87,6 +114,8 @@ describe('POST /api/sync/import release upsert is_read semantics', () => {
     // is_read 位于 (id, tag_name, name, body, html_url, published_at, prerelease, draft, is_read, ...) 第 9 位
     // 非显式时落 0（与 releases 表 DEFAULT 0 语义一致），避免新导入行落 NULL 导致 unread 过滤漏行
     expect(releaseStmt.params[8]).toBe(0);
+    expect(releaseStmt.params[16]).toBe(0);
+    expect(releaseStmt.sql).toContain('updated_asset_ids = CASE WHEN ? = 1 THEN excluded.updated_asset_ids ELSE releases.updated_asset_ids END');
     // 覆盖分支语句不应被命中
     expect(releaseOverwriteIndex(statements)).toBe(-1);
   });
@@ -106,8 +135,39 @@ describe('POST /api/sync/import release upsert is_read semantics', () => {
     // 覆盖分支：冲突时 is_read = excluded.is_read（用快照中的已读状态覆盖）
     expect(statements[idx].sql).toContain('is_read = excluded.is_read');
     expect(statements[idx].params[8]).toBe(1);
+    expect(statements[idx].params[16]).toBe(0);
     // 保留分支语句不应被命中
     expect(releasePreserveIndex(statements)).toBe(-1);
+  });
+
+  it('preserves stored asset markers when an imported snapshot omits updated_asset_ids', async () => {
+    const db = await createReleaseDb();
+    try {
+      db.prepare(`
+        INSERT INTO releases (
+          id, tag_name, name, body, html_url, published_at,
+          prerelease, draft, is_read, assets, updated_asset_ids,
+          repo_id, repo_full_name, repo_name, zipball_url, tarball_url
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        1, 'v0', 'Old release', null, 'https://example.com/old', null,
+        0, 0, 1, '[]', '[100,101]', 10, 'owner/repo', 'repo', null, null
+      );
+
+      await request(createTestApp())
+        .post('/api/sync/import')
+        .send({ repositories: [], releases: [validRelease({ name: 'Imported release' })] })
+        .expect(200);
+
+      const row = db.prepare('SELECT updated_asset_ids, name FROM releases WHERE id = 1').get() as {
+        updated_asset_ids: string;
+        name: string;
+      };
+      expect(row.updated_asset_ids).toBe('[100,101]');
+      expect(row.name).toBe('Imported release');
+    } finally {
+      db.close();
+    }
   });
 
   it('rejects release snapshot missing required repository fields with 400', async () => {
@@ -171,8 +231,9 @@ describe('POST /api/sync/import release upsert is_read semantics', () => {
 
     const idx = releasePreserveIndex(statements);
     expect(idx).toBeGreaterThan(-1);
-    expect(statements[idx].sql).toContain('updated_asset_ids = excluded.updated_asset_ids');
+    expect(statements[idx].sql).toContain('updated_asset_ids = CASE WHEN ? = 1 THEN excluded.updated_asset_ids ELSE releases.updated_asset_ids END');
     expect(statements[idx].params[10]).toBe('[100,101]');
+    expect(statements[idx].params[16]).toBe(1);
   });
 
   it('preserves exported JSON string form of updated_asset_ids', async () => {
@@ -188,6 +249,7 @@ describe('POST /api/sync/import release upsert is_read semantics', () => {
     const idx = releasePreserveIndex(statements);
     expect(idx).toBeGreaterThan(-1);
     expect(statements[idx].params[10]).toBe('[100,101]');
+    expect(statements[idx].params[16]).toBe(1);
   });
 
   it('persists zipball_url and tarball_url on import UPSERT', async () => {

--- a/src/components/ReleaseCard.tsx
+++ b/src/components/ReleaseCard.tsx
@@ -42,6 +42,7 @@ interface ReleaseCardProps {
   onToggleFullContent: (e: React.MouseEvent) => void;
   onUnsubscribe: () => void;
   onMarkAsRead: () => void;
+  onMarkAssetAsRead: (assetId: number) => void;
   language: 'zh' | 'en';
   formatFileSize: (bytes: number) => string;
 }
@@ -61,6 +62,7 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
   onToggleFullContent,
   onUnsubscribe,
   onMarkAsRead,
+  onMarkAssetAsRead,
   language,
   formatFileSize,
 }) => {
@@ -361,7 +363,7 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
               </div>
 
               <div className="bg-gray-50 dark:bg-[#121314] rounded border border-black/[0.06] dark:border-white/[0.04] max-h-72 overflow-y-auto">
-                {downloadLinks.map((link, index) => {
+                {downloadLinks.map((link) => {
                   const isRpcEnabled = rpcDownloadConfig.enabled;
                   const isDownloading = downloadingRef.current[link.url];
                   const isDownloaded = downloadedRef.current[link.url];
@@ -372,9 +374,12 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
                   if (isRpcEnabled) {
                     return (
                       <button
-                        key={index}
+                        key={link.assetId ?? link.url}
                         onClick={(e) => {
                           e.stopPropagation();
+                          if (link.assetId !== undefined) {
+                            onMarkAssetAsRead(link.assetId);
+                          }
                           handleRpcDownload(link);
                         }}
                         disabled={isDownloading || isDownloaded}
@@ -415,14 +420,19 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
 
                   return (
                     <a
-                      key={index}
+                      key={link.assetId ?? link.url}
                       href={link.url}
                       target="_blank"
                       rel="noopener noreferrer"
                       className={`flex items-center justify-between px-4 py-3 hover:bg-light-surface dark:hover:bg-white/[0.06] transition-colors border-b border-black/[0.04] dark:border-white/[0.04] last:border-b-0 ${
                         link.isSourceCode ? 'bg-gray-100 dark:bg-white/[0.04]' : ''
                       }`}
-                      onClick={(e) => e.stopPropagation()}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (link.assetId !== undefined) {
+                          onMarkAssetAsRead(link.assetId);
+                        }
+                      }}
                     >
                       <div className="flex items-center space-x-1.5 min-w-0 flex-1">
                         {link.isSourceCode ? (

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -42,6 +42,7 @@ export const ReleaseTimeline: React.FC = () => {
     addReleases,
     upsertReleases,
     markReleaseAsRead,
+    markReleaseAssetAsRead,
     markAllReleasesAsRead,
     batchUnsubscribeReleases,
     removeReleasesByRepoFullName,
@@ -133,8 +134,6 @@ export const ReleaseTimeline: React.FC = () => {
         newSet.delete(releaseId);
       } else {
         newSet.add(releaseId);
-        // Mark as read when expanding assets
-        markReleaseAsRead(releaseId);
       }
       return newSet;
     });
@@ -1241,6 +1240,7 @@ export const ReleaseTimeline: React.FC = () => {
                 onToggleFullContent={(e) => toggleFullContent(release.id, e)}
                 onUnsubscribe={() => handleUnsubscribeRelease(release.repository.id)}
                 onMarkAsRead={() => markReleaseAsRead(release.id)}
+                onMarkAssetAsRead={(assetId) => markReleaseAssetAsRead(release.id, assetId)}
                 language={language}
                 formatFileSize={formatFileSize}
               />
@@ -1341,6 +1341,7 @@ export const ReleaseTimeline: React.FC = () => {
                             onToggleFullContent={(e) => toggleFullContent(release.id, e)}
                             onUnsubscribe={() => handleUnsubscribeRelease(release.repository.id)}
                             onMarkAsRead={() => markReleaseAsRead(release.id)}
+                            onMarkAssetAsRead={(assetId) => markReleaseAssetAsRead(release.id, assetId)}
                             language={language}
                             formatFileSize={formatFileSize}
                           />

--- a/src/store/useAppStore.test.ts
+++ b/src/store/useAppStore.test.ts
@@ -143,6 +143,21 @@ describe('useAppStore release add/upsert actions', () => {
     expect(useAppStore.getState().releases.map(r => r.id)).toEqual([1]);
   });
 
+  it('markReleaseAssetAsRead clears only the clicked asset marker', () => {
+    useAppStore.getState().addReleases([makeRelease(1, { updated_asset_ids: [101, 999] })]);
+
+    useAppStore.getState().markReleaseAssetAsRead(1, 101);
+
+    const afterFirstClick = useAppStore.getState().releases[0];
+    expect(afterFirstClick.updated_asset_ids).toEqual([999]);
+    expect(useAppStore.getState().readReleases.has(1)).toBe(false);
+
+    useAppStore.getState().markReleaseAssetAsRead(1, 999);
+
+    expect(useAppStore.getState().releases[0].updated_asset_ids).toEqual([]);
+    expect(useAppStore.getState().readReleases.has(1)).toBe(false);
+  });
+
   it('regression: asset update resets read state and gates the "Assets updated" indicator until marked read', () => {
     const publishedAt = '2026-01-01T00:00:00.000Z';
     const assetAtPublish = { ...makeRelease(1).assets[0], updated_at: publishedAt };

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -406,6 +406,7 @@ interface AppActions {
   removeReleasesByRepoId: (repoId: number) => void;
   removeReleasesByRepoFullName: (fullName: string) => void;
   markReleaseAsRead: (releaseId: number) => void;
+  markReleaseAssetAsRead: (releaseId: number, assetId: number) => void;
   markAllReleasesAsRead: () => void;
   setReleaseSourceSettings: (settings: ReleaseSourceSettings) => void;
   setReleaseEnabledSources: (sourceIds: ReleaseSourceId[]) => void;
@@ -2082,6 +2083,24 @@ export const useAppStore = create<AppState & AppActions>()(
         }
 
         return { readReleases: newReadReleases };
+      }),
+      markReleaseAssetAsRead: (releaseId, assetId) => set((state) => {
+        const targetRelease = state.releases.find(release => release.id === releaseId);
+        if (!targetRelease?.updated_asset_ids?.includes(assetId)) {
+          return state;
+        }
+
+        const updatedAssetIds = targetRelease.updated_asset_ids.filter(id => id !== assetId);
+        return {
+          releases: state.releases.map(release =>
+            release.id === releaseId
+              ? {
+                  ...release,
+                  updated_asset_ids: updatedAssetIds,
+                }
+              : release
+          ),
+        };
       }),
       markAllReleasesAsRead: () => set((state) => {
         const allReleaseIds = new Set(state.releases.map(r => r.id));


### PR DESCRIPTION
## Summary

- keep the `Asset updated` marker visible when a Release's asset list is expanded
- clear only the clicked asset marker, without marking the Release as read
- preserve Release-level read behavior for Release links and Release notes
- persist `updated_asset_ids` through the Release API, sync import/export, and database migrations

## Validation

- `npm run test:run`
- `npm run lint`
- `npm run build`
- `cd server && npm test`
- `cd server && npm run build`

All tests and builds pass. The existing lint warning in `src/components/settings/VectorSearchSettings.tsx` remains unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asset-level read tracking for release assets.
  * Opening or downloading an asset now marks only that asset as read, without marking the entire release.
  * Asset read status is preserved across release updates and synchronization.

* **Bug Fixes**
  * Improved handling of asset read markers by removing only the selected asset.
  * Invalid, duplicate, or malformed asset identifiers are safely normalized.

* **Tests**
  * Added coverage for database upgrades, release updates, synchronization, and asset-level read behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->