### PR TITLE
refactor: move RepositoryCard operations into a domain hook

### DIFF
--- a/src/components/RepositoryCard.lazyReadme.test.tsx
+++ b/src/components/RepositoryCard.lazyReadme.test.tsx
@@ -7,14 +7,25 @@ import type { Repository } from '../types';
 const mocks = vi.hoisted(() => ({
   useAppStore: vi.fn(),
   consoleError: vi.fn(),
+  repositoryCardActions: {
+    analyze: vi.fn(),
+    findSimilar: vi.fn(),
+    unstar: vi.fn(),
+    toggleReleaseSubscription: vi.fn(),
+    isSubscribed: false,
+    isAnalyzing: false,
+    isFindingSimilar: false,
+    isUnstarring: false,
+    vectorSearchAvailable: false,
+  },
 }));
 
 vi.mock('../store/useAppStore', () => ({
   useAppStore: mocks.useAppStore,
 }));
 
-vi.mock('../hooks/useDialog', () => ({
-  useDialog: () => ({ toast: vi.fn(), confirm: vi.fn() }),
+vi.mock('../features/repositories/hooks/useRepositoryCardActions', () => ({
+  useRepositoryCardActions: () => mocks.repositoryCardActions,
 }));
 
 vi.mock('./RepositoryEditModal', () => ({

--- a/src/components/RepositoryCard.test.tsx
+++ b/src/components/RepositoryCard.test.tsx
@@ -6,12 +6,26 @@ import { RepositoryCard } from './RepositoryCard';
 import { useAppStore } from '../store/useAppStore';
 import type { Repository } from '../types';
 
+const actionMocks = vi.hoisted(() => ({
+  actions: {
+    analyze: vi.fn(),
+    findSimilar: vi.fn(),
+    unstar: vi.fn(),
+    toggleReleaseSubscription: vi.fn(),
+    isSubscribed: true,
+    isAnalyzing: false,
+    isFindingSimilar: false,
+    isUnstarring: false,
+    vectorSearchAvailable: true,
+  },
+}));
+
 vi.mock('../store/useAppStore', () => ({
   useAppStore: vi.fn(),
 }));
 
-vi.mock('../hooks/useDialog', () => ({
-  useDialog: () => ({ toast: vi.fn(), confirm: vi.fn() }),
+vi.mock('../features/repositories/hooks/useRepositoryCardActions', () => ({
+  useRepositoryCardActions: () => actionMocks.actions,
 }));
 
 vi.mock('./FloatingTooltip', () => ({
@@ -98,6 +112,13 @@ beforeEach(() => {
   vi.clearAllMocks();
   storeState.releaseSubscriptions = new Set<number>([1]);
   storeState.vectorSearchConfig.enabled = true;
+  Object.assign(actionMocks.actions, {
+    isSubscribed: true,
+    isAnalyzing: false,
+    isFindingSimilar: false,
+    isUnstarring: false,
+    vectorSearchAvailable: true,
+  });
   mockUseAppStore.mockImplementation(((selector?: (state: typeof storeState) => unknown) => (
     selector ? selector(storeState) : storeState
   )) as typeof useAppStore);
@@ -130,9 +151,9 @@ describe('RepositoryCard view modes', () => {
 
   it('only exposes similar-repository search in the menu when vector search is available', async () => {
     const user = userEvent.setup();
-    const originalVectorSearchEnabled = storeState.vectorSearchConfig.enabled;
+    const originalVectorSearchAvailable = actionMocks.actions.vectorSearchAvailable;
     try {
-      storeState.vectorSearchConfig.enabled = false;
+      actionMocks.actions.vectorSearchAvailable = false;
       renderRepositoryCard('list');
 
       await user.click(screen.getByRole('button', { name: '更多操作' }));
@@ -141,8 +162,18 @@ describe('RepositoryCard view modes', () => {
       await user.keyboard('{Escape}');
       await waitFor(() => expect(screen.queryByText('仓库操作')).not.toBeInTheDocument());
     } finally {
-      storeState.vectorSearchConfig.enabled = originalVectorSearchEnabled;
+      actionMocks.actions.vectorSearchAvailable = originalVectorSearchAvailable;
     }
+  });
+
+  it('delegates the list similar-search menu action to the domain Hook', async () => {
+    const user = userEvent.setup();
+    renderRepositoryCard('list');
+
+    await user.click(screen.getByRole('button', { name: '更多操作' }));
+    await user.click(screen.getByRole('menuitem', { name: '查找同类仓库' }));
+
+    expect(actionMocks.actions.findSimilar).toHaveBeenCalledOnce();
   });
 
   it('closes the list action menu from card whitespace, page whitespace, or Escape', async () => {
@@ -186,7 +217,7 @@ describe('RepositoryCard view modes', () => {
     const unsubscribe = await screen.findByRole('menuitem', { name: '取消订阅 Release' });
     unsubscribe.focus();
     await user.keyboard('{Enter}');
-    expect(storeState.toggleReleaseSubscription).toHaveBeenCalledWith(repository.id);
+    expect(actionMocks.actions.toggleReleaseSubscription).toHaveBeenCalledOnce();
     await waitFor(() => expect(screen.queryByRole('menuitem', { name: '取消订阅 Release' })).not.toBeInTheDocument());
     expect(screen.queryByTestId('readme-modal')).not.toBeInTheDocument();
 
@@ -194,6 +225,17 @@ describe('RepositoryCard view modes', () => {
     editAction.focus();
     await user.keyboard('{Enter}');
     expect(screen.getByTestId('repository-edit-modal')).toBeInTheDocument();
+  });
+
+  it('delegates grid quick actions to the domain Hook without changing their presentation', async () => {
+    const user = userEvent.setup();
+    renderRepositoryCard('grid');
+
+    await user.click(screen.getByTitle('AI分析此仓库'));
+    await user.click(screen.getByTitle('取消 Star'));
+
+    expect(actionMocks.actions.analyze).toHaveBeenCalledOnce();
+    expect(actionMocks.actions.unstar).toHaveBeenCalledOnce();
   });
 
   it('retains the existing quick action row in grid mode', () => {

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -3,21 +3,14 @@ import { createPortal } from 'react-dom';
 import { GripVertical, Star, StarOff, ExternalLink, Calendar, Bell, BellOff, Bot, Sparkles, Monitor, Smartphone, Globe, Terminal, Package, Edit3, BookOpen, Apple, Square, CheckSquare, Loader2, HelpCircle, Search, Scale, MoreHorizontal } from 'lucide-react';
 import { Repository, Category } from '../types';
 import { useAppStore } from '../store/useAppStore';
-import { EmbeddingClient, VectorSearchService, findSimilarRepositories } from '../services/vectorSearchService';
 import { getAICategory, getDefaultCategory } from '../utils/categoryUtils';
-import { analyzeRepository, createFailedAnalysisResult } from '../services/aiAnalysisHelper';
-import { forceSyncToBackend } from '../services/autoSync';
-import { GitHubApiService } from '../services/githubApi';
 import { formatDistanceToNow } from 'date-fns';
 import { RepositoryEditModal } from './RepositoryEditModal';
 import { ErrorBoundary } from './ErrorBoundary';
 import { Dialog, DialogContent, DialogTitle } from './ui/dialog';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { NO_LICENSE_SENTINEL, normalizeLicense } from '../utils/licenseFilter';
-import { shallow } from 'zustand/shallow';
-import { useDialog } from '../hooks/useDialog';
-import { logger } from '../services/logger';
-import { applyAnalysisFailure, applyAnalysisSuccess } from '../features/repositories/application/repositoryPatches';
+import { useRepositoryCardActions } from '../features/repositories/hooks/useRepositoryCardActions';
 import { Button } from './ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from './ui/dropdown-menu';
 
@@ -124,91 +117,23 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
   allCategories,
   viewMode = 'grid'
 }) => {
-  const repoId = repository.id;
-
-  const isSubscribed = useAppStore(
-    useCallback((state) => state.releaseSubscriptions.has(repoId), [repoId])
-  );
-  const isStoreAnalyzing = useAppStore(
-    useCallback((state) => state.analyzingRepositoryIds.has(repoId), [repoId])
-  );
-
+  const language = useAppStore((state) => state.language);
   const {
+    analyze: handleAIAnalyze,
+    findSimilar: handleFindSimilar,
+    unstar: handleUnstar,
     toggleReleaseSubscription,
-    githubToken,
-    activeAIConfig,
-    setAnalyzingRepository,
-    language,
-    updateRepository,
-    deleteRepository,
-    vectorSearchConfig,
-    vectorSearchStatus,
-    embeddingConfigs,
-    activeEmbeddingConfig,
-    repositories,
-    enterSimilarView
-  } = useAppStore(
-    useCallback(
-      (state) => ({
-        toggleReleaseSubscription: state.toggleReleaseSubscription,
-        githubToken: state.githubToken,
-        activeAIConfig: state.activeAIConfig,
-        setAnalyzingRepository: state.setAnalyzingRepository,
-        language: state.language,
-        updateRepository: state.updateRepository,
-        deleteRepository: state.deleteRepository,
-        vectorSearchConfig: state.vectorSearchConfig,
-        vectorSearchStatus: state.vectorSearchStatus,
-        embeddingConfigs: state.embeddingConfigs,
-        activeEmbeddingConfig: state.activeEmbeddingConfig,
-        repositories: state.repositories,
-        enterSimilarView: state.enterSimilarView
-      }),
-      []
-    ),
-    shallow
-  );
-
-  const abortControllerRef = useRef<AbortController | null>(null);
-
-  useEffect(() => {
-    return () => {
-      abortControllerRef.current?.abort();
-      setAnalyzingRepository(repoId, false);
-    };
-  }, [repoId, setAnalyzingRepository]);
-
-  const aiConfigs = useAppStore(state => state.aiConfigs);
-
-  const { toast, confirm } = useDialog();
+    isSubscribed,
+    isAnalyzing,
+    isFindingSimilar,
+    isUnstarring: unstarring,
+    vectorSearchAvailable,
+  } = useRepositoryCardActions({ repository, allCategories });
 
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [readmeModalOpen, setReadmeModalOpen] = useState(false);
-  const [unstarring, setUnstarring] = useState(false);
   const [showDragHint, setShowDragHint] = useState(false);
   const dragHintTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [isLocallyAnalyzing, setIsLocallyAnalyzing] = useState(false);
-  const isAnalyzing = isLocallyAnalyzing || isStoreAnalyzing;
-
-  // 向量搜索是否可用（开关开启 + Worker 已连接 + 有索引 + Embedding 配置完整）
-  // 仅在可用时显示"查找相似仓库"按钮，避免无效点击
-  const vectorSearchAvailable = useMemo(() => {
-    const activeConfig = embeddingConfigs.find((c) => c.id === activeEmbeddingConfig);
-    const configComplete = !!activeConfig
-      && !!activeConfig.baseUrl
-      && !!activeConfig.model
-      && (activeConfig.apiType === 'ollama' || !!activeConfig.apiKey);
-    return (
-      vectorSearchConfig.enabled
-      && !!vectorSearchStatus?.connected
-      && (vectorSearchStatus?.vectorCount ?? 0) > 0
-      && configComplete
-      && !!vectorSearchConfig.workerUrl
-      && !!vectorSearchConfig.authToken
-    );
-  }, [embeddingConfigs, activeEmbeddingConfig, vectorSearchConfig, vectorSearchStatus]);
-
-  const [isFindingSimilar, setIsFindingSimilar] = useState(false);
   const [isActionsMenuOpen, setIsActionsMenuOpen] = useState(false);
   const cardRef = useRef<HTMLDivElement>(null);
   const menuDismissedByPointerDownRef = useRef(false);
@@ -337,199 +262,9 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
     return platformNameMap[platformLower as keyof typeof platformNameMap] || platform;
   }, [platformNameMap]);
 
-  const handleAIAnalyze = async () => {
-    if (!githubToken) {
-      toast(t('GitHub token 未找到，请重新登录。', 'GitHub token not found. Please login again.'), 'error');
-      return;
-    }
-
-    const activeConfig = aiConfigs.find(config => config.id === activeAIConfig);
-    if (!activeConfig) {
-      toast(t('请先在设置中配置AI服务。', 'Please configure AI service in settings first.'), 'error');
-      return;
-    }
-
-    if (activeConfig.apiKeyStatus === 'decrypt_failed' || activeConfig.apiKeyStatus === 'empty') {
-      toast(t('AI服务的API密钥无法解密或为空，请在设置中重新输入并保存该配置。', 'The AI service API key could not be decrypted or is empty. Please re-enter and save the configuration in settings.'), 'error');
-      return;
-    }
-
-    if (!activeConfig.baseUrl || !activeConfig.apiKey || !activeConfig.model) {
-      toast(t('AI服务配置不完整，请检查API端点、密钥和模型名称。', 'AI service configuration is incomplete. Please check the API endpoint, key, and model name.'), 'error');
-      return;
-    }
-
-    if (repository.analyzed_at) {
-      const confirmMessage = language === 'zh'
-        ? `此仓库已于 ${new Date(repository.analyzed_at).toLocaleString()} 进行过AI分析。\n\n是否要重新分析？这将覆盖现有的分析结果。`
-        : `This repository was analyzed on ${new Date(repository.analyzed_at).toLocaleString()}.\n\nDo you want to re-analyze? This will overwrite the existing analysis results.`;
-
-      if (!await confirm(t('重新分析确认', 'Re-analyze Confirmation'), confirmMessage, { type: 'warning' })) {
-        return;
-      }
-    }
-
-    abortControllerRef.current?.abort();
-    const controller = new AbortController();
-    abortControllerRef.current = controller;
-
-    const analysisStartedAt = performance.now();
-    setIsLocallyAnalyzing(true);
-    requestAnimationFrame(() => {
-      logger.info('ai.performance', 'Repository card AI spinner painted', {
-        repoId,
-        fullName: repository.full_name,
-        elapsedMs: Math.round(performance.now() - analysisStartedAt),
-      });
-    });
-    setAnalyzingRepository(repoId, true);
-    try {
-      const result = await analyzeRepository({
-        repository,
-        githubToken,
-        aiConfig: activeConfig,
-        language,
-        categories: allCategories,
-        onProgress: (status) => {
-          logger.info('ai.performance', 'Repository card AI analysis step', {
-            repoId,
-            fullName: repository.full_name,
-            status,
-            elapsedMs: Math.round(performance.now() - analysisStartedAt),
-          });
-        },
-        signal: controller.signal,
-      });
-      logger.info('ai.performance', 'Repository card AI request completed', {
-        repoId,
-        fullName: repository.full_name,
-        elapsedMs: Math.round(performance.now() - analysisStartedAt),
-      });
-
-      if (controller.signal.aborted) return;
-
-      const updatedRepo = applyAnalysisSuccess(repository, {
-        summary: result.summary,
-        tags: result.tags,
-        platforms: result.platforms,
-        category: result.custom_category,
-        categoryLocked: result.category_locked,
-        analyzedAt: result.analyzed_at,
-      });
-
-      const updateStartedAt = performance.now();
-      updateRepository(updatedRepo);
-      logger.info('ai.performance', 'Repository card AI result stored', {
-        repoId,
-        fullName: repository.full_name,
-        updateMs: Math.round(performance.now() - updateStartedAt),
-        elapsedMs: Math.round(performance.now() - analysisStartedAt),
-      });
-
-      const successMessage = repository.analyzed_at
-        ? (language === 'zh' ? 'AI重新分析完成！' : 'AI re-analysis completed!')
-        : (language === 'zh' ? 'AI分析完成！' : 'AI analysis completed!');
-
-      toast(successMessage, 'success');
-    } catch (error) {
-      if (!controller.signal.aborted) {
-        console.error('AI analysis failed:', error);
-
-        const errorMsg = error instanceof Error && error.message
-          ? error.message
-          : (language === 'zh' ? 'AI分析失败，请检查AI配置和网络连接' : 'AI analysis failed, please check AI configuration and network connection');
-        const failedResult = createFailedAnalysisResult(errorMsg);
-        const failedRepo = applyAnalysisFailure(repository, {
-          analyzedAt: failedResult.analyzed_at,
-          error: failedResult.analysis_error,
-        });
-
-        const updateStartedAt = performance.now();
-        updateRepository(failedRepo);
-        logger.info('ai.performance', 'Repository card AI failure stored', {
-          repoId,
-          fullName: repository.full_name,
-          updateMs: Math.round(performance.now() - updateStartedAt),
-          elapsedMs: Math.round(performance.now() - analysisStartedAt),
-        });
-
-        toast(language === 'zh' ? 'AI分析失败，请检查AI配置和网络连接。' : 'AI analysis failed. Please check AI configuration and network connection.', 'error');
-      }
-    } finally {
-      setIsLocallyAnalyzing(false);
-      if (!controller.signal.aborted) {
-        setAnalyzingRepository(repoId, false);
-      }
-    }
-  };
-
   // Convert GitHub URL to DeepWiki URL
   const getDeepWikiUrl = (githubUrl: string) => {
     return githubUrl.replace('github.com', 'deepwiki.com');
-  };
-
-  // 查找相似仓库：利用向量检索匹配语义相关的仓库，并进入相似仓库视图
-  /**
-   * 点击"查找相似仓库"：校验向量搜索就绪后，对源仓库生成 embedding 并在 Worker
-   * 中检索相似仓库，将结果交给 store 进入相似视图。处理加载、空结果与错误态。
-   */
-  const handleFindSimilar = async () => {
-    if (isFindingSimilar) return;
-    if (!vectorSearchAvailable) {
-      toast(
-        language === 'zh'
-          ? '向量搜索未就绪：请先在设置中开启向量搜索并完成索引。'
-          : 'Vector search is not ready. Please enable vector search and build the index in settings first.',
-        'error'
-      );
-      return;
-    }
-
-    const activeConfig = embeddingConfigs.find((c) => c.id === activeEmbeddingConfig);
-    if (!activeConfig) return;
-
-    setIsFindingSimilar(true);
-    try {
-      const embeddingClient = new EmbeddingClient({
-        ...activeConfig,
-        apiType: activeConfig.apiType,
-        baseUrl: activeConfig.baseUrl,
-        apiKey: activeConfig.apiKey,
-        model: activeConfig.model,
-        dimensions: activeConfig.dimensions,
-      });
-      const vectorService = new VectorSearchService({
-        workerUrl: vectorSearchConfig.workerUrl,
-        authToken: vectorSearchConfig.authToken,
-      });
-
-      const similar = await findSimilarRepositories(repository, {
-        embeddingClient,
-        vectorService,
-        allRepos: repositories,
-        topK: vectorSearchConfig.searchTopK ?? 30,
-        threshold: vectorSearchConfig.searchThreshold ?? 0.35,
-      });
-
-      enterSimilarView(similar, repository);
-
-      if (similar.length === 0) {
-        toast(
-          language === 'zh'
-            ? '未找到相似的仓库。'
-            : 'No similar repositories found.',
-          'info'
-        );
-      }
-    } catch (error) {
-      console.error('Find similar repositories failed:', error);
-      const errorMessage = error instanceof Error && error.message
-        ? error.message
-        : (language === 'zh' ? '查找相似仓库失败，请检查向量搜索配置。' : 'Failed to find similar repositories. Please check vector search configuration.');
-      toast(errorMessage, 'error');
-    } finally {
-      setIsFindingSimilar(false);
-    }
   };
 
   // Convert GitHub URL to Zread URL
@@ -694,44 +429,6 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
       return language === 'zh' ? 'AI分析此仓库' : 'Analyze with AI';
     }
   }, [repository.analysis_failed, repository.analyzed_at, language]);
-
-  const t = (zh: string, en: string) => language === 'zh' ? zh : en;
-
-  const handleUnstar = async () => {
-    if (!githubToken) {
-      toast(t('未找到 GitHub Token，请重新登录。', 'GitHub token not found. Please login again.'), 'error');
-      return;
-    }
-
-    const confirmMessage = language === 'zh'
-      ? `确定要取消 Star "${repository.full_name}" 吗？\n\n这将会从您的 GitHub 收藏中移除该仓库。`
-      : `Are you sure you want to unstar "${repository.full_name}"?\n\nThis will remove the repository from your GitHub stars.`;
-
-    if (!await confirm(t('取消Star确认', 'Unstar Confirmation'), confirmMessage, { type: 'danger', confirmText: t('取消Star', 'Unstar') })) {
-      return;
-    }
-
-    setUnstarring(true);
-    try {
-      const githubApi = new GitHubApiService(githubToken);
-      const [owner, repo] = repository.full_name.split('/');
-      await githubApi.unstarRepository(owner, repo);
-      deleteRepository(repository.id);
-      await forceSyncToBackend();
-      const successMessage = language === 'zh'
-        ? '已成功取消 Star'
-        : 'Successfully unstarred';
-      toast(successMessage, 'success');
-    } catch (error) {
-      console.error('Failed to unstar repository:', error);
-      const errorMessage = language === 'zh'
-        ? '取消 Star 失败，请检查网络连接或重新登录。'
-        : 'Failed to unstar repository. Please check your network connection or login again.';
-      toast(errorMessage, 'error');
-    } finally {
-      setUnstarring(false);
-    }
-  };
 
   const dragStartPosRef = useRef<{ x: number; y: number } | null>(null);
   const isDraggingRef = useRef(false);
@@ -1017,7 +714,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
                 {isAnalyzing ? <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" /> : <Bot className="mr-2 h-3.5 w-3.5" />}
                 {language === 'zh' ? 'AI 分析' : 'Analyze with AI'}
               </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => toggleReleaseSubscription(repository.id)}>
+              <DropdownMenuItem onSelect={() => toggleReleaseSubscription()}>
                 {isSubscribed ? <Bell className="mr-2 h-3.5 w-3.5" /> : <BellOff className="mr-2 h-3.5 w-3.5" />}
                 {isSubscribed ? (language === 'zh' ? '取消订阅 Release' : 'Unsubscribe from releases') : (language === 'zh' ? '订阅 Release' : 'Subscribe to releases')}
               </DropdownMenuItem>
@@ -1107,7 +804,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
             {isAnalyzing ? <Loader2 className="w-4 h-4 animate-spin" /> : <Bot className="w-4 h-4" />}
           </SelectionAwareButton>
           <SelectionAwareButton
-            onClick={() => toggleReleaseSubscription(repository.id)}
+            onClick={() => toggleReleaseSubscription()}
             selectionMode={selectionMode}
             className={`${isSubscribed
               ? 'bg-primary text-primary-foreground shadow-sm'

--- a/src/features/repositories/hooks/useRepositoryCardActions.test.tsx
+++ b/src/features/repositories/hooks/useRepositoryCardActions.test.tsx
@@ -1,0 +1,292 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Repository } from '../../../types';
+import { useRepositoryCardActions } from './useRepositoryCardActions';
+import { useAppStore } from '../../../store/useAppStore';
+
+const mocks = vi.hoisted(() => ({
+  useAppStore: vi.fn(),
+  toast: vi.fn(),
+  confirm: vi.fn(),
+  analyzeRepository: vi.fn(),
+  createFailedAnalysisResult: vi.fn((error: string) => ({
+    analyzed_at: '2026-08-25T00:00:00.000Z',
+    analysis_error: error,
+  })),
+  findSimilarRepositories: vi.fn(),
+  forceSyncToBackend: vi.fn(),
+  unstarRepository: vi.fn(),
+  loggerInfo: vi.fn(),
+}));
+
+vi.mock('../../../store/useAppStore', () => ({
+  useAppStore: mocks.useAppStore,
+}));
+
+vi.mock('../../../hooks/useDialog', () => ({
+  useDialog: () => ({ toast: mocks.toast, confirm: mocks.confirm }),
+}));
+
+vi.mock('../../../services/aiAnalysisHelper', () => ({
+  analyzeRepository: mocks.analyzeRepository,
+  createFailedAnalysisResult: mocks.createFailedAnalysisResult,
+}));
+
+vi.mock('../../../services/vectorSearchService', () => ({
+  EmbeddingClient: vi.fn(),
+  VectorSearchService: vi.fn(),
+  findSimilarRepositories: mocks.findSimilarRepositories,
+}));
+
+vi.mock('../../../services/autoSync', () => ({
+  forceSyncToBackend: mocks.forceSyncToBackend,
+}));
+
+vi.mock('../../../services/githubApi', () => ({
+  GitHubApiService: class {
+    unstarRepository = mocks.unstarRepository;
+  },
+}));
+
+vi.mock('../../../services/logger', () => ({
+  logger: { info: mocks.loggerInfo },
+}));
+
+const repository: Repository = {
+  id: 1,
+  name: 'example-repository',
+  full_name: 'owner/example-repository',
+  description: 'Repository description',
+  html_url: 'https://github.com/owner/example-repository',
+  stargazers_count: 128,
+  forks_count: 3,
+  forks: 3,
+  language: 'TypeScript',
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-02T00:00:00.000Z',
+  pushed_at: '2026-01-03T00:00:00.000Z',
+  owner: {
+    login: 'owner',
+    avatar_url: 'https://example.com/avatar.png',
+  },
+  topics: ['test'],
+};
+
+const createStoreState = () => ({
+  releaseSubscriptions: new Set<number>(),
+  analyzingRepositoryIds: new Set<number>(),
+  githubToken: 'github-token',
+  activeAIConfig: 'ai-config',
+  setAnalyzingRepository: vi.fn(),
+  language: 'zh' as const,
+  updateRepository: vi.fn(),
+  deleteRepository: vi.fn(),
+  vectorSearchConfig: {
+    enabled: true,
+    workerUrl: 'https://worker.example.com',
+    authToken: 'worker-token',
+    embeddingConfigId: 'embedding-config',
+    indexMode: 'readme' as const,
+    readmeMaxChars: 6000,
+  },
+  vectorSearchStatus: { connected: true, vectorCount: 1, dimensions: 1536 },
+  embeddingConfigs: [{
+    id: 'embedding-config',
+    name: 'Test embedding',
+    apiType: 'openai-compatible' as const,
+    baseUrl: 'https://example.com/v1',
+    apiKey: 'embedding-key',
+    model: 'embedding-model',
+    dimensions: 1536,
+    isActive: true,
+  }],
+  activeEmbeddingConfig: 'embedding-config',
+  repositories: [repository],
+  enterSimilarView: vi.fn(),
+  aiConfigs: [{
+    id: 'ai-config',
+    name: 'Test AI',
+    baseUrl: 'https://example.com/v1',
+    apiKey: 'ai-key',
+    model: 'ai-model',
+  }],
+  toggleReleaseSubscription: vi.fn(),
+});
+
+let storeState = createStoreState();
+const mockUseAppStore = vi.mocked(useAppStore);
+const allCategories: [] = [];
+
+const renderActions = (targetRepository = repository) => renderHook(() => (
+  useRepositoryCardActions({ repository: targetRepository, allCategories })
+));
+
+describe('useRepositoryCardActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeState = createStoreState();
+    mockUseAppStore.mockImplementation(((selector?: (state: typeof storeState) => unknown) => (
+      selector ? selector(storeState) : storeState
+    )) as typeof useAppStore);
+    mocks.confirm.mockResolvedValue(true);
+    mocks.forceSyncToBackend.mockResolvedValue(undefined);
+    mocks.unstarRepository.mockResolvedValue(undefined);
+    vi.stubGlobal('requestAnimationFrame', vi.fn((callback: FrameRequestCallback) => {
+      callback(performance.now());
+      return 1;
+    }));
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('returns a stable view API while its dependencies are unchanged', () => {
+    const { result, rerender } = renderActions();
+    const actions = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(actions);
+  });
+
+  it('aborts an in-flight analysis and clears the store marker on unmount', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    mocks.analyzeRepository.mockImplementation(({ signal }: { signal: AbortSignal }) => {
+      capturedSignal = signal;
+      return new Promise((_, reject) => {
+        signal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')));
+      });
+    });
+    const { result, unmount } = renderActions();
+
+    let analysisPromise!: Promise<void>;
+    await act(async () => {
+      analysisPromise = result.current.analyze();
+    });
+    await waitFor(() => expect(mocks.analyzeRepository).toHaveBeenCalledTimes(1));
+
+    unmount();
+    await expect(analysisPromise).resolves.toBeUndefined();
+
+    expect(capturedSignal?.aborted).toBe(true);
+    expect(storeState.setAnalyzingRepository).toHaveBeenCalledWith(repository.id, true);
+    expect(storeState.setAnalyzingRepository).toHaveBeenLastCalledWith(repository.id, false);
+  });
+
+  it('does not start re-analysis when the confirmation is cancelled', async () => {
+    mocks.confirm.mockResolvedValue(false);
+    const analyzedRepository = {
+      ...repository,
+      analyzed_at: '2026-08-24T00:00:00.000Z',
+    };
+    const { result } = renderActions(analyzedRepository);
+
+    await act(async () => {
+      await result.current.analyze();
+    });
+
+    expect(mocks.confirm).toHaveBeenCalledOnce();
+    expect(mocks.analyzeRepository).not.toHaveBeenCalled();
+    expect(storeState.setAnalyzingRepository).not.toHaveBeenCalled();
+  });
+
+  it('reports an unavailable vector search without creating a search request', async () => {
+    storeState.vectorSearchConfig.enabled = false;
+    const { result } = renderActions();
+
+    expect(result.current.vectorSearchAvailable).toBe(false);
+    await act(async () => {
+      await result.current.findSimilar();
+    });
+
+    expect(mocks.findSimilarRepositories).not.toHaveBeenCalled();
+    expect(mocks.toast).toHaveBeenCalledWith(
+      '向量搜索未就绪：请先在设置中开启向量搜索并完成索引。',
+      'error',
+    );
+  });
+
+  it('stores the PR-03 failure patch and preserves the failure toast on AI errors', async () => {
+    mocks.analyzeRepository.mockRejectedValue(new Error('model unavailable'));
+    const { result } = renderActions();
+
+    await act(async () => {
+      await result.current.analyze();
+    });
+
+    expect(storeState.updateRepository).toHaveBeenCalledWith(expect.objectContaining({
+      id: repository.id,
+      analyzed_at: '2026-08-25T00:00:00.000Z',
+      analysis_failed: true,
+      analysis_error: 'model unavailable',
+    }));
+    expect(mocks.toast).toHaveBeenCalledWith('AI分析失败，请检查AI配置和网络连接。', 'error');
+    expect(mocks.forceSyncToBackend).not.toHaveBeenCalled();
+  });
+
+  it('stores the PR-03 success patch without triggering a backend sync', async () => {
+    mocks.analyzeRepository.mockResolvedValue({
+      summary: 'AI summary',
+      tags: ['ai-tag'],
+      platforms: ['web'],
+      custom_category: 'Tools',
+      category_locked: true,
+      analyzed_at: '2026-08-25T00:00:00.000Z',
+    });
+    const { result } = renderActions();
+
+    await act(async () => {
+      await result.current.analyze();
+    });
+
+    expect(storeState.updateRepository).toHaveBeenCalledWith(expect.objectContaining({
+      id: repository.id,
+      ai_summary: 'AI summary',
+      ai_tags: ['ai-tag'],
+      analysis_failed: false,
+    }));
+    expect(mocks.forceSyncToBackend).not.toHaveBeenCalled();
+  });
+
+  it('enters the similar view without triggering a backend sync', async () => {
+    mocks.findSimilarRepositories.mockResolvedValue([]);
+    const { result } = renderActions();
+
+    await act(async () => {
+      await result.current.findSimilar();
+    });
+
+    expect(storeState.enterSimilarView).toHaveBeenCalledWith([], repository);
+    expect(mocks.forceSyncToBackend).not.toHaveBeenCalled();
+    expect(mocks.toast).toHaveBeenCalledWith('未找到相似的仓库。', 'info');
+  });
+
+  it('does not delete local data or trigger a backend sync when remote unstar fails', async () => {
+    mocks.unstarRepository.mockRejectedValue(new Error('GitHub unavailable'));
+    const { result } = renderActions();
+
+    await act(async () => {
+      await result.current.unstar();
+    });
+
+    expect(storeState.deleteRepository).not.toHaveBeenCalled();
+    expect(mocks.forceSyncToBackend).not.toHaveBeenCalled();
+    expect(mocks.toast).toHaveBeenCalledWith('取消 Star 失败，请检查网络连接或重新登录。', 'error');
+  });
+
+  it('syncs only after a successful remote unstar and local deletion', async () => {
+    const { result } = renderActions();
+
+    await act(async () => {
+      await result.current.unstar();
+    });
+
+    expect(mocks.unstarRepository).toHaveBeenCalledWith('owner', 'example-repository');
+    expect(storeState.deleteRepository).toHaveBeenCalledWith(repository.id);
+    expect(mocks.forceSyncToBackend).toHaveBeenCalledOnce();
+    expect(mocks.toast).toHaveBeenCalledWith('已成功取消 Star', 'success');
+  });
+});

--- a/src/features/repositories/hooks/useRepositoryCardActions.ts
+++ b/src/features/repositories/hooks/useRepositoryCardActions.ts
@@ -1,0 +1,420 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { shallow } from 'zustand/shallow';
+import type { Category, Repository } from '../../../types';
+import { useAppStore } from '../../../store/useAppStore';
+import { useDialog } from '../../../hooks/useDialog';
+import { EmbeddingClient, VectorSearchService, findSimilarRepositories } from '../../../services/vectorSearchService';
+import { analyzeRepository, createFailedAnalysisResult } from '../../../services/aiAnalysisHelper';
+import { forceSyncToBackend } from '../../../services/autoSync';
+import { GitHubApiService } from '../../../services/githubApi';
+import { logger } from '../../../services/logger';
+import { applyAnalysisFailure, applyAnalysisSuccess } from '../application/repositoryPatches';
+
+interface UseRepositoryCardActionsOptions {
+  repository: Repository;
+  allCategories: Category[];
+}
+
+export interface RepositoryCardActions {
+  analyze: () => Promise<void>;
+  findSimilar: () => Promise<void>;
+  unstar: () => Promise<void>;
+  toggleReleaseSubscription: () => void;
+  isSubscribed: boolean;
+  isAnalyzing: boolean;
+  isFindingSimilar: boolean;
+  isUnstarring: boolean;
+  vectorSearchAvailable: boolean;
+}
+
+/**
+ * Encapsulates RepositoryCard's domain operations while leaving card-local UI
+ * state, layout, keyboard handling, and drag behaviour in the view component.
+ */
+export const useRepositoryCardActions = ({
+  repository,
+  allCategories,
+}: UseRepositoryCardActionsOptions): RepositoryCardActions => {
+  const repoId = repository.id;
+  const isSubscribed = useAppStore(
+    useCallback((state) => state.releaseSubscriptions.has(repoId), [repoId]),
+  );
+  const isStoreAnalyzing = useAppStore(
+    useCallback((state) => state.analyzingRepositoryIds.has(repoId), [repoId]),
+  );
+  const {
+    githubToken,
+    activeAIConfig,
+    setAnalyzingRepository,
+    language,
+    updateRepository,
+    deleteRepository,
+    vectorSearchConfig,
+    vectorSearchStatus,
+    embeddingConfigs,
+    activeEmbeddingConfig,
+    repositories,
+    enterSimilarView,
+    aiConfigs,
+    toggleReleaseSubscription: toggleStoreReleaseSubscription,
+  } = useAppStore(
+    useCallback(
+      (state) => ({
+        githubToken: state.githubToken,
+        activeAIConfig: state.activeAIConfig,
+        setAnalyzingRepository: state.setAnalyzingRepository,
+        language: state.language,
+        updateRepository: state.updateRepository,
+        deleteRepository: state.deleteRepository,
+        vectorSearchConfig: state.vectorSearchConfig,
+        vectorSearchStatus: state.vectorSearchStatus,
+        embeddingConfigs: state.embeddingConfigs,
+        activeEmbeddingConfig: state.activeEmbeddingConfig,
+        repositories: state.repositories,
+        enterSimilarView: state.enterSimilarView,
+        aiConfigs: state.aiConfigs,
+        toggleReleaseSubscription: state.toggleReleaseSubscription,
+      }),
+      [],
+    ),
+    shallow,
+  );
+  const { toast, confirm } = useDialog();
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const [isLocallyAnalyzing, setIsLocallyAnalyzing] = useState(false);
+  const [isFindingSimilar, setIsFindingSimilar] = useState(false);
+  const [isUnstarring, setIsUnstarring] = useState(false);
+
+  useEffect(() => () => {
+    abortControllerRef.current?.abort();
+    setAnalyzingRepository(repoId, false);
+  }, [repoId, setAnalyzingRepository]);
+
+  const vectorSearchAvailable = useMemo(() => {
+    const activeConfig = embeddingConfigs.find((config) => config.id === activeEmbeddingConfig);
+    const configComplete = !!activeConfig
+      && !!activeConfig.baseUrl
+      && !!activeConfig.model
+      && (activeConfig.apiType === 'ollama' || !!activeConfig.apiKey);
+
+    return (
+      vectorSearchConfig.enabled
+      && !!vectorSearchStatus?.connected
+      && (vectorSearchStatus?.vectorCount ?? 0) > 0
+      && configComplete
+      && !!vectorSearchConfig.workerUrl
+      && !!vectorSearchConfig.authToken
+    );
+  }, [embeddingConfigs, activeEmbeddingConfig, vectorSearchConfig, vectorSearchStatus]);
+
+  const analyze = useCallback(async () => {
+    if (!githubToken) {
+      toast(
+        language === 'zh'
+          ? 'GitHub token 未找到，请重新登录。'
+          : 'GitHub token not found. Please login again.',
+        'error',
+      );
+      return;
+    }
+
+    const activeConfig = aiConfigs.find((config) => config.id === activeAIConfig);
+    if (!activeConfig) {
+      toast(
+        language === 'zh'
+          ? '请先在设置中配置AI服务。'
+          : 'Please configure AI service in settings first.',
+        'error',
+      );
+      return;
+    }
+
+    if (activeConfig.apiKeyStatus === 'decrypt_failed' || activeConfig.apiKeyStatus === 'empty') {
+      toast(
+        language === 'zh'
+          ? 'AI服务的API密钥无法解密或为空，请在设置中重新输入并保存该配置。'
+          : 'The AI service API key could not be decrypted or is empty. Please re-enter and save the configuration in settings.',
+        'error',
+      );
+      return;
+    }
+
+    if (!activeConfig.baseUrl || !activeConfig.apiKey || !activeConfig.model) {
+      toast(
+        language === 'zh'
+          ? 'AI服务配置不完整，请检查API端点、密钥和模型名称。'
+          : 'AI service configuration is incomplete. Please check the API endpoint, key, and model name.',
+        'error',
+      );
+      return;
+    }
+
+    if (repository.analyzed_at) {
+      const confirmMessage = language === 'zh'
+        ? `此仓库已于 ${new Date(repository.analyzed_at).toLocaleString()} 进行过AI分析。\n\n是否要重新分析？这将覆盖现有的分析结果。`
+        : `This repository was analyzed on ${new Date(repository.analyzed_at).toLocaleString()}.\n\nDo you want to re-analyze? This will overwrite the existing analysis results.`;
+
+      if (!await confirm(
+        language === 'zh' ? '重新分析确认' : 'Re-analyze Confirmation',
+        confirmMessage,
+        { type: 'warning' },
+      )) {
+        return;
+      }
+    }
+
+    abortControllerRef.current?.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    const analysisStartedAt = performance.now();
+    setIsLocallyAnalyzing(true);
+    requestAnimationFrame(() => {
+      logger.info('ai.performance', 'Repository card AI spinner painted', {
+        repoId,
+        fullName: repository.full_name,
+        elapsedMs: Math.round(performance.now() - analysisStartedAt),
+      });
+    });
+    setAnalyzingRepository(repoId, true);
+
+    try {
+      const result = await analyzeRepository({
+        repository,
+        githubToken,
+        aiConfig: activeConfig,
+        language,
+        categories: allCategories,
+        onProgress: (status) => {
+          logger.info('ai.performance', 'Repository card AI analysis step', {
+            repoId,
+            fullName: repository.full_name,
+            status,
+            elapsedMs: Math.round(performance.now() - analysisStartedAt),
+          });
+        },
+        signal: controller.signal,
+      });
+      logger.info('ai.performance', 'Repository card AI request completed', {
+        repoId,
+        fullName: repository.full_name,
+        elapsedMs: Math.round(performance.now() - analysisStartedAt),
+      });
+
+      if (controller.signal.aborted) return;
+
+      const updatedRepo = applyAnalysisSuccess(repository, {
+        summary: result.summary,
+        tags: result.tags,
+        platforms: result.platforms,
+        category: result.custom_category,
+        categoryLocked: result.category_locked,
+        analyzedAt: result.analyzed_at,
+      });
+
+      const updateStartedAt = performance.now();
+      updateRepository(updatedRepo);
+      logger.info('ai.performance', 'Repository card AI result stored', {
+        repoId,
+        fullName: repository.full_name,
+        updateMs: Math.round(performance.now() - updateStartedAt),
+        elapsedMs: Math.round(performance.now() - analysisStartedAt),
+      });
+
+      toast(
+        repository.analyzed_at
+          ? (language === 'zh' ? 'AI重新分析完成！' : 'AI re-analysis completed!')
+          : (language === 'zh' ? 'AI分析完成！' : 'AI analysis completed!'),
+        'success',
+      );
+    } catch (error) {
+      if (!controller.signal.aborted) {
+        console.error('AI analysis failed:', error);
+
+        const errorMessage = error instanceof Error && error.message
+          ? error.message
+          : (language === 'zh'
+            ? 'AI分析失败，请检查AI配置和网络连接'
+            : 'AI analysis failed, please check AI configuration and network connection');
+        const failedResult = createFailedAnalysisResult(errorMessage);
+        const failedRepo = applyAnalysisFailure(repository, {
+          analyzedAt: failedResult.analyzed_at,
+          error: failedResult.analysis_error,
+        });
+
+        const updateStartedAt = performance.now();
+        updateRepository(failedRepo);
+        logger.info('ai.performance', 'Repository card AI failure stored', {
+          repoId,
+          fullName: repository.full_name,
+          updateMs: Math.round(performance.now() - updateStartedAt),
+          elapsedMs: Math.round(performance.now() - analysisStartedAt),
+        });
+
+        toast(
+          language === 'zh'
+            ? 'AI分析失败，请检查AI配置和网络连接。'
+            : 'AI analysis failed. Please check AI configuration and network connection.',
+          'error',
+        );
+      }
+    } finally {
+      setIsLocallyAnalyzing(false);
+      if (!controller.signal.aborted) {
+        setAnalyzingRepository(repoId, false);
+      }
+    }
+  }, [
+    activeAIConfig,
+    aiConfigs,
+    allCategories,
+    confirm,
+    githubToken,
+    language,
+    repoId,
+    repository,
+    setAnalyzingRepository,
+    toast,
+    updateRepository,
+  ]);
+
+  const findSimilar = useCallback(async () => {
+    if (isFindingSimilar) return;
+    if (!vectorSearchAvailable) {
+      toast(
+        language === 'zh'
+          ? '向量搜索未就绪：请先在设置中开启向量搜索并完成索引。'
+          : 'Vector search is not ready. Please enable vector search and build the index in settings first.',
+        'error',
+      );
+      return;
+    }
+
+    const activeConfig = embeddingConfigs.find((config) => config.id === activeEmbeddingConfig);
+    if (!activeConfig) return;
+
+    setIsFindingSimilar(true);
+    try {
+      const embeddingClient = new EmbeddingClient({
+        ...activeConfig,
+        apiType: activeConfig.apiType,
+        baseUrl: activeConfig.baseUrl,
+        apiKey: activeConfig.apiKey,
+        model: activeConfig.model,
+        dimensions: activeConfig.dimensions,
+      });
+      const vectorService = new VectorSearchService({
+        workerUrl: vectorSearchConfig.workerUrl,
+        authToken: vectorSearchConfig.authToken,
+      });
+      const similar = await findSimilarRepositories(repository, {
+        embeddingClient,
+        vectorService,
+        allRepos: repositories,
+        topK: vectorSearchConfig.searchTopK ?? 30,
+        threshold: vectorSearchConfig.searchThreshold ?? 0.35,
+      });
+
+      enterSimilarView(similar, repository);
+
+      if (similar.length === 0) {
+        toast(language === 'zh' ? '未找到相似的仓库。' : 'No similar repositories found.', 'info');
+      }
+    } catch (error) {
+      console.error('Find similar repositories failed:', error);
+      const errorMessage = error instanceof Error && error.message
+        ? error.message
+        : (language === 'zh'
+          ? '查找相似仓库失败，请检查向量搜索配置。'
+          : 'Failed to find similar repositories. Please check vector search configuration.');
+      toast(errorMessage, 'error');
+    } finally {
+      setIsFindingSimilar(false);
+    }
+  }, [
+    activeEmbeddingConfig,
+    embeddingConfigs,
+    enterSimilarView,
+    isFindingSimilar,
+    language,
+    repositories,
+    repository,
+    toast,
+    vectorSearchAvailable,
+    vectorSearchConfig,
+  ]);
+
+  const toggleReleaseSubscription = useCallback(() => {
+    toggleStoreReleaseSubscription(repoId);
+  }, [repoId, toggleStoreReleaseSubscription]);
+
+  const unstar = useCallback(async () => {
+    if (!githubToken) {
+      toast(
+        language === 'zh'
+          ? '未找到 GitHub Token，请重新登录。'
+          : 'GitHub token not found. Please login again.',
+        'error',
+      );
+      return;
+    }
+
+    const confirmMessage = language === 'zh'
+      ? `确定要取消 Star "${repository.full_name}" 吗？\n\n这将会从您的 GitHub 收藏中移除该仓库。`
+      : `Are you sure you want to unstar "${repository.full_name}"?\n\nThis will remove the repository from your GitHub stars.`;
+
+    if (!await confirm(
+      language === 'zh' ? '取消Star确认' : 'Unstar Confirmation',
+      confirmMessage,
+      {
+        type: 'danger',
+        confirmText: language === 'zh' ? '取消Star' : 'Unstar',
+      },
+    )) {
+      return;
+    }
+
+    setIsUnstarring(true);
+    try {
+      const githubApi = new GitHubApiService(githubToken);
+      const [owner, repo] = repository.full_name.split('/');
+      await githubApi.unstarRepository(owner, repo);
+      deleteRepository(repository.id);
+      await forceSyncToBackend();
+      toast(language === 'zh' ? '已成功取消 Star' : 'Successfully unstarred', 'success');
+    } catch (error) {
+      console.error('Failed to unstar repository:', error);
+      toast(
+        language === 'zh'
+          ? '取消 Star 失败，请检查网络连接或重新登录。'
+          : 'Failed to unstar repository. Please check your network connection or login again.',
+        'error',
+      );
+    } finally {
+      setIsUnstarring(false);
+    }
+  }, [confirm, deleteRepository, githubToken, language, repository, toast]);
+
+  return useMemo(() => ({
+    analyze,
+    findSimilar,
+    unstar,
+    toggleReleaseSubscription,
+    isSubscribed,
+    isAnalyzing: isLocallyAnalyzing || isStoreAnalyzing,
+    isFindingSimilar,
+    isUnstarring,
+    vectorSearchAvailable,
+  }), [
+    analyze,
+    findSimilar,
+    isFindingSimilar,
+    isLocallyAnalyzing,
+    isStoreAnalyzing,
+    isSubscribed,
+    isUnstarring,
+    toggleReleaseSubscription,
+    unstar,
+    vectorSearchAvailable,
+  ]);
+};


### PR DESCRIPTION
## Summary

Move `RepositoryCard` domain operations into `useRepositoryCardActions` so the card remains a presentation component while preserving the existing user-visible behavior and persistence contracts.

| Previous `RepositoryCard` concern | New hook API / owner |
| --- | --- |
| `handleAIAnalyze` and local/store analyzing orchestration | `analyze`, `isAnalyzing` |
| `handleFindSimilar` and vector readiness calculation | `findSimilar`, `isFindingSimilar`, `vectorSearchAvailable` |
| `handleUnstar`, remote GitHub mutation, local deletion, backend sync | `unstar`, `isUnstarring` |
| Release subscription state and action | `isSubscribed`, `toggleReleaseSubscription` |

The view retains its local modal/menu/drag/keyboard/highlight state and JSX structure. `RepositoryCard.tsx` no longer imports or directly invokes `vectorSearchService`, `aiAnalysisHelper`, `autoSync`, or `githubApi`.

## Verification

- [x] Added hook coverage for stable API identity, abort cleanup, cancelled re-analysis, unavailable vector search, AI success/failure patches, similar-view entry, and unstar success/failure ordering.
- [x] Updated component tests to mock the domain hook and verify list/grid action bindings.
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:run` — 41 files / 435 tests passed.
- [x] `git diff --check`
- [x] No prohibited business-service imports or direct calls remain in `RepositoryCard.tsx`.
- [ ] `npm run build` — the sandbox terminated Vite during `rendering chunks` with exit code 143 (also observed on the unmodified baseline), so the bundle budget must be verified by CI.

## Scope guardrails

No persistence schema/key changes, no second persisted store, no `forceSyncToBackend` invocation was added to AI/similar paths, and no `RepositoryList` work is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Repository cards now provide more reliable actions for AI analysis, similar-repository searches, unsubscribing, and release subscriptions.
  * Added clearer handling for unavailable search capabilities, incomplete configuration, cancelled confirmations, and in-progress actions.
  * Analysis operations now stop safely when leaving the page, while success and failure results are reflected on the repository.
  * Unstarring now updates the repository only after the remote action succeeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->