### PR TITLE
fix: handle GitHub 204 on watched repos sync (#285)

### DIFF
--- a/src/components/ReleaseSourceSettingsModal.tsx
+++ b/src/components/ReleaseSourceSettingsModal.tsx
@@ -224,7 +224,9 @@ const WatchCustomReleaseSyncPanel: React.FC<WatchCustomReleaseSyncPanelProps> = 
     setIsSyncing(true);
     try {
       const githubApi = new GitHubApiService(githubToken);
-      const watchedRepos = await githubApi.getAllWatchedRepositoriesForCurrentUser();
+      // 只拉 /user/subscriptions（含私有仓）。/users/{login}/subscriptions 已被 GitHub 改为
+      // 恒定返回 204 空响应体，且其结果本就是前者的公开子集，并行合并只会拖垮整个同步。
+      const watchedRepos = await githubApi.getAllWatchedRepositories();
       const hiddenByRepo = new Map(repos.map(repo => [normalizeRepoKey(repo.full_name), repo.release_hidden]));
       const sourceRepos = watchedRepos.map(repo => ({
         ...repositoryToCustomReleaseRepository(repo, WATCH_CUSTOM_RELEASE_SOURCE_ID),

--- a/src/services/githubApi.test.ts
+++ b/src/services/githubApi.test.ts
@@ -165,3 +165,44 @@ describe('GitHubApiService.getMultipleRepositoryReleases asset refresh', () => {
     expect(result.releases.map(r => r.id)).toEqual([50]);
   });
 });
+
+describe('GitHubApiService.getWatchedRepositories', () => {
+  it('returns [] when GitHub responds 204 and makeRequest normalizes the body to null', async () => {
+    const service = new GitHubApiService('token');
+    // 复现 issue #285：GitHub 对 watched repos 返回 204 空响应体，makeRequest 归一化为 null
+    vi.spyOn(service, 'makeRequest' as never).mockResolvedValueOnce(null as never);
+
+    const repos = await service.getWatchedRepositories();
+
+    expect(repos).toEqual([]);
+  });
+
+  it('normalizes raw license objects into SPDX ids', async () => {
+    const service = new GitHubApiService('token');
+    const repo = makeRepository(10, 'owner/repo', {
+      license: { key: 'mit', name: 'MIT License', spdx_id: 'MIT', url: 'https://api.github.com/licenses/mit', node_id: 'x' } as never,
+    });
+    vi.spyOn(service, 'makeRequest' as never).mockResolvedValueOnce([repo] as never);
+
+    const [result] = await service.getWatchedRepositories();
+
+    expect(result.license).toBe('MIT');
+  });
+
+  it('paginates /user/subscriptions only and stops on a partial page', async () => {
+    const service = new GitHubApiService('token');
+    const makeRequestSpy = vi.spyOn(service, 'makeRequest' as never)
+      .mockResolvedValueOnce(Array.from({ length: 100 }, (_, i) => makeRepository(i + 1, `owner/repo-${i + 1}`)) as never)
+      .mockResolvedValueOnce([makeRepository(999, 'owner/last')] as never);
+
+    const repos = await service.getAllWatchedRepositories();
+
+    expect(repos).toHaveLength(101);
+    // 固定分页行为与端点序列：只走 /user/subscriptions
+    // （旧的 /users/{login}/subscriptions 并行合并已整体移除，由编译器兜底）
+    expect(makeRequestSpy.mock.calls.map(c => (c[0] as string).split('?')[0])).toEqual([
+      '/user/subscriptions',
+      '/user/subscriptions',
+    ]);
+  });
+});

--- a/src/services/githubApi.ts
+++ b/src/services/githubApi.ts
@@ -612,23 +612,21 @@ export class GitHubApiService {
       .slice(0, maxChars);
   }
 
-  async getWatchedRepositories(page = 1, perPage = 100, username?: string): Promise<Repository[]> {
-    const endpoint = username
-      ? `/users/${encodeURIComponent(username)}/subscriptions?page=${page}&per_page=${perPage}`
-      : `/user/subscriptions?page=${page}&per_page=${perPage}`;
+  async getWatchedRepositories(page = 1, perPage = 100): Promise<Repository[]> {
     // GitHub 对 watched repos 同样返回原始 license 对象，这里统一归一化为 SPDX id / null，
     // 与 /user/starred 路径保持一致，避免下游 normalizeLicense 拿到对象时崩溃。
-    const repos = await this.makeRequest<Repository[]>(endpoint);
-    return repos.map((repo) => ({ ...repo, license: toLicenseSpdxId(repo.license) }));
+    // 空响应体（204）会被 makeRequest 归一化为 null，这里按空列表处理，避免 .map 抛错拖垮同步。
+    const repos = await this.makeRequest<Repository[] | null>(`/user/subscriptions?page=${page}&per_page=${perPage}`);
+    return (repos ?? []).map((repo) => ({ ...repo, license: toLicenseSpdxId(repo.license) }));
   }
 
-  async getAllWatchedRepositories(username?: string): Promise<Repository[]> {
+  async getAllWatchedRepositories(): Promise<Repository[]> {
     let allRepos: Repository[] = [];
     let page = 1;
     const perPage = 100;
 
     while (true) {
-      const repos = await this.getWatchedRepositories(page, perPage, username);
+      const repos = await this.getWatchedRepositories(page, perPage);
       if (repos.length === 0) break;
 
       allRepos = [...allRepos, ...repos];
@@ -640,19 +638,6 @@ export class GitHubApiService {
     }
 
     return allRepos;
-  }
-
-  async getAllWatchedRepositoriesForCurrentUser(): Promise<Repository[]> {
-    const currentUser = await this.getCurrentUser();
-    const [privateAware, publicProfile] = await Promise.all([
-      this.getAllWatchedRepositories(),
-      this.getAllWatchedRepositories(currentUser.login),
-    ]);
-    const reposByName = new Map<string, Repository>();
-    [...privateAware, ...publicProfile].forEach(repo => {
-      reposByName.set(repo.full_name.toLowerCase(), repo);
-    });
-    return Array.from(reposByName.values());
   }
 
   private decodeContentResponse(response: GitHubContentResponse): string {


### PR DESCRIPTION
## Problem (#285)

Watch 同步报“同步 Watch 仓库失败，请检查网络或 Token 权限”。带 Token 实测复现：

| 端点 | 现状 |
|---|---|
| `GET /user/subscriptions` | ✅ 200，返回完整 Watch 列表（含私有仓） |
| `GET /users/{login}/subscriptions` | ❌ **204 No Content**（空响应体；对任意用户均如此，属 GitHub 侧行为变更） |

旧逻辑在 `Promise.all` 中并行请求两端点；`makeRequest` 将 204 空体归一化为 `null`，`getWatchedRepositories` 随后对其 `.map()` 抛 TypeError，把本已成功拉到的 `/user/subscriptions` 数据一起拖垮，最终走到 catch 弹出失败提示。

## Changes

- 移除冗余的公开端点合并 `getAllWatchedRepositoriesForCurrentUser`：其结果本就是 `/user/subscriptions` 的公开子集，同步集合不变，且每次同步少打一条请求链（含一次多余的 `GET /user`）
- `getWatchedRepositories` 对空响应体（204 → `null`）防御为空列表，空 Watch 列表也能正常同步
- 新增回归测试：204→null 不再崩溃（对旧代码可复现失败）、license 对象归一化为 SPDX id、分页仅命中 `/user/subscriptions`

## Verification

- `npx tsc --noEmit` ✅
- `eslint`（三个改动文件）✅
- 全量测试 32 files / **336 tests** ✅（新增 3 条）
- 独立 code review 通过（无高/中级问题；低级建议已在提交前修复）

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watched-repository synchronization to reliably load repositories from the connected account.
  * Empty or unavailable repository responses are now handled gracefully without disrupting synchronization.
  * Repository license information is normalized for more consistent display.
  * Synchronization continues to preserve repository visibility settings and provide appropriate success or error feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->