### PR TITLE
refactor: centralize repository state transitions as pure commands

### DIFF
--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -17,6 +17,7 @@ import { NO_LICENSE_SENTINEL, normalizeLicense } from '../utils/licenseFilter';
 import { shallow } from 'zustand/shallow';
 import { useDialog } from '../hooks/useDialog';
 import { logger } from '../services/logger';
+import { applyAnalysisFailure, applyAnalysisSuccess } from '../features/repositories/application/repositoryPatches';
 import { Button } from './ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from './ui/dropdown-menu';
 
@@ -407,17 +408,14 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
 
       if (controller.signal.aborted) return;
 
-      const updatedRepo = {
-        ...repository,
-        ai_summary: result.summary,
-        ai_tags: result.tags,
-        ai_platforms: result.platforms,
-        custom_category: result.custom_category,
-        category_locked: result.category_locked,
-        analyzed_at: result.analyzed_at,
-        analysis_failed: result.analysis_failed,
-        analysis_error: undefined,
-      };
+      const updatedRepo = applyAnalysisSuccess(repository, {
+        summary: result.summary,
+        tags: result.tags,
+        platforms: result.platforms,
+        category: result.custom_category,
+        categoryLocked: result.category_locked,
+        analyzedAt: result.analyzed_at,
+      });
 
       const updateStartedAt = performance.now();
       updateRepository(updatedRepo);
@@ -441,12 +439,10 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
           ? error.message
           : (language === 'zh' ? 'AI分析失败，请检查AI配置和网络连接' : 'AI analysis failed, please check AI configuration and network connection');
         const failedResult = createFailedAnalysisResult(errorMsg);
-        const failedRepo = {
-          ...repository,
-          analyzed_at: failedResult.analyzed_at,
-          analysis_failed: failedResult.analysis_failed,
-          analysis_error: failedResult.analysis_error,
-        };
+        const failedRepo = applyAnalysisFailure(repository, {
+          analyzedAt: failedResult.analyzed_at,
+          error: failedResult.analysis_error,
+        });
 
         const updateStartedAt = performance.now();
         updateRepository(failedRepo);

--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -17,6 +17,15 @@ import { useDialog } from '../hooks/useDialog';
 import { Button } from './ui/button';
 import { RadioGroup, RadioGroupItem } from './ui/radio-group';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from './ui/dropdown-menu';
+import {
+  applyAnalysisFailure,
+  applyAnalysisSuccess,
+  applyCategoryAssignment,
+  lockRepositoryCategory,
+  restoreRepositoryFields,
+  setReleaseSubscriptionMarker,
+  unlockRepositoryCategory,
+} from '../features/repositories/application/repositoryPatches';
 
 interface RepositoryListProps {
   repositories: Repository[];
@@ -350,25 +359,20 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
 
           const wasCategoryLocked = !!result.repo.category_locked;
 
-          updateRepository({
-            ...result.repo,
-            ai_summary: result.summary,
-            ai_tags: result.tags,
-            ai_platforms: result.platforms,
-            custom_category: resolvedCategory,
-            category_locked: wasCategoryLocked,
-            analyzed_at: new Date().toISOString(),
-            analysis_failed: false,
-            analysis_error: undefined,
-          });
+          updateRepository(applyAnalysisSuccess(result.repo, {
+            summary: result.summary,
+            tags: result.tags,
+            platforms: result.platforms,
+            category: resolvedCategory,
+            categoryLocked: wasCategoryLocked,
+            analyzedAt: new Date().toISOString(),
+          }));
           successCount++;
         } else {
-          updateRepository({
-            ...result.repo,
-            analyzed_at: new Date().toISOString(),
-            analysis_failed: true,
-            analysis_error: result.error?.message || undefined,
-          });
+          updateRepository(applyAnalysisFailure(result.repo, {
+            analyzedAt: new Date().toISOString(),
+            error: result.error?.message || undefined,
+          }));
           failedCount++;
         }
       };
@@ -504,53 +508,9 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
 
     for (const repo of selectedRepos) {
       try {
-        const updatedRepo = { ...repo };
+        const updatedRepo = restoreRepositoryFields(repo, config, new Date().toISOString());
 
-        if (config.description.enabled) {
-          updatedRepo.custom_description = undefined;
-          if (config.description.target === 'original') {
-            updatedRepo.ai_summary = undefined;
-            updatedRepo.analyzed_at = undefined;
-            updatedRepo.analysis_failed = undefined;
-            updatedRepo.analysis_error = undefined;
-          }
-        }
-
-        if (config.tags.enabled) {
-          updatedRepo.custom_tags = undefined;
-          if (config.tags.target === 'original') {
-            updatedRepo.ai_tags = undefined;
-            updatedRepo.ai_platforms = undefined;
-            updatedRepo.analyzed_at = undefined;
-            updatedRepo.analysis_failed = undefined;
-            updatedRepo.analysis_error = undefined;
-          }
-        }
-
-        if (config.category.enabled) {
-          updatedRepo.custom_category = undefined;
-          updatedRepo.category_locked = false;
-          if (config.category.target === 'original') {
-            updatedRepo.ai_tags = undefined;
-            updatedRepo.ai_platforms = undefined;
-            updatedRepo.analyzed_at = undefined;
-            updatedRepo.analysis_failed = undefined;
-            updatedRepo.analysis_error = undefined;
-          }
-        }
-
-        const hasChanges = updatedRepo.custom_description !== repo.custom_description ||
-          updatedRepo.custom_tags !== repo.custom_tags ||
-          updatedRepo.custom_category !== repo.custom_category ||
-          updatedRepo.category_locked !== repo.category_locked ||
-          updatedRepo.ai_summary !== repo.ai_summary ||
-          updatedRepo.ai_tags !== repo.ai_tags ||
-          updatedRepo.ai_platforms !== repo.ai_platforms ||
-          updatedRepo.analyzed_at !== repo.analyzed_at ||
-          updatedRepo.analysis_failed !== repo.analysis_failed;
-
-        if (hasChanges) {
-          updatedRepo.last_edited = new Date().toISOString();
+        if (updatedRepo) {
           updateRepository(updatedRepo);
         }
         successCount++;
@@ -708,25 +668,20 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
                 const wasCategoryLocked = !!result.repo.category_locked;
                 const shouldKeepLocked = wasCategoryLocked && resolvedCategory !== undefined && resolvedCategory !== '';
 
-                updateRepository({
-                  ...result.repo,
-                  ai_summary: result.summary,
-                  ai_tags: result.tags,
-                  ai_platforms: result.platforms,
-                  custom_category: resolvedCategory,
-                  category_locked: shouldKeepLocked || wasCategoryLocked,
-                  analyzed_at: new Date().toISOString(),
-                  analysis_failed: false,
-                  analysis_error: undefined,
-                });
+                updateRepository(applyAnalysisSuccess(result.repo, {
+                  summary: result.summary,
+                  tags: result.tags,
+                  platforms: result.platforms,
+                  category: resolvedCategory,
+                  categoryLocked: shouldKeepLocked || wasCategoryLocked,
+                  analyzedAt: new Date().toISOString(),
+                }));
                 successCount++;
               } else {
-                updateRepository({
-                  ...result.repo,
-                  analyzed_at: new Date().toISOString(),
-                  analysis_failed: true,
-                  analysis_error: result.error?.message || undefined,
-                });
+                updateRepository(applyAnalysisFailure(result.repo, {
+                  analyzedAt: new Date().toISOString(),
+                  error: result.error?.message || undefined,
+                }));
                 failedCount++;
               }
             };
@@ -775,8 +730,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
           for (const repo of repos) {
             try {
               // 显式设置订阅为 true，避免误取消已订阅仓库
-              const updatedRepo = { ...repo, subscribed_to_releases: true };
-              updateRepository(updatedRepo);
+              updateRepository(setReleaseSubscriptionMarker(repo, true));
               // 只在未订阅时才调用 toggle，避免误取消
               if (!releaseSubscriptions.has(repo.id)) {
                 toggleReleaseSubscription(repo.id);
@@ -812,8 +766,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
           const failedRepos: string[] = [];
           for (const repo of subscribedRepos) {
             try {
-              const updatedRepo = { ...repo, subscribed_to_releases: false };
-              updateRepository(updatedRepo);
+              updateRepository(setReleaseSubscriptionMarker(repo, false));
             } catch (error) {
               console.error(`Failed to update repository ${repo.full_name}:`, error);
               failedRepos.push(repo.full_name);
@@ -848,12 +801,9 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
           for (const repo of repos) {
             try {
               // 只有有自定义分类的仓库才能锁定，锁定不改变自定义状态
-              if (repo.custom_category && repo.custom_category !== '') {
-                updateRepository({
-                  ...repo,
-                  category_locked: true,
-                  last_edited: new Date().toISOString()
-                });
+              const updatedRepo = lockRepositoryCategory(repo, new Date().toISOString());
+              if (updatedRepo) {
+                updateRepository(updatedRepo);
                 successCount++;
               } else {
                 skippedCount++;
@@ -890,11 +840,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
 
           for (const repo of repos) {
             try {
-              updateRepository({
-                ...repo,
-                category_locked: false,
-                last_edited: new Date().toISOString()
-              });
+              updateRepository(unlockRepositoryCategory(repo, new Date().toISOString()));
               successCount++;
             } catch (error) {
               console.error(`Failed to unlock category for ${repo.full_name}:`, error);
@@ -949,12 +895,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
         // 如果设置的分类与AI/默认一致，则清除自定义标记
         const customCategoryValue = computeCustomCategory(categoryName, aiCat, defaultCat);
 
-        updateRepository({
-          ...repo,
-          custom_category: customCategoryValue,
-          category_locked: customCategoryValue !== undefined && customCategoryValue !== '',
-          last_edited: new Date().toISOString()
-        });
+        updateRepository(applyCategoryAssignment(repo, customCategoryValue, new Date().toISOString()));
       } catch (error) {
         console.error(`Failed to categorize ${repo.full_name}:`, error);
         failedRepos.push(repo.full_name);

--- a/src/features/repositories/__tests__/repositoryPatches.test.ts
+++ b/src/features/repositories/__tests__/repositoryPatches.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, it } from 'vitest';
+import type { Repository } from '../../../types';
+import {
+  applyAnalysisFailure,
+  applyAnalysisSuccess,
+  applyCategoryAssignment,
+  lockRepositoryCategory,
+  restoreRepositoryFields,
+  setReleaseSubscriptionMarker,
+  unlockRepositoryCategory,
+} from '../application/repositoryPatches';
+
+const analyzedAt = '2026-08-25T10:00:00.000Z';
+const editedAt = '2026-08-25T10:05:00.000Z';
+
+const createRepository = (overrides: Partial<Repository> = {}): Repository => ({
+  id: 1,
+  name: 'repository',
+  full_name: 'owner/repository',
+  description: 'Original description',
+  html_url: 'https://github.com/owner/repository',
+  stargazers_count: 10,
+  forks_count: 2,
+  forks: 2,
+  language: 'TypeScript',
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-02T00:00:00.000Z',
+  pushed_at: '2026-01-03T00:00:00.000Z',
+  owner: { login: 'owner', avatar_url: 'https://example.com/avatar.png' },
+  topics: ['testing'],
+  ...overrides,
+});
+
+const expectInputUnchanged = <T>(input: T, snapshot: T) => {
+  expect(input).toEqual(snapshot);
+};
+
+describe('repositoryPatches', () => {
+  describe('applyAnalysisSuccess', () => {
+    it('stores successful AI fields, clears an old failure, and keeps a locked category', () => {
+      const repository = createRepository({
+        ai_summary: 'Old summary',
+        analysis_failed: true,
+        analysis_error: 'Old failure',
+        custom_description: 'User description',
+        custom_tags: ['user-tag'],
+        custom_category: 'Locked category',
+        category_locked: true,
+      });
+      const before = structuredClone(repository);
+
+      const result = applyAnalysisSuccess(repository, {
+        summary: 'New summary',
+        tags: ['new-tag'],
+        platforms: ['web'],
+        category: 'AI category',
+        categoryLocked: true,
+        analyzedAt,
+      });
+
+      expect(result).toEqual(expect.objectContaining({
+        ai_summary: 'New summary',
+        ai_tags: ['new-tag'],
+        ai_platforms: ['web'],
+        custom_category: 'AI category',
+        category_locked: true,
+        analyzed_at: analyzedAt,
+        analysis_failed: false,
+        analysis_error: undefined,
+        custom_description: 'User description',
+        custom_tags: ['user-tag'],
+      }));
+      expectInputUnchanged(repository, before);
+    });
+
+    it.each([
+      { category: undefined, categoryLocked: false, label: 'undefined category' },
+      { category: '', categoryLocked: false, label: 'explicitly empty category' },
+      { category: 'Default category', categoryLocked: false, label: 'default category' },
+      { category: 'AI category', categoryLocked: false, label: 'AI category' },
+    ])('keeps the supplied $label distinct from the lock state', ({ category, categoryLocked }) => {
+      const repository = createRepository({ category_locked: true, custom_category: 'Manual category' });
+      const before = structuredClone(repository);
+
+      const result = applyAnalysisSuccess(repository, {
+        summary: 'Summary',
+        tags: [],
+        platforms: [],
+        category,
+        categoryLocked,
+        analyzedAt,
+      });
+
+      expect(result.custom_category).toBe(category);
+      expect(result.category_locked).toBe(categoryLocked);
+      expectInputUnchanged(repository, before);
+    });
+  });
+
+  describe('applyAnalysisFailure', () => {
+    it('records only failure fields and preserves user-managed values', () => {
+      const repository = createRepository({
+        ai_summary: 'Keep prior AI summary',
+        custom_description: 'User description',
+        custom_tags: ['user-tag'],
+        custom_category: 'Manual category',
+        category_locked: true,
+      });
+      const before = structuredClone(repository);
+
+      const result = applyAnalysisFailure(repository, { analyzedAt, error: 'AI unavailable' });
+
+      expect(result).toEqual(expect.objectContaining({
+        analyzed_at: analyzedAt,
+        analysis_failed: true,
+        analysis_error: 'AI unavailable',
+        ai_summary: 'Keep prior AI summary',
+        custom_description: 'User description',
+        custom_tags: ['user-tag'],
+        custom_category: 'Manual category',
+        category_locked: true,
+      }));
+      expectInputUnchanged(repository, before);
+    });
+
+    it('keeps an absent failure message absent', () => {
+      const repository = createRepository();
+      const before = structuredClone(repository);
+
+      const result = applyAnalysisFailure(repository, { analyzedAt, error: undefined });
+
+      expect(result.analysis_error).toBeUndefined();
+      expect(result.analysis_failed).toBe(true);
+      expectInputUnchanged(repository, before);
+    });
+  });
+
+  describe('restoreRepositoryFields', () => {
+    it('restores selected original fields and clears the matching AI metadata', () => {
+      const repository = createRepository({
+        custom_description: 'Custom description',
+        custom_tags: ['custom-tag'],
+        custom_category: 'Custom category',
+        category_locked: true,
+        ai_summary: 'AI summary',
+        ai_tags: ['ai-tag'],
+        ai_platforms: ['web'],
+        analyzed_at: analyzedAt,
+        analysis_failed: true,
+        analysis_error: 'Old failure',
+      });
+      const before = structuredClone(repository);
+
+      const result = restoreRepositoryFields(repository, {
+        description: { enabled: true, target: 'original' },
+        tags: { enabled: true, target: 'original' },
+        category: { enabled: true, target: 'original' },
+      }, editedAt);
+
+      expect(result).toEqual(expect.objectContaining({
+        custom_description: undefined,
+        custom_tags: undefined,
+        custom_category: undefined,
+        category_locked: false,
+        ai_summary: undefined,
+        ai_tags: undefined,
+        ai_platforms: undefined,
+        analyzed_at: undefined,
+        analysis_failed: undefined,
+        analysis_error: undefined,
+        last_edited: editedAt,
+      }));
+      expectInputUnchanged(repository, before);
+    });
+
+    it('restores user overrides to the AI view without clearing AI analysis results', () => {
+      const repository = createRepository({
+        custom_description: 'Custom description',
+        custom_tags: ['custom-tag'],
+        custom_category: 'Custom category',
+        category_locked: true,
+        ai_summary: 'AI summary',
+        ai_tags: ['ai-tag'],
+        ai_platforms: ['web'],
+        analyzed_at: analyzedAt,
+        analysis_failed: false,
+      });
+      const before = structuredClone(repository);
+
+      const result = restoreRepositoryFields(repository, {
+        description: { enabled: true, target: 'ai' },
+        tags: { enabled: true, target: 'ai' },
+        category: { enabled: true, target: 'ai' },
+      }, editedAt);
+
+      expect(result).toEqual(expect.objectContaining({
+        custom_description: undefined,
+        custom_tags: undefined,
+        custom_category: undefined,
+        category_locked: false,
+        ai_summary: 'AI summary',
+        ai_tags: ['ai-tag'],
+        ai_platforms: ['web'],
+        analyzed_at: analyzedAt,
+        analysis_failed: false,
+        last_edited: editedAt,
+      }));
+      expectInputUnchanged(repository, before);
+    });
+
+    it('returns no-op when no compared restore fields would change', () => {
+      const repository = createRepository({ analysis_error: 'orphaned failure message' });
+      const before = structuredClone(repository);
+
+      const result = restoreRepositoryFields(repository, {
+        description: { enabled: true, target: 'original' },
+        tags: { enabled: false, target: 'ai' },
+        category: { enabled: false, target: 'ai' },
+      }, editedAt);
+
+      expect(result).toBeUndefined();
+      expectInputUnchanged(repository, before);
+    });
+  });
+
+  describe('category commands', () => {
+    it.each([
+      { category: undefined, expectedLocked: false, label: 'AI/default category without an override' },
+      { category: '', expectedLocked: false, label: 'explicitly empty category' },
+      { category: 'Manual category', expectedLocked: true, label: 'manual category' },
+    ])('assigns $label without conflating it with category locking', ({ category, expectedLocked }) => {
+      const repository = createRepository({ custom_category: 'Previous category', category_locked: true });
+      const before = structuredClone(repository);
+
+      const result = applyCategoryAssignment(repository, category, editedAt);
+
+      expect(result).toEqual(expect.objectContaining({
+        custom_category: category,
+        category_locked: expectedLocked,
+        last_edited: editedAt,
+      }));
+      expectInputUnchanged(repository, before);
+    });
+
+    it.each([
+      { category: undefined, label: 'undefined category' },
+      { category: '', label: 'empty category' },
+    ])('does not lock a repository with $label', ({ category }) => {
+      const repository = createRepository({ custom_category: category });
+      const before = structuredClone(repository);
+
+      expect(lockRepositoryCategory(repository, editedAt)).toBeUndefined();
+      expectInputUnchanged(repository, before);
+    });
+
+    it('locks a non-empty custom category and unlocks without modifying that category', () => {
+      const repository = createRepository({ custom_category: 'Manual category', category_locked: false });
+      const before = structuredClone(repository);
+
+      const locked = lockRepositoryCategory(repository, editedAt);
+      const unlocked = unlockRepositoryCategory(locked!, analyzedAt);
+
+      expect(locked).toEqual(expect.objectContaining({
+        custom_category: 'Manual category',
+        category_locked: true,
+        last_edited: editedAt,
+      }));
+      expect(unlocked).toEqual(expect.objectContaining({
+        custom_category: 'Manual category',
+        category_locked: false,
+        last_edited: analyzedAt,
+      }));
+      expectInputUnchanged(repository, before);
+    });
+  });
+
+  describe('setReleaseSubscriptionMarker', () => {
+    it.each([true, false])('returns an immutable local marker for subscribed=%s', (subscribed) => {
+      const repository = createRepository({ subscribed_to_releases: !subscribed });
+      const before = structuredClone(repository);
+
+      const result = setReleaseSubscriptionMarker(repository, subscribed);
+
+      expect(result).toEqual(expect.objectContaining({ subscribed_to_releases: subscribed }));
+      expectInputUnchanged(repository, before);
+    });
+  });
+});

--- a/src/features/repositories/application/repositoryPatches.ts
+++ b/src/features/repositories/application/repositoryPatches.ts
@@ -1,0 +1,151 @@
+import type { Repository } from '../../../types';
+
+export interface AnalysisSuccessInput {
+  summary: string | undefined;
+  tags: string[] | undefined;
+  platforms: string[] | undefined;
+  category: string | undefined;
+  categoryLocked: boolean | undefined;
+  analyzedAt: string;
+}
+
+export interface AnalysisFailureInput {
+  analyzedAt: string;
+  error: string | undefined;
+}
+
+export type RestoreTarget = 'original' | 'ai';
+
+export interface RestoreFieldConfig {
+  enabled: boolean;
+  target: RestoreTarget;
+}
+
+export interface RepositoryRestoreConfig {
+  description: RestoreFieldConfig;
+  tags: RestoreFieldConfig;
+  category: RestoreFieldConfig;
+}
+
+export const applyAnalysisSuccess = (
+  repository: Repository,
+  input: AnalysisSuccessInput,
+): Repository => ({
+  ...repository,
+  ai_summary: input.summary,
+  ai_tags: input.tags,
+  ai_platforms: input.platforms,
+  custom_category: input.category,
+  category_locked: input.categoryLocked,
+  analyzed_at: input.analyzedAt,
+  analysis_failed: false,
+  analysis_error: undefined,
+});
+
+export const applyAnalysisFailure = (
+  repository: Repository,
+  input: AnalysisFailureInput,
+): Repository => ({
+  ...repository,
+  analyzed_at: input.analyzedAt,
+  analysis_failed: true,
+  analysis_error: input.error,
+});
+
+export const restoreRepositoryFields = (
+  repository: Repository,
+  config: RepositoryRestoreConfig,
+  editedAt: string,
+): Repository | undefined => {
+  const updatedRepository: Repository = { ...repository };
+
+  if (config.description.enabled) {
+    updatedRepository.custom_description = undefined;
+    if (config.description.target === 'original') {
+      updatedRepository.ai_summary = undefined;
+      updatedRepository.analyzed_at = undefined;
+      updatedRepository.analysis_failed = undefined;
+      updatedRepository.analysis_error = undefined;
+    }
+  }
+
+  if (config.tags.enabled) {
+    updatedRepository.custom_tags = undefined;
+    if (config.tags.target === 'original') {
+      updatedRepository.ai_tags = undefined;
+      updatedRepository.ai_platforms = undefined;
+      updatedRepository.analyzed_at = undefined;
+      updatedRepository.analysis_failed = undefined;
+      updatedRepository.analysis_error = undefined;
+    }
+  }
+
+  if (config.category.enabled) {
+    updatedRepository.custom_category = undefined;
+    updatedRepository.category_locked = false;
+    if (config.category.target === 'original') {
+      updatedRepository.ai_tags = undefined;
+      updatedRepository.ai_platforms = undefined;
+      updatedRepository.analyzed_at = undefined;
+      updatedRepository.analysis_failed = undefined;
+      updatedRepository.analysis_error = undefined;
+    }
+  }
+
+  const hasChanges = updatedRepository.custom_description !== repository.custom_description
+    || updatedRepository.custom_tags !== repository.custom_tags
+    || updatedRepository.custom_category !== repository.custom_category
+    || updatedRepository.category_locked !== repository.category_locked
+    || updatedRepository.ai_summary !== repository.ai_summary
+    || updatedRepository.ai_tags !== repository.ai_tags
+    || updatedRepository.ai_platforms !== repository.ai_platforms
+    || updatedRepository.analyzed_at !== repository.analyzed_at
+    || updatedRepository.analysis_failed !== repository.analysis_failed;
+
+  return hasChanges
+    ? { ...updatedRepository, last_edited: editedAt }
+    : undefined;
+};
+
+export const applyCategoryAssignment = (
+  repository: Repository,
+  category: string | undefined,
+  editedAt: string,
+): Repository => ({
+  ...repository,
+  custom_category: category,
+  category_locked: category !== undefined && category !== '',
+  last_edited: editedAt,
+});
+
+export const lockRepositoryCategory = (
+  repository: Repository,
+  editedAt: string,
+): Repository | undefined => {
+  if (!repository.custom_category || repository.custom_category === '') {
+    return undefined;
+  }
+
+  return {
+    ...repository,
+    category_locked: true,
+    last_edited: editedAt,
+  };
+};
+
+export const unlockRepositoryCategory = (
+  repository: Repository,
+  editedAt: string,
+): Repository => ({
+  ...repository,
+  category_locked: false,
+  last_edited: editedAt,
+});
+
+export const setReleaseSubscriptionMarker = (
+  repository: Repository,
+  subscribed: boolean,
+): Repository => ({
+  ...repository,
+  subscribed_to_releases: subscribed,
+});


### PR DESCRIPTION
## Summary

This refactor centralizes repository field transitions in `src/features/repositories/application/repositoryPatches.ts`. The module imports only the `Repository` type and has no React, Store, browser, service, API, synchronization, or persistence dependency. UI confirmations, toast messages, service construction, subscription toggles, synchronization, and job lifecycle handling remain in their original components.

| Existing inline transition | Pure command | Call sites migrated |
|---|---|---|
| AI analysis success writes | `applyAnalysisSuccess` | `RepositoryCard`; both `RepositoryList` batch analysis paths |
| AI analysis failure writes | `applyAnalysisFailure` | `RepositoryCard`; both `RepositoryList` batch analysis paths |
| Bulk restore fields | `restoreRepositoryFields` | `RepositoryList` bulk restore |
| Assign bulk category | `applyCategoryAssignment` | `RepositoryList` bulk categorize |
| Lock / unlock category | `lockRepositoryCategory` / `unlockRepositoryCategory` | `RepositoryList` bulk actions |
| Local release-subscription marker | `setReleaseSubscriptionMarker` | `RepositoryList` subscribe / unsubscribe |

The new unit suite includes 18 parameterized and boundary-focused tests for AI success/failure, original-vs-AI restore behavior, no-op restore behavior, `undefined`/empty/default/AI/manual categories, locking, unlocking, subscription markers, and immutable inputs.

## Verification

| Check | Result |
|---|---|
| `npm run lint` | Passed |
| `npm run typecheck` | Passed |
| `npm run test:run` | Passed: 40 files, 424 tests |
| `git diff --check` | Passed |
| `npm run build` | Blocked in this environment: Vite received `SIGTERM` while rendering chunks after transforming 5,116 modules; reproduced with an extended 180-second command timeout. |

## Scope

No persistence schema, Store key/version, service invocation, backend secret handling, proxy/RPC behavior, or JSX structure was changed. The browser harness served the source modules but did not render the app root, preventing token-based manual UI verification in this environment; this is documented for follow-up manual validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when updating repository analysis results, categories, restoration states, and release subscription settings.
  * Preserved user-managed repository data during automated updates.
  * Ensured unchanged repositories are not unnecessarily modified.

* **Tests**
  * Added comprehensive coverage for repository updates, restoration behavior, metadata handling, no-op operations, and immutability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->