### PR TITLE
fix: restore focus after closing README modal

### DIFF
--- a/src/components/ReadmeModal.tsx
+++ b/src/components/ReadmeModal.tsx
@@ -20,6 +20,7 @@ interface TocItem {
 interface ReadmeModalProps {
   isOpen: boolean;
   onClose: () => void;
+  onCloseAutoFocus?: () => void;
   repository: Repository | null;
 }
 
@@ -43,6 +44,7 @@ const isAbortError = (error: unknown, signal?: AbortSignal): boolean => {
 export const ReadmeModal: React.FC<ReadmeModalProps> = ({
   isOpen,
   onClose,
+  onCloseAutoFocus,
   repository
 }) => {
   const { githubToken, language, setReadmeModalOpen } = useAppStore();
@@ -592,6 +594,11 @@ export const ReadmeModal: React.FC<ReadmeModalProps> = ({
         showClose={false}
         aria-describedby={undefined}
         className="w-[calc(100%_-_2rem)] max-w-[1130px] min-w-0 overflow-hidden p-0"
+        onCloseAutoFocus={(event) => {
+          if (!onCloseAutoFocus) return;
+          event.preventDefault();
+          onCloseAutoFocus();
+        }}
       >
         <div className="relative flex max-h-[90vh] min-w-0 max-w-full w-full flex-col overflow-hidden bg-card dark:bg-card">
           {readmeContent && !loading && (

--- a/src/components/RepositoryCard.lazyReadme.test.tsx
+++ b/src/components/RepositoryCard.lazyReadme.test.tsx
@@ -42,6 +42,11 @@ const repository: Repository = {
   ai_platforms: ['web'],
 };
 
+type ReadmeModalMockProps = {
+  onClose: () => void;
+  onCloseAutoFocus?: () => void;
+};
+
 const storeState = {
   releaseSubscriptions: new Set<number>(),
   analyzingRepositoryIds: new Set<number>(),
@@ -76,6 +81,39 @@ describe('RepositoryCard README lazy boundary', () => {
     mocks.useAppStore.mockImplementation((selector?: (state: typeof storeState) => unknown) => (
       selector ? selector(storeState) : storeState
     ));
+  });
+
+  it('restores focus to the keyboard trigger after the README modal closes', async () => {
+    vi.doMock('./ReadmeModal', () => ({
+      ReadmeModal: ({ onClose, onCloseAutoFocus }: ReadmeModalMockProps) => (
+        <button
+          type="button"
+          onClick={() => {
+            onClose();
+            onCloseAutoFocus?.();
+          }}
+        >
+          Close README
+        </button>
+      ),
+    }));
+
+    const { RepositoryCard } = await import('./RepositoryCard');
+    const user = userEvent.setup();
+
+    render(
+      <TooltipProvider>
+        <RepositoryCard repository={repository} allCategories={[]} />
+      </TooltipProvider>,
+    );
+
+    const trigger = screen.getByRole('button', { name: /owner\/example-repository/i });
+    trigger.focus();
+    await user.keyboard('{Enter}');
+
+    await user.click(await screen.findByRole('button', { name: 'Close README' }));
+
+    expect(trigger).toHaveFocus();
   });
 
   it('renders the existing error boundary when the README lazy chunk cannot load', async () => {

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -24,9 +24,19 @@ const LazyReadmeModal = React.lazy(() =>
   import('./ReadmeModal').then((module) => ({ default: module.ReadmeModal }))
 );
 
-const ReadmeModalLoadingFallback: React.FC<{ onClose: () => void }> = ({ onClose }) => (
+const ReadmeModalLoadingFallback: React.FC<{
+  onClose: () => void;
+  onCloseAutoFocus: () => void;
+}> = ({ onClose, onCloseAutoFocus }) => (
   <Dialog open onOpenChange={(open) => !open && onClose()}>
-    <DialogContent aria-describedby={undefined} className="w-[calc(100%_-_2rem)] max-w-[1130px] p-6">
+    <DialogContent
+      aria-describedby={undefined}
+      className="w-[calc(100%_-_2rem)] max-w-[1130px] p-6"
+      onCloseAutoFocus={(event) => {
+        event.preventDefault();
+        onCloseAutoFocus();
+      }}
+    >
       <DialogTitle className="sr-only">Loading README</DialogTitle>
       <div className="flex min-h-40 flex-col items-center justify-center gap-4" role="status" aria-live="polite">
         <Loader2 className="h-8 w-8 animate-spin text-primary" aria-hidden="true" />
@@ -201,6 +211,10 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
   const [isActionsMenuOpen, setIsActionsMenuOpen] = useState(false);
   const cardRef = useRef<HTMLDivElement>(null);
   const menuDismissedByPointerDownRef = useRef(false);
+
+  const restoreReadmeTriggerFocus = useCallback(() => {
+    cardRef.current?.focus();
+  }, []);
 
   useEffect(() => {
     if (viewMode !== 'list' || selectionMode) {
@@ -1349,10 +1363,18 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
       {/* README Modal - lazily loaded and rendered outside the card container */}
       {readmeModalOpen && createPortal(
         <ErrorBoundary>
-          <Suspense fallback={<ReadmeModalLoadingFallback onClose={() => setReadmeModalOpen(false)} />}>
+          <Suspense
+            fallback={
+              <ReadmeModalLoadingFallback
+                onClose={() => setReadmeModalOpen(false)}
+                onCloseAutoFocus={restoreReadmeTriggerFocus}
+              />
+            }
+          >
             <LazyReadmeModal
               isOpen={readmeModalOpen}
               onClose={() => setReadmeModalOpen(false)}
+              onCloseAutoFocus={restoreReadmeTriggerFocus}
               repository={repository}
             />
           </Suspense>


### PR DESCRIPTION
## Summary

Fixes the README modal accessibility regression found during PR-02 Web verification. Closing the modal now restores focus to the repository card that opened it, instead of leaving focus on `body`.

## Changes

- Add an optional `onCloseAutoFocus` callback to `ReadmeModal` and prevent Radix's default focus restoration only when a caller supplies a target.
- Restore the owning `RepositoryCard` ref on close for both the resolved README modal and the lazy-loading fallback dialog.
- Add a regression test covering card focus → keyboard `Enter` → README close → focus returns to the card.

## Validation

- `npm run typecheck`
- Targeted README lazy-boundary tests: 2/2 passed.
- Full lint, test suite, production build, and 3,000 KiB bundle gate passed.
- Production-browser retest using only a local controlled API response confirmed the closed dialog restores `document.activeElement` to the repository card.

No GitHub mutations or real token were used in the browser retest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard focus handling when closing lazily loaded README dialogs.
  * Focus now reliably returns to the control that opened the dialog, including while content is loading.
  * Added support for custom focus restoration behavior when closing README dialogs.

* **Tests**
  * Added coverage verifying focus returns to the keyboard trigger after closing the README dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->