### PR TITLE
refactor: move RepositoryList batch workflows into job hooks

### DIFF
--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
+import { shallow } from 'zustand/shallow';
 import { Bot, ChevronDown, LayoutGrid, List, Pause, Play } from 'lucide-react';
 import { RepositoryCard } from './RepositoryCard';
 import { SimilarViewBanner } from './SimilarViewBanner';
@@ -8,24 +9,13 @@ import { BulkRestoreModal, RestoreConfig } from './BulkRestoreModal';
 
 import { Repository } from '../types';
 import { useAppStore, getAllCategories } from '../store/useAppStore';
-import { GitHubApiService } from '../services/githubApi';
-import { AIService } from '../services/aiService';
-import { AIAnalysisOptimizer, AnalysisResult } from '../services/aiAnalysisOptimizer';
-import { resolveCategoryAssignment, getAICategory, getDefaultCategory, computeCustomCategory, matchesCategory, buildCategoryHints } from '../utils/categoryUtils';
-import { forceSyncToBackend } from '../services/autoSync';
+import { matchesCategory } from '../utils/categoryUtils';
+import { useRepositoryAnalysisJob } from '../features/repositories/hooks/useRepositoryAnalysisJob';
+import { useBulkRepositoryActions } from '../features/repositories/hooks/useBulkRepositoryActions';
 import { useDialog } from '../hooks/useDialog';
 import { Button } from './ui/button';
 import { RadioGroup, RadioGroupItem } from './ui/radio-group';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from './ui/dropdown-menu';
-import {
-  applyAnalysisFailure,
-  applyAnalysisSuccess,
-  applyCategoryAssignment,
-  lockRepositoryCategory,
-  restoreRepositoryFields,
-  setReleaseSubscriptionMarker,
-  unlockRepositoryCategory,
-} from '../features/repositories/application/repositoryPatches';
 
 interface RepositoryListProps {
   repositories: Repository[];
@@ -37,43 +27,40 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
   selectedCategory
 }) => {
   const {
-    githubToken,
-    aiConfigs,
-    activeAIConfig,
-    isLoading,
-    setLoading,
-    updateRepository,
-    deleteRepository,
     language,
     customCategories,
     hiddenDefaultCategoryIds,
     defaultCategoryOverrides,
     categoryMatchMode,
-    analysisProgress,
-    setAnalysisProgress,
     searchFilters,
-    toggleReleaseSubscription,
-    batchUnsubscribeReleases,
-    releaseSubscriptions,
     similarView,
     resetSimilarView,
     repositoryViewMode,
-    setRepositoryViewMode
-  } = useAppStore();
+    setRepositoryViewMode,
+  } = useAppStore(
+    useCallback((state) => ({
+      language: state.language,
+      customCategories: state.customCategories,
+      hiddenDefaultCategoryIds: state.hiddenDefaultCategoryIds,
+      defaultCategoryOverrides: state.defaultCategoryOverrides,
+      categoryMatchMode: state.categoryMatchMode,
+      searchFilters: state.searchFilters,
+      similarView: state.similarView,
+      resetSimilarView: state.resetSimilarView,
+      repositoryViewMode: state.repositoryViewMode,
+      setRepositoryViewMode: state.setRepositoryViewMode,
+    }), []),
+    shallow,
+  );
 
-  const { toast, confirm } = useDialog();
+  const { toast } = useDialog();
 
   const [showAISummary, setShowAISummary] = useState(true);
-  const [isPaused, setIsPaused] = useState(false);
   const [disableCardAnimations, setDisableCardAnimations] = useState(false);
   const previousCategoryRef = useRef(selectedCategory);
   const savedScrollYRef = useRef<number | null>(null);
   const restoreScrollFrameRef = useRef<number | null>(null);
   
-  // 使用 useRef 来管理停止状态，确保在异步操作中能正确访问最新值
-  const shouldStopRef = useRef(false);
-  const isAnalyzingRef = useRef(false);
-  const optimizerRef = useRef<AIAnalysisOptimizer | null>(null);
 
   // 批量选择状态
   const [selectedRepoIds, setSelectedRepoIds] = useState<Set<number>>(new Set());
@@ -86,6 +73,10 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
     () => getAllCategories(customCategories, language, hiddenDefaultCategoryIds, defaultCategoryOverrides),
     [customCategories, language, hiddenDefaultCategoryIds, defaultCategoryOverrides]
   );
+  const analysisJob = useRepositoryAnalysisJob({ allCategories });
+  const bulkActions = useBulkRepositoryActions({ allCategories });
+  const isLoading = analysisJob.isRunning;
+  const { isPaused, progress: analysisProgress } = analysisJob;
 
   const filteredRepositories = useMemo(() => {
     if (selectedCategory === 'all') return repositories;
@@ -262,204 +253,30 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
 
   const t = (zh: string, en: string) => language === 'zh' ? zh : en;
 
-  const handleAIAnalyze = async (analyzeUnanalyzedOnly: boolean = false, analyzeFailedOnly: boolean = false) => {
-    if (!githubToken) {
-      toast(language === 'zh' ? 'GitHub token 未找到，请重新登录。' : 'GitHub token not found. Please login again.', 'error');
-      return;
-    }
-
-    const activeConfig = aiConfigs.find(config => config.id === activeAIConfig);
-    if (!activeConfig) {
-      toast(language === 'zh' ? '请先在设置中配置AI服务。' : 'Please configure AI service in settings first.', 'error');
-      return;
-    }
-
-    if (activeConfig.apiKeyStatus === 'decrypt_failed' || activeConfig.apiKeyStatus === 'empty') {
-      toast(language === 'zh' ? 'AI服务的API密钥无法解密或为空，请在设置中重新输入并保存该配置。' : 'The AI service API key could not be decrypted or is empty. Please re-enter and save the configuration in settings.', 'error');
-      return;
-    }
-
-    if (!activeConfig.baseUrl || !activeConfig.apiKey || !activeConfig.model) {
-      toast(language === 'zh' ? 'AI服务配置不完整，请检查API端点、密钥和模型名称。' : 'AI service configuration is incomplete. Please check the API endpoint, key, and model name.', 'error');
-      return;
-    }
-
-    const targetRepos = analyzeFailedOnly
-      ? filteredRepositories.filter(repo => repo.analysis_failed)
-      : analyzeUnanalyzedOnly 
-        ? filteredRepositories.filter(repo => !repo.analyzed_at)
+  const handleAIAnalyze = (analyzeUnanalyzedOnly: boolean = false, analyzeFailedOnly: boolean = false) => {
+    const scope = analyzeFailedOnly ? 'failed' : analyzeUnanalyzedOnly ? 'unanalyzed' : 'all';
+    const targetRepositories = analyzeFailedOnly
+      ? filteredRepositories.filter((repository) => repository.analysis_failed)
+      : analyzeUnanalyzedOnly
+        ? filteredRepositories.filter((repository) => !repository.analyzed_at)
         : filteredRepositories;
 
-    if (targetRepos.length === 0) {
-      const message = analyzeFailedOnly
-        ? t('没有分析失败的仓库！', 'No failed repositories to re-analyze!')
-        : analyzeUnanalyzedOnly
-          ? t('所有仓库都已经分析过了！', 'All repositories have been analyzed!')
-          : t('没有可分析的仓库！', 'No repositories to analyze!');
-      toast(message, 'info');
-      return;
-    }
-
-    const actionText = analyzeFailedOnly
-      ? (language === 'zh' ? '失败' : 'failed')
-      : analyzeUnanalyzedOnly
-        ? (language === 'zh' ? '未分析' : 'unanalyzed')
-        : (language === 'zh' ? '全部' : 'all');
-
-    const confirmMessage = language === 'zh'
-      ? `将对 ${targetRepos.length} 个${actionText}仓库进行AI分析，这可能需要几分钟时间。是否继续？`
-      : `Will analyze ${targetRepos.length} ${actionText} repositories with AI. This may take several minutes. Continue?`;
-
-    const confirmed = await confirm(
-      t('AI分析确认', 'AI Analysis Confirmation'),
-      confirmMessage,
-      { type: 'warning' }
-    );
-    if (!confirmed) return;
-
-    // 重置状态
-    shouldStopRef.current = false;
-    isAnalyzingRef.current = true;
-    setLoading(true);
-    setAnalysisProgress({ current: 0, total: targetRepos.length });
-    setIsPaused(false);
-
-    // 创建优化器实例并保存到 ref
-    optimizerRef.current = new AIAnalysisOptimizer({
-      initialConcurrency: activeConfig.concurrency || 3,
-      maxConcurrency: 10,
-      minConcurrency: 1,
-      targetResponseTime: 5000,
-      batchDelayMs: 100,
-      maxRetries: 3,
-      retryDelayBaseMs: 1000,
-      enableAdaptiveConcurrency: true,
-      rateLimiter: {
-        maxConcurrency: 0,
-        requestsPerMinute: activeConfig.requestsPerMinute || 0,
-      },
+    return analysisJob.run({
+      repositories: targetRepositories,
+      scope,
+      syncOnComplete: false,
     });
-
-    try {
-      const githubApi = new GitHubApiService(githubToken);
-      const aiService = new AIService(activeConfig, language);
-      const categoryNames = allCategories.filter(cat => cat.id !== 'all').map(cat => cat.name);
-      const aiCategoryHints = buildCategoryHints(allCategories);
-
-      let successCount = 0;
-      let failedCount = 0;
-
-      const handleResult = (result: AnalysisResult) => {
-        if (result.success) {
-          const resolvedCategory = resolveCategoryAssignment(
-            { ...result.repo, ai_summary: result.summary },
-            result.tags || [],
-            allCategories
-          );
-
-          const wasCategoryLocked = !!result.repo.category_locked;
-
-          updateRepository(applyAnalysisSuccess(result.repo, {
-            summary: result.summary,
-            tags: result.tags,
-            platforms: result.platforms,
-            category: resolvedCategory,
-            categoryLocked: wasCategoryLocked,
-            analyzedAt: new Date().toISOString(),
-          }));
-          successCount++;
-        } else {
-          updateRepository(applyAnalysisFailure(result.repo, {
-            analyzedAt: new Date().toISOString(),
-            error: result.error?.message || undefined,
-          }));
-          failedCount++;
-        }
-      };
-
-      setAnalysisProgress({ current: 0, total: targetRepos.length });
-
-      await optimizerRef.current!.analyzeRepositoriesPipelined(
-        targetRepos,
-        githubApi,
-        aiService,
-        categoryNames,
-        aiCategoryHints,
-        (completed, total, currentConcurrency) => {
-          setAnalysisProgress({ current: completed, total });
-          console.log(`AI Analysis Progress: ${completed}/${total}, Concurrency: ${currentConcurrency}`);
-        },
-        handleResult
-      );
-
-      const stats = optimizerRef.current!.getStats();
-      console.log('AI Analysis Stats:', stats);
-
-      const completionMessage = shouldStopRef.current
-        ? (language === 'zh'
-            ? `AI分析已停止！成功: ${successCount}, 失败: ${failedCount}`
-            : `AI analysis stopped! Success: ${successCount}, Failed: ${failedCount}`)
-        : (language === 'zh'
-            ? `AI分析完成！成功: ${successCount}, 失败: ${failedCount} (平均响应: ${stats.averageResponseTime}ms)`
-            : `AI analysis completed! Success: ${successCount}, Failed: ${failedCount} (avg: ${stats.averageResponseTime}ms)`);
-
-      toast(completionMessage, 'success');
-    } catch (error) {
-      console.error('AI analysis failed:', error);
-      const errorMessage = language === 'zh'
-        ? 'AI分析失败，请检查AI配置和网络连接。'
-        : 'AI analysis failed. Please check AI configuration and network connection.';
-      toast(errorMessage, 'error');
-    } finally {
-      // 清理状态
-      optimizerRef.current = null;
-      isAnalyzingRef.current = false;
-      shouldStopRef.current = false;
-      setLoading(false);
-      setAnalysisProgress({ current: 0, total: 0 });
-      setIsPaused(false);
-    }
   };
 
   const handlePauseResume = () => {
-    if (!isAnalyzingRef.current) return;
-    const newPausedState = !isPaused;
-    setIsPaused(newPausedState);
-
-    // 控制优化器的暂停/恢复
-    if (optimizerRef.current) {
-      if (newPausedState) {
-        optimizerRef.current.pause();
-        console.log('Analysis paused');
-      } else {
-        optimizerRef.current.resume();
-        console.log('Analysis resumed');
-      }
+    if (isPaused) {
+      analysisJob.resume();
+      return;
     }
+    analysisJob.pause();
   };
 
-  const handleStop = async () => {
-    if (!isAnalyzingRef.current) return;
-
-    const confirmMessage = language === 'zh'
-      ? '确定要停止 AI 分析吗？已分析的结果将会保存。'
-      : 'Are you sure you want to stop AI analysis? Analyzed results will be saved.';
-
-    const confirmed = await confirm(
-      t('停止AI分析', 'Stop AI Analysis'),
-      confirmMessage,
-      { type: 'warning' }
-    );
-    if (confirmed) {
-      shouldStopRef.current = true;
-      // 中止优化器
-      if (optimizerRef.current) {
-        optimizerRef.current.abort();
-      }
-      setIsPaused(false);
-      console.log('Stop requested by user');
-    }
-  };
+  const handleStop = () => analysisJob.requestStop();
 
   // 批量操作处理函数
   // 使用 useCallback 优化事件处理函数
@@ -499,42 +316,6 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
     }, 250);
   }, []);
 
-  const handleBulkRestore = useCallback(async (config: RestoreConfig) => {
-    const selectedRepos = repositories.filter(repo => selectedRepoIds.has(repo.id));
-    if (selectedRepos.length === 0) return;
-
-    let successCount = 0;
-    const failedRepos: string[] = [];
-
-    for (const repo of selectedRepos) {
-      try {
-        const updatedRepo = restoreRepositoryFields(repo, config, new Date().toISOString());
-
-        if (updatedRepo) {
-          updateRepository(updatedRepo);
-        }
-        successCount++;
-      } catch (error) {
-        console.error(`Failed to restore ${repo.full_name}:`, error);
-        failedRepos.push(repo.full_name);
-      }
-    }
-
-    await forceSyncToBackend();
-
-    const skipMsg = failedRepos.length > 0
-      ? (language === 'zh'
-        ? `\n\n失败 (${failedRepos.length} 个):\n${failedRepos.join('\n')}`
-        : `\n\nFailed (${failedRepos.length}):\n${failedRepos.join('\n')}`)
-      : '';
-
-    toast(language === 'zh'
-      ? `成功还原 ${successCount} 个仓库${skipMsg}`
-      : `Successfully restored ${successCount} repositories${skipMsg}`,
-      failedRepos.length > 0 ? 'error' : 'success'
-    );
-  }, [repositories, selectedRepoIds, updateRepository, language, toast]);
-
   // 处理单击空白处 - 触发回到顶部按钮跳跃动画
   const handleClick = useCallback((e: React.MouseEvent) => {
     // 检查点击的是否是空白区域（不是卡片或其他元素）
@@ -552,325 +333,46 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
     }
   }, [showBulkToolbar, handleDeselectAll]);
 
-  const handleBulkAction = async (action: string, repos: Repository[]) => {
+  const handleBulkAction = async (action: string, selectedRepositories: Repository[]) => {
     try {
+      let completed = false;
       switch (action) {
-        case 'unstar': {
-          if (!githubToken) {
-            toast(language === 'zh' ? 'GitHub token 未找到，请重新登录。' : 'GitHub token not found. Please login again.', 'error');
-            return;
-          }
-
-          const confirmMessage = language === 'zh'
-            ? `确定要取消 ${repos.length} 个仓库的 Star 吗？此操作不可撤销！`
-            : `Are you sure you want to unstar ${repos.length} repositories? This action cannot be undone!`;
-
-          const confirmed = await confirm(
-            t('取消Star确认', 'Unstar Confirmation'),
-            confirmMessage,
-            { type: 'danger', confirmText: t('取消Star', 'Unstar') }
-          );
-          if (!confirmed) return;
-
-          const githubApi = new GitHubApiService(githubToken);
-          const successIds: number[] = [];
-
-          for (const repo of repos) {
-            try {
-              const [owner, name] = repo.full_name.split('/');
-              await githubApi.unstarRepository(owner, name);
-              successIds.push(repo.id);
-            } catch (error) {
-              console.error(`Failed to unstar ${repo.full_name}:`, error);
-            }
-          }
-
-          // 仅删除成功 unstar 的仓库
-          for (const repoId of successIds) {
-            deleteRepository(repoId);
-          }
-
-          await forceSyncToBackend();
-          toast(language === 'zh'
-            ? `成功取消 ${successIds.length} 个仓库的 Star`
-            : `Successfully unstarred ${successIds.length} repositories`,
-            'success'
-          );
+        case 'unstar':
+          completed = await bulkActions.unstar(selectedRepositories);
           break;
-        }
-
-        case 'categorize': {
+        case 'categorize':
           setShowCategorizeModal(true);
           return;
-        }
-
-        case 'restore': {
+        case 'restore':
           setShowRestoreModal(true);
           return;
-        }
-
-        case 'ai-summary': {
-          if (!githubToken) {
-            toast(language === 'zh' ? 'GitHub token 未找到，请重新登录。' : 'GitHub token not found. Please login again.', 'error');
-            return;
-          }
-
-          const confirmMessage = language === 'zh'
-            ? `将对 ${repos.length} 个仓库进行 AI 分析，这可能需要几分钟时间。是否继续？`
-            : `Will analyze ${repos.length} repositories with AI. This may take several minutes. Continue?`;
-
-          if (!await confirm(t('AI分析确认', 'AI Analysis Confirmation'), confirmMessage, { type: 'warning' })) return;
-
-          const activeConfig = aiConfigs.find(config => config.id === activeAIConfig);
-          if (!activeConfig) {
-            toast(language === 'zh' ? '请先在设置中配置 AI 服务。' : 'Please configure AI service in settings first.', 'error');
-            return;
-          }
-
-          // 设置加载状态
-          setLoading(true);
-          isAnalyzingRef.current = true;
-          setAnalysisProgress({ current: 0, total: repos.length });
-
-          // 创建优化器实例并保存到 ref
-          optimizerRef.current = new AIAnalysisOptimizer({
-            initialConcurrency: activeConfig.concurrency || 3,
-            maxConcurrency: 10,
-            minConcurrency: 1,
-            targetResponseTime: 5000,
-            batchDelayMs: 100,
-            maxRetries: 3,
-            retryDelayBaseMs: 1000,
-            enableAdaptiveConcurrency: true,
-            rateLimiter: {
-              maxConcurrency: 0,
-              requestsPerMinute: activeConfig.requestsPerMinute || 0,
-            },
+        case 'ai-summary':
+          completed = await analysisJob.run({
+            repositories: selectedRepositories,
+            scope: 'selected',
+            syncOnComplete: true,
           });
-
-          try {
-            const githubApi = new GitHubApiService(githubToken);
-            const aiService = new AIService(activeConfig, language);
-            const categoryNames = allCategories.filter(cat => cat.id !== 'all').map(cat => cat.name);
-            const aiCategoryHints = buildCategoryHints(allCategories);
-
-            let successCount = 0;
-            let failedCount = 0;
-
-            const handleResult = (result: AnalysisResult) => {
-              if (result.success) {
-                const resolvedCategory = resolveCategoryAssignment(
-                  { ...result.repo, ai_summary: result.summary },
-                  result.tags || [],
-                  allCategories
-                );
-
-                const wasCategoryLocked = !!result.repo.category_locked;
-                const shouldKeepLocked = wasCategoryLocked && resolvedCategory !== undefined && resolvedCategory !== '';
-
-                updateRepository(applyAnalysisSuccess(result.repo, {
-                  summary: result.summary,
-                  tags: result.tags,
-                  platforms: result.platforms,
-                  category: resolvedCategory,
-                  categoryLocked: shouldKeepLocked || wasCategoryLocked,
-                  analyzedAt: new Date().toISOString(),
-                }));
-                successCount++;
-              } else {
-                updateRepository(applyAnalysisFailure(result.repo, {
-                  analyzedAt: new Date().toISOString(),
-                  error: result.error?.message || undefined,
-                }));
-                failedCount++;
-              }
-            };
-
-            setAnalysisProgress({ current: 0, total: repos.length });
-
-            await optimizerRef.current!.analyzeRepositoriesPipelined(
-              repos,
-              githubApi,
-              aiService,
-              categoryNames,
-              aiCategoryHints,
-              (completed, total, currentConcurrency) => {
-                setAnalysisProgress({ current: completed, total });
-                console.log(`Bulk AI Analysis Progress: ${completed}/${total}, Concurrency: ${currentConcurrency}`);
-              },
-              handleResult
-            );
-
-            const stats = optimizerRef.current!.getStats();
-            console.log('Bulk AI Analysis Stats:', stats);
-
-            await forceSyncToBackend();
-            toast(language === 'zh'
-              ? `成功分析 ${successCount} 个仓库，失败 ${failedCount} 个 (平均响应: ${stats.averageResponseTime}ms)`
-              : `Successfully analyzed ${successCount} repositories, ${failedCount} failed (avg: ${stats.averageResponseTime}ms)`,
-              failedCount > 0 ? 'error' : 'success'
-            );
-          } catch (error) {
-            console.error('Bulk AI analysis failed:', error);
-            toast(language === 'zh' ? '批量AI分析失败' : 'Bulk AI analysis failed', 'error');
-          } finally {
-            // 确保状态重置
-            optimizerRef.current = null;
-            isAnalyzingRef.current = false;
-            shouldStopRef.current = false;
-            setLoading(false);
-            setAnalysisProgress({ current: 0, total: 0 });
-          }
           break;
-        }
-
-        case 'subscribe': {
-          let successCount = 0;
-
-          for (const repo of repos) {
-            try {
-              // 显式设置订阅为 true，避免误取消已订阅仓库
-              updateRepository(setReleaseSubscriptionMarker(repo, true));
-              // 只在未订阅时才调用 toggle，避免误取消
-              if (!releaseSubscriptions.has(repo.id)) {
-                toggleReleaseSubscription(repo.id);
-              }
-              successCount++;
-            } catch (error) {
-              console.error(`Failed to subscribe ${repo.full_name}:`, error);
-            }
-          }
-
-          await forceSyncToBackend();
-          toast(language === 'zh'
-            ? `成功订阅 ${successCount} 个仓库的版本发布`
-            : `Successfully subscribed to ${successCount} repositories releases`,
-            'success'
-          );
+        case 'subscribe':
+          completed = await bulkActions.subscribe(selectedRepositories);
           break;
-        }
-
-        case 'unsubscribe': {
-          const subscribedRepos = repos.filter(repo => releaseSubscriptions.has(repo.id));
-
-          if (subscribedRepos.length === 0) {
-            toast(t('选中的仓库中没有被订阅的', 'None of the selected repositories are subscribed'), 'info');
-            return;
-          }
-
-          // 批量取消订阅
-          const repoIds = subscribedRepos.map(repo => repo.id);
-          batchUnsubscribeReleases(repoIds);
-
-          // 更新仓库的 subscribed_to_releases 字段，记录失败项
-          const failedRepos: string[] = [];
-          for (const repo of subscribedRepos) {
-            try {
-              updateRepository(setReleaseSubscriptionMarker(repo, false));
-            } catch (error) {
-              console.error(`Failed to update repository ${repo.full_name}:`, error);
-              failedRepos.push(repo.full_name);
-            }
-          }
-
-          await forceSyncToBackend();
-
-          // 汇总结果显示
-          const successCount = subscribedRepos.length - failedRepos.length;
-          if (failedRepos.length > 0) {
-            toast(language === 'zh'
-              ? `成功取消 ${successCount} 个仓库的版本发布订阅\n\n失败 (${failedRepos.length} 个):\n${failedRepos.join('\n')}`
-              : `Successfully unsubscribed ${successCount} repositories from releases\n\nFailed (${failedRepos.length}):\n${failedRepos.join('\n')}`,
-              'error'
-            );
-          } else {
-            toast(language === 'zh'
-              ? `成功取消 ${successCount} 个仓库的版本发布订阅`
-              : `Successfully unsubscribed ${successCount} repositories from releases`,
-              'success'
-            );
-          }
+        case 'unsubscribe':
+          completed = await bulkActions.unsubscribe(selectedRepositories);
           break;
-        }
-
-        case 'lock-category': {
-          let successCount = 0;
-          let skippedCount = 0;
-          const failedRepos: string[] = [];
-
-          for (const repo of repos) {
-            try {
-              // 只有有自定义分类的仓库才能锁定，锁定不改变自定义状态
-              const updatedRepo = lockRepositoryCategory(repo, new Date().toISOString());
-              if (updatedRepo) {
-                updateRepository(updatedRepo);
-                successCount++;
-              } else {
-                skippedCount++;
-              }
-            } catch (error) {
-              console.error(`Failed to lock category for ${repo.full_name}:`, error);
-              failedRepos.push(repo.full_name);
-            }
-          }
-
-          await forceSyncToBackend();
-          const skipMsg = skippedCount > 0
-            ? (language === 'zh' ? `\n\n跳过 ${skippedCount} 个没有自定义分类的仓库` : `\n\nSkipped ${skippedCount} repositories without custom category`)
-            : '';
-          if (failedRepos.length > 0) {
-            toast(language === 'zh'
-              ? `成功锁定 ${successCount} 个仓库的分类\n\n失败 (${failedRepos.length} 个):\n${failedRepos.join('\n')}${skipMsg}`
-              : `Successfully locked categories for ${successCount} repositories\n\nFailed (${failedRepos.length}):\n${failedRepos.join('\n')}${skipMsg}`,
-              'error'
-            );
-          } else {
-            toast(language === 'zh'
-              ? `成功锁定 ${successCount} 个仓库的分类${skipMsg}`
-              : `Successfully locked categories for ${successCount} repositories${skipMsg}`,
-              'success'
-            );
-          }
+        case 'lock-category':
+          completed = await bulkActions.lockCategory(selectedRepositories);
           break;
-        }
-
-        case 'unlock-category': {
-          let successCount = 0;
-          const failedRepos: string[] = [];
-
-          for (const repo of repos) {
-            try {
-              updateRepository(unlockRepositoryCategory(repo, new Date().toISOString()));
-              successCount++;
-            } catch (error) {
-              console.error(`Failed to unlock category for ${repo.full_name}:`, error);
-              failedRepos.push(repo.full_name);
-            }
-          }
-
-          await forceSyncToBackend();
-          if (failedRepos.length > 0) {
-            toast(language === 'zh'
-              ? `成功解锁 ${successCount} 个仓库的分类\n\n失败 (${failedRepos.length} 个):\n${failedRepos.join('\n')}`
-              : `Successfully unlocked categories for ${successCount} repositories\n\nFailed (${failedRepos.length}):\n${failedRepos.join('\n')}`,
-              'error'
-            );
-          } else {
-            toast(language === 'zh'
-              ? `成功解锁 ${successCount} 个仓库的分类`
-              : `Successfully unlocked categories for ${successCount} repositories`,
-              'success'
-            );
-          }
+        case 'unlock-category':
+          completed = await bulkActions.unlockCategory(selectedRepositories);
           break;
-        }
-
         default:
           toast(language === 'zh' ? '未知操作' : 'Unknown action', 'error');
+          completed = true;
       }
 
-      // 清除选择
-      handleDeselectAll();
+      if (completed) {
+        handleDeselectAll();
+      }
     } catch (error) {
       console.error('Bulk action failed:', error);
       toast(language === 'zh' ? '批量操作失败' : 'Bulk action failed', 'error');
@@ -878,49 +380,17 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
   };
 
   const handleBulkCategorize = async (categoryName: string) => {
-    const selectedRepos = filteredRepositories.filter(repo =>
-      selectedRepoIds.has(repo.id)
-    );
-
-    const failedRepos: string[] = [];
-
-    for (const repo of selectedRepos) {
-      try {
-        // 获取所有分类用于计算AI和默认分类
-        const allCategoriesList = getAllCategories(customCategories, language, hiddenDefaultCategoryIds, defaultCategoryOverrides);
-        const aiCat = getAICategory(repo, allCategoriesList);
-        const defaultCat = getDefaultCategory(repo, allCategoriesList);
-
-        // 使用通用函数计算应该保存的自定义分类值
-        // 如果设置的分类与AI/默认一致，则清除自定义标记
-        const customCategoryValue = computeCustomCategory(categoryName, aiCat, defaultCat);
-
-        updateRepository(applyCategoryAssignment(repo, customCategoryValue, new Date().toISOString()));
-      } catch (error) {
-        console.error(`Failed to categorize ${repo.full_name}:`, error);
-        failedRepos.push(repo.full_name);
-      }
+    const selectedRepositories = filteredRepositories.filter((repository) => selectedRepoIds.has(repository.id));
+    if (await bulkActions.categorize(selectedRepositories, categoryName)) {
+      handleDeselectAll();
     }
+  };
 
-    await forceSyncToBackend();
-
-    // 汇总结果显示
-    const successCount = selectedRepos.length - failedRepos.length;
-    if (failedRepos.length > 0) {
-      toast(language === 'zh'
-        ? `成功为 ${successCount} 个仓库设置分类：${categoryName}\n\n失败 (${failedRepos.length} 个):\n${failedRepos.join('\n')}`
-        : `Successfully categorized ${successCount} repositories as: ${categoryName}\n\nFailed (${failedRepos.length}):\n${failedRepos.join('\n')}`,
-        'error'
-      );
-    } else {
-      toast(language === 'zh'
-        ? `成功为 ${successCount} 个仓库设置分类：${categoryName}`
-        : `Successfully categorized ${successCount} repositories as: ${categoryName}`,
-        'success'
-      );
+  const handleBulkRestore = async (config: RestoreConfig) => {
+    const selectedRepositories = repositories.filter((repository) => selectedRepoIds.has(repository.id));
+    if (await bulkActions.restore(selectedRepositories, config)) {
+      handleDeselectAll();
     }
-
-    handleDeselectAll();
   };
 
   if (filteredRepositories.length === 0) {
@@ -1138,7 +608,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
             key={repo.id}
             repository={repo}
             showAISummary={showAISummary}
-            searchQuery={useAppStore.getState().searchFilters.query}
+            searchQuery={searchFilters.query}
             isSelected={selectedRepoIds.has(repo.id)}
             onSelect={handleSelectRepo}
             selectionMode={showBulkToolbar}

--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
-import { shallow } from 'zustand/shallow';
+import { useShallow } from 'zustand/react/shallow';
 import { Bot, ChevronDown, LayoutGrid, List, Pause, Play } from 'lucide-react';
 import { RepositoryCard } from './RepositoryCard';
 import { SimilarViewBanner } from './SimilarViewBanner';
@@ -37,21 +37,19 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
     resetSimilarView,
     repositoryViewMode,
     setRepositoryViewMode,
-  } = useAppStore(
-    useCallback((state) => ({
-      language: state.language,
-      customCategories: state.customCategories,
-      hiddenDefaultCategoryIds: state.hiddenDefaultCategoryIds,
-      defaultCategoryOverrides: state.defaultCategoryOverrides,
-      categoryMatchMode: state.categoryMatchMode,
-      searchFilters: state.searchFilters,
-      similarView: state.similarView,
-      resetSimilarView: state.resetSimilarView,
-      repositoryViewMode: state.repositoryViewMode,
-      setRepositoryViewMode: state.setRepositoryViewMode,
-    }), []),
-    shallow,
-  );
+  } = useAppStore(useShallow((state) => ({
+    language: state.language,
+    customCategories: state.customCategories,
+    hiddenDefaultCategoryIds: state.hiddenDefaultCategoryIds,
+    defaultCategoryOverrides: state.defaultCategoryOverrides,
+    categoryMatchMode: state.categoryMatchMode,
+    searchFilters: state.searchFilters,
+    similarView: state.similarView,
+    resetSimilarView: state.resetSimilarView,
+    repositoryViewMode: state.repositoryViewMode,
+    setRepositoryViewMode: state.setRepositoryViewMode,
+  })));
+
 
   const { toast } = useDialog();
 

--- a/src/features/repositories/hooks/useBulkRepositoryActions.test.tsx
+++ b/src/features/repositories/hooks/useBulkRepositoryActions.test.tsx
@@ -1,0 +1,190 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Repository } from '../../../types';
+import { useBulkRepositoryActions } from './useBulkRepositoryActions';
+import { useAppStore } from '../../../store/useAppStore';
+
+const mocks = vi.hoisted(() => ({
+  useAppStore: vi.fn(),
+  toast: vi.fn(),
+  confirm: vi.fn(),
+  unstarRepository: vi.fn(),
+  forceSyncToBackend: vi.fn(),
+}));
+
+vi.mock('../../../store/useAppStore', () => ({
+  useAppStore: mocks.useAppStore,
+}));
+
+vi.mock('../../../hooks/useDialog', () => ({
+  useDialog: () => ({ toast: mocks.toast, confirm: mocks.confirm }),
+}));
+
+vi.mock('../../../services/githubApi', () => ({
+  GitHubApiService: vi.fn(function GitHubApiService() {
+    return { unstarRepository: mocks.unstarRepository };
+  }),
+}));
+
+vi.mock('../../../services/autoSync', () => ({
+  forceSyncToBackend: mocks.forceSyncToBackend,
+}));
+
+const repository = (id: number, overrides: Partial<Repository> = {}): Repository => ({
+  id,
+  name: `repository-${id}`,
+  full_name: `owner/repository-${id}`,
+  description: 'Repository description',
+  html_url: `https://github.com/owner/repository-${id}`,
+  stargazers_count: 10,
+  forks_count: 1,
+  forks: 1,
+  language: 'TypeScript',
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-02T00:00:00.000Z',
+  pushed_at: '2026-01-03T00:00:00.000Z',
+  owner: { login: 'owner', avatar_url: 'https://example.com/avatar.png' },
+  topics: [],
+  ...overrides,
+});
+
+const categories = [
+  { id: 'all', name: '全部分类', icon: 'folder', keywords: [] },
+  { id: 'tools', name: '工具', icon: 'wrench', keywords: ['tool'], isCustom: true },
+];
+
+const createStoreState = () => ({
+  githubToken: 'github-token',
+  language: 'zh' as const,
+  updateRepository: vi.fn(),
+  deleteRepository: vi.fn(),
+  toggleReleaseSubscription: vi.fn(),
+  batchUnsubscribeReleases: vi.fn(),
+  releaseSubscriptions: new Set<number>(),
+});
+
+let storeState = createStoreState();
+const mockUseAppStore = vi.mocked(useAppStore);
+const renderActions = () => renderHook(() => useBulkRepositoryActions({ allCategories: categories }));
+
+describe('useBulkRepositoryActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeState = createStoreState();
+    mockUseAppStore.mockImplementation(((selector?: (state: typeof storeState) => unknown) => (
+      selector ? selector(storeState) : storeState
+    )) as typeof useAppStore);
+    mocks.confirm.mockResolvedValue(true);
+    mocks.forceSyncToBackend.mockResolvedValue(undefined);
+    mocks.unstarRepository.mockResolvedValue(undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  it('has zero side effects when batch unstar confirmation is cancelled', async () => {
+    mocks.confirm.mockResolvedValue(false);
+    const { result } = renderActions();
+
+    await act(async () => {
+      await result.current.unstar([repository(1)]);
+    });
+
+    expect(mocks.unstarRepository).not.toHaveBeenCalled();
+    expect(storeState.deleteRepository).not.toHaveBeenCalled();
+    expect(mocks.forceSyncToBackend).not.toHaveBeenCalled();
+  });
+
+  it('deletes only remote-successful repositories, reports partial batch unstar failure, and syncs once', async () => {
+    const first = repository(1);
+    const second = repository(2);
+    mocks.unstarRepository.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('network unavailable'));
+    const { result } = renderActions();
+
+    await act(async () => {
+      await result.current.unstar([first, second]);
+    });
+
+    expect(storeState.deleteRepository).toHaveBeenCalledTimes(1);
+    expect(storeState.deleteRepository).toHaveBeenCalledWith(first.id);
+    expect(storeState.deleteRepository).not.toHaveBeenCalledWith(second.id);
+    expect(mocks.forceSyncToBackend).toHaveBeenCalledTimes(1);
+    expect(mocks.toast).toHaveBeenCalledWith(expect.stringContaining('失败 (1 个)'), 'error');
+  });
+
+  it('restores original fields through the pure patch and syncs exactly once', async () => {
+    const target = repository(1, {
+      custom_description: 'Custom description',
+      custom_tags: ['custom'],
+      custom_category: '工具',
+      category_locked: true,
+      ai_summary: 'AI summary',
+      ai_tags: ['ai'],
+      analyzed_at: '2026-02-01T00:00:00.000Z',
+    });
+    const { result } = renderActions();
+
+    await act(async () => {
+      await result.current.restore([target], {
+        description: { enabled: true, target: 'original' },
+        tags: { enabled: true, target: 'original' },
+        category: { enabled: true, target: 'original' },
+      });
+    });
+
+    expect(storeState.updateRepository).toHaveBeenCalledWith(expect.objectContaining({
+      id: target.id,
+      custom_description: undefined,
+      custom_tags: undefined,
+      custom_category: undefined,
+      category_locked: false,
+      ai_summary: undefined,
+    }));
+    expect(mocks.forceSyncToBackend).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses category and lock patches while synchronizing each completed batch once', async () => {
+    const categorized = repository(1, { ai_tags: ['tool'], custom_category: '手动' });
+    const notCategorized = repository(2);
+    const { result } = renderActions();
+
+    await act(async () => {
+      await result.current.categorize([categorized], '工具');
+    });
+    expect(storeState.updateRepository).toHaveBeenCalledWith(expect.objectContaining({ id: categorized.id, custom_category: undefined }));
+    expect(mocks.forceSyncToBackend).toHaveBeenCalledTimes(1);
+
+    vi.clearAllMocks();
+    mocks.forceSyncToBackend.mockResolvedValue(undefined);
+    await act(async () => {
+      await result.current.lockCategory([categorized, notCategorized]);
+    });
+    expect(storeState.updateRepository).toHaveBeenCalledWith(expect.objectContaining({ id: categorized.id, category_locked: true }));
+    expect(storeState.updateRepository).not.toHaveBeenCalledWith(expect.objectContaining({ id: notCategorized.id, category_locked: true }));
+    expect(mocks.forceSyncToBackend).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps release subscription markers and subscriptions consistent on subscribe and unsubscribe', async () => {
+    const alreadySubscribed = repository(1, { subscribed_to_releases: true });
+    const toSubscribe = repository(2);
+    storeState.releaseSubscriptions = new Set([alreadySubscribed.id]);
+    const { result } = renderActions();
+
+    await act(async () => {
+      await result.current.subscribe([alreadySubscribed, toSubscribe]);
+    });
+    expect(storeState.updateRepository).toHaveBeenCalledWith(expect.objectContaining({ id: alreadySubscribed.id, subscribed_to_releases: true }));
+    expect(storeState.updateRepository).toHaveBeenCalledWith(expect.objectContaining({ id: toSubscribe.id, subscribed_to_releases: true }));
+    expect(storeState.toggleReleaseSubscription).toHaveBeenCalledTimes(1);
+    expect(storeState.toggleReleaseSubscription).toHaveBeenCalledWith(toSubscribe.id);
+    expect(mocks.forceSyncToBackend).toHaveBeenCalledTimes(1);
+
+    vi.clearAllMocks();
+    mocks.forceSyncToBackend.mockResolvedValue(undefined);
+    await act(async () => {
+      await result.current.unsubscribe([alreadySubscribed, toSubscribe]);
+    });
+    expect(storeState.batchUnsubscribeReleases).toHaveBeenCalledWith([alreadySubscribed.id]);
+    expect(storeState.updateRepository).toHaveBeenCalledWith(expect.objectContaining({ id: alreadySubscribed.id, subscribed_to_releases: false }));
+    expect(storeState.updateRepository).not.toHaveBeenCalledWith(expect.objectContaining({ id: toSubscribe.id, subscribed_to_releases: false }));
+    expect(mocks.forceSyncToBackend).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/repositories/hooks/useBulkRepositoryActions.ts
+++ b/src/features/repositories/hooks/useBulkRepositoryActions.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { shallow } from 'zustand/shallow';
+import { useShallow } from 'zustand/react/shallow';
 import type { Category, Repository } from '../../../types';
 import { useAppStore } from '../../../store/useAppStore';
 import { useDialog } from '../../../hooks/useDialog';
@@ -57,18 +57,16 @@ export const useBulkRepositoryActions = ({
     toggleReleaseSubscription,
     batchUnsubscribeReleases,
     releaseSubscriptions,
-  } = useAppStore(
-    useCallback((state) => ({
-      githubToken: state.githubToken,
-      language: state.language,
-      updateRepository: state.updateRepository,
-      deleteRepository: state.deleteRepository,
-      toggleReleaseSubscription: state.toggleReleaseSubscription,
-      batchUnsubscribeReleases: state.batchUnsubscribeReleases,
-      releaseSubscriptions: state.releaseSubscriptions,
-    }), []),
-    shallow,
-  );
+  } = useAppStore(useShallow((state) => ({
+    githubToken: state.githubToken,
+    language: state.language,
+    updateRepository: state.updateRepository,
+    deleteRepository: state.deleteRepository,
+    toggleReleaseSubscription: state.toggleReleaseSubscription,
+    batchUnsubscribeReleases: state.batchUnsubscribeReleases,
+    releaseSubscriptions: state.releaseSubscriptions,
+  })));
+
   const { toast, confirm } = useDialog();
   const t = useCallback((zh: string, en: string) => language === 'zh' ? zh : en, [language]);
 

--- a/src/features/repositories/hooks/useBulkRepositoryActions.ts
+++ b/src/features/repositories/hooks/useBulkRepositoryActions.ts
@@ -1,0 +1,295 @@
+import { useCallback } from 'react';
+import { shallow } from 'zustand/shallow';
+import type { Category, Repository } from '../../../types';
+import { useAppStore } from '../../../store/useAppStore';
+import { useDialog } from '../../../hooks/useDialog';
+import { forceSyncToBackend } from '../../../services/autoSync';
+import { GitHubApiService } from '../../../services/githubApi';
+import { computeCustomCategory, getAICategory, getDefaultCategory } from '../../../utils/categoryUtils';
+import {
+  applyCategoryAssignment,
+  lockRepositoryCategory,
+  restoreRepositoryFields,
+  setReleaseSubscriptionMarker,
+  unlockRepositoryCategory,
+} from '../application/repositoryPatches';
+
+export interface RepositoryRestoreConfig {
+  description: { enabled: boolean; target: 'original' | 'ai' };
+  tags: { enabled: boolean; target: 'original' | 'ai' };
+  category: { enabled: boolean; target: 'original' | 'ai' };
+}
+
+interface UseBulkRepositoryActionsOptions {
+  allCategories: Category[];
+}
+
+export interface BulkRepositoryActions {
+  unstar: (repositories: Repository[]) => Promise<boolean>;
+  restore: (repositories: Repository[], config: RepositoryRestoreConfig) => Promise<boolean>;
+  categorize: (repositories: Repository[], categoryName: string) => Promise<boolean>;
+  subscribe: (repositories: Repository[]) => Promise<boolean>;
+  unsubscribe: (repositories: Repository[]) => Promise<boolean>;
+  lockCategory: (repositories: Repository[]) => Promise<boolean>;
+  unlockCategory: (repositories: Repository[]) => Promise<boolean>;
+}
+
+const formatFailures = (language: 'zh' | 'en', failedRepositories: string[]) => {
+  if (failedRepositories.length === 0) return '';
+  return language === 'zh'
+    ? `\n\n失败 (${failedRepositories.length} 个):\n${failedRepositories.join('\n')}`
+    : `\n\nFailed (${failedRepositories.length}):\n${failedRepositories.join('\n')}`;
+};
+
+/**
+ * Encapsulates RepositoryList's non-AI bulk workflows. Every completed logical
+ * batch owns exactly one backend synchronization call and uses the repository
+ * patch module for local state transitions.
+ */
+export const useBulkRepositoryActions = ({
+  allCategories,
+}: UseBulkRepositoryActionsOptions): BulkRepositoryActions => {
+  const {
+    githubToken,
+    language,
+    updateRepository,
+    deleteRepository,
+    toggleReleaseSubscription,
+    batchUnsubscribeReleases,
+    releaseSubscriptions,
+  } = useAppStore(
+    useCallback((state) => ({
+      githubToken: state.githubToken,
+      language: state.language,
+      updateRepository: state.updateRepository,
+      deleteRepository: state.deleteRepository,
+      toggleReleaseSubscription: state.toggleReleaseSubscription,
+      batchUnsubscribeReleases: state.batchUnsubscribeReleases,
+      releaseSubscriptions: state.releaseSubscriptions,
+    }), []),
+    shallow,
+  );
+  const { toast, confirm } = useDialog();
+  const t = useCallback((zh: string, en: string) => language === 'zh' ? zh : en, [language]);
+
+  const unstar = useCallback(async (repositories: Repository[]) => {
+    if (!githubToken) {
+      toast(language === 'zh' ? 'GitHub token 未找到，请重新登录。' : 'GitHub token not found. Please login again.', 'error');
+      return false;
+    }
+
+    const confirmed = await confirm(
+      t('取消Star确认', 'Unstar Confirmation'),
+      language === 'zh'
+        ? `确定要取消 ${repositories.length} 个仓库的 Star 吗？此操作不可撤销！`
+        : `Are you sure you want to unstar ${repositories.length} repositories? This action cannot be undone!`,
+      { type: 'danger', confirmText: t('取消Star', 'Unstar') },
+    );
+    if (!confirmed) return false;
+
+    const githubApi = new GitHubApiService(githubToken);
+    const successIds: number[] = [];
+    const failedRepositories: string[] = [];
+
+    for (const repository of repositories) {
+      try {
+        const [owner, name] = repository.full_name.split('/');
+        await githubApi.unstarRepository(owner, name);
+        successIds.push(repository.id);
+      } catch (error) {
+        console.error(`Failed to unstar ${repository.full_name}:`, error);
+        failedRepositories.push(repository.full_name);
+      }
+    }
+
+    for (const repositoryId of successIds) {
+      deleteRepository(repositoryId);
+    }
+
+    await forceSyncToBackend();
+    const failures = formatFailures(language, failedRepositories);
+    toast(
+      language === 'zh'
+        ? `成功取消 ${successIds.length} 个仓库的 Star${failures}`
+        : `Successfully unstarred ${successIds.length} repositories${failures}`,
+      failedRepositories.length > 0 ? 'error' : 'success',
+    );
+    return true;
+  }, [confirm, deleteRepository, githubToken, language, t, toast]);
+
+  const restore = useCallback(async (repositories: Repository[], config: RepositoryRestoreConfig) => {
+    if (repositories.length === 0) return false;
+
+    let successCount = 0;
+    const failedRepositories: string[] = [];
+    for (const repository of repositories) {
+      try {
+        const updatedRepository = restoreRepositoryFields(repository, config, new Date().toISOString());
+        if (updatedRepository) {
+          updateRepository(updatedRepository);
+        }
+        successCount += 1;
+      } catch (error) {
+        console.error(`Failed to restore ${repository.full_name}:`, error);
+        failedRepositories.push(repository.full_name);
+      }
+    }
+
+    await forceSyncToBackend();
+    const failures = formatFailures(language, failedRepositories);
+    toast(
+      language === 'zh'
+        ? `成功还原 ${successCount} 个仓库${failures}`
+        : `Successfully restored ${successCount} repositories${failures}`,
+      failedRepositories.length > 0 ? 'error' : 'success',
+    );
+    return true;
+  }, [language, toast, updateRepository]);
+
+  const categorize = useCallback(async (repositories: Repository[], categoryName: string) => {
+    const failedRepositories: string[] = [];
+    for (const repository of repositories) {
+      try {
+        const aiCategory = getAICategory(repository, allCategories);
+        const defaultCategory = getDefaultCategory(repository, allCategories);
+        const customCategory = computeCustomCategory(categoryName, aiCategory, defaultCategory);
+        updateRepository(applyCategoryAssignment(repository, customCategory, new Date().toISOString()));
+      } catch (error) {
+        console.error(`Failed to categorize ${repository.full_name}:`, error);
+        failedRepositories.push(repository.full_name);
+      }
+    }
+
+    await forceSyncToBackend();
+    const successCount = repositories.length - failedRepositories.length;
+    const failures = formatFailures(language, failedRepositories);
+    toast(
+      language === 'zh'
+        ? `成功为 ${successCount} 个仓库设置分类：${categoryName}${failures}`
+        : `Successfully categorized ${successCount} repositories as: ${categoryName}${failures}`,
+      failedRepositories.length > 0 ? 'error' : 'success',
+    );
+    return true;
+  }, [allCategories, language, toast, updateRepository]);
+
+  const subscribe = useCallback(async (repositories: Repository[]) => {
+    let successCount = 0;
+    for (const repository of repositories) {
+      try {
+        updateRepository(setReleaseSubscriptionMarker(repository, true));
+        if (!releaseSubscriptions.has(repository.id)) {
+          toggleReleaseSubscription(repository.id);
+        }
+        successCount += 1;
+      } catch (error) {
+        console.error(`Failed to subscribe ${repository.full_name}:`, error);
+      }
+    }
+
+    await forceSyncToBackend();
+    toast(
+      language === 'zh'
+        ? `成功订阅 ${successCount} 个仓库的版本发布`
+        : `Successfully subscribed to ${successCount} repositories releases`,
+      'success',
+    );
+    return true;
+  }, [language, releaseSubscriptions, toast, toggleReleaseSubscription, updateRepository]);
+
+  const unsubscribe = useCallback(async (repositories: Repository[]) => {
+    const subscribedRepositories = repositories.filter((repository) => releaseSubscriptions.has(repository.id));
+    if (subscribedRepositories.length === 0) {
+      toast(t('选中的仓库中没有被订阅的', 'None of the selected repositories are subscribed'), 'info');
+      return false;
+    }
+
+    batchUnsubscribeReleases(subscribedRepositories.map((repository) => repository.id));
+    const failedRepositories: string[] = [];
+    for (const repository of subscribedRepositories) {
+      try {
+        updateRepository(setReleaseSubscriptionMarker(repository, false));
+      } catch (error) {
+        console.error(`Failed to update repository ${repository.full_name}:`, error);
+        failedRepositories.push(repository.full_name);
+      }
+    }
+
+    await forceSyncToBackend();
+    const successCount = subscribedRepositories.length - failedRepositories.length;
+    const failures = formatFailures(language, failedRepositories);
+    toast(
+      language === 'zh'
+        ? `成功取消 ${successCount} 个仓库的版本发布订阅${failures}`
+        : `Successfully unsubscribed ${successCount} repositories from releases${failures}`,
+      failedRepositories.length > 0 ? 'error' : 'success',
+    );
+    return true;
+  }, [batchUnsubscribeReleases, language, releaseSubscriptions, t, toast, updateRepository]);
+
+  const lockCategory = useCallback(async (repositories: Repository[]) => {
+    let successCount = 0;
+    let skippedCount = 0;
+    const failedRepositories: string[] = [];
+    for (const repository of repositories) {
+      try {
+        const updatedRepository = lockRepositoryCategory(repository, new Date().toISOString());
+        if (updatedRepository) {
+          updateRepository(updatedRepository);
+          successCount += 1;
+        } else {
+          skippedCount += 1;
+        }
+      } catch (error) {
+        console.error(`Failed to lock category for ${repository.full_name}:`, error);
+        failedRepositories.push(repository.full_name);
+      }
+    }
+
+    await forceSyncToBackend();
+    const skipped = skippedCount > 0
+      ? (language === 'zh' ? `\n\n跳过 ${skippedCount} 个没有自定义分类的仓库` : `\n\nSkipped ${skippedCount} repositories without custom category`)
+      : '';
+    const failures = formatFailures(language, failedRepositories);
+    toast(
+      language === 'zh'
+        ? `成功锁定 ${successCount} 个仓库的分类${failures}${skipped}`
+        : `Successfully locked categories for ${successCount} repositories${failures}${skipped}`,
+      failedRepositories.length > 0 ? 'error' : 'success',
+    );
+    return true;
+  }, [language, toast, updateRepository]);
+
+  const unlockCategory = useCallback(async (repositories: Repository[]) => {
+    let successCount = 0;
+    const failedRepositories: string[] = [];
+    for (const repository of repositories) {
+      try {
+        updateRepository(unlockRepositoryCategory(repository, new Date().toISOString()));
+        successCount += 1;
+      } catch (error) {
+        console.error(`Failed to unlock category for ${repository.full_name}:`, error);
+        failedRepositories.push(repository.full_name);
+      }
+    }
+
+    await forceSyncToBackend();
+    const failures = formatFailures(language, failedRepositories);
+    toast(
+      language === 'zh'
+        ? `成功解锁 ${successCount} 个仓库的分类${failures}`
+        : `Successfully unlocked categories for ${successCount} repositories${failures}`,
+      failedRepositories.length > 0 ? 'error' : 'success',
+    );
+    return true;
+  }, [language, toast, updateRepository]);
+
+  return {
+    unstar,
+    restore,
+    categorize,
+    subscribe,
+    unsubscribe,
+    lockCategory,
+    unlockCategory,
+  };
+};

--- a/src/features/repositories/hooks/useRepositoryAnalysisJob.test.tsx
+++ b/src/features/repositories/hooks/useRepositoryAnalysisJob.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode, type ReactNode } from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Repository } from '../../../types';
@@ -247,6 +248,28 @@ describe('useRepositoryAnalysisJob', () => {
 
     expect(mocks.toast).toHaveBeenCalledWith('AI分析失败，请检查AI配置和网络连接。', 'error');
     expect(result.current).toMatchObject({ isRunning: false, isPaused: false, progress: { current: 0, total: 0 } });
+  });
+
+  it('re-enables result writes after StrictMode rehearses the lifecycle cleanup', async () => {
+    const target = repository(1);
+    mocks.analyzeRepositoriesPipelined.mockImplementation(async (...args: unknown[]) => {
+      const onResult = args[6] as (result: Record<string, unknown>) => void;
+      onResult({ success: true, repo: target, summary: 'StrictMode result', tags: [], platforms: [] });
+    });
+
+    const { result } = renderHook(
+      () => useRepositoryAnalysisJob({ allCategories: [] }),
+      { wrapper: ({ children }: { children: ReactNode }) => <StrictMode>{children}</StrictMode> },
+    );
+
+    await act(async () => {
+      await result.current.run(runOptions([target]));
+    });
+
+    expect(storeState.updateRepository).toHaveBeenCalledWith(expect.objectContaining({
+      id: target.id,
+      ai_summary: 'StrictMode result',
+    }));
   });
 
   it('aborts an active job on unmount and prevents further result writes', async () => {

--- a/src/features/repositories/hooks/useRepositoryAnalysisJob.test.tsx
+++ b/src/features/repositories/hooks/useRepositoryAnalysisJob.test.tsx
@@ -1,0 +1,271 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Repository } from '../../../types';
+import { useRepositoryAnalysisJob } from './useRepositoryAnalysisJob';
+import { useAppStore } from '../../../store/useAppStore';
+
+const mocks = vi.hoisted(() => ({
+  useAppStore: vi.fn(),
+  toast: vi.fn(),
+  confirm: vi.fn(),
+  analyzeRepositoriesPipelined: vi.fn(),
+  pause: vi.fn(),
+  resume: vi.fn(),
+  abort: vi.fn(),
+  getStats: vi.fn(() => ({ averageResponseTime: 12 })),
+  forceSyncToBackend: vi.fn(),
+}));
+
+vi.mock('../../../store/useAppStore', () => ({
+  useAppStore: mocks.useAppStore,
+}));
+
+vi.mock('../../../hooks/useDialog', () => ({
+  useDialog: () => ({ toast: mocks.toast, confirm: mocks.confirm }),
+}));
+
+vi.mock('../../../services/aiAnalysisOptimizer', () => ({
+  AIAnalysisOptimizer: vi.fn(function AIAnalysisOptimizer() {
+    return {
+      analyzeRepositoriesPipelined: mocks.analyzeRepositoriesPipelined,
+      pause: mocks.pause,
+      resume: mocks.resume,
+      abort: mocks.abort,
+      isPaused: vi.fn(() => false),
+      getStats: mocks.getStats,
+    };
+  }),
+}));
+
+vi.mock('../../../services/aiService', () => ({
+  AIService: vi.fn(),
+}));
+
+vi.mock('../../../services/githubApi', () => ({
+  GitHubApiService: vi.fn(),
+}));
+
+vi.mock('../../../services/autoSync', () => ({
+  forceSyncToBackend: mocks.forceSyncToBackend,
+}));
+
+const repository = (id: number, overrides: Partial<Repository> = {}): Repository => ({
+  id,
+  name: `repository-${id}`,
+  full_name: `owner/repository-${id}`,
+  description: 'Repository description',
+  html_url: `https://github.com/owner/repository-${id}`,
+  stargazers_count: 10,
+  forks_count: 1,
+  forks: 1,
+  language: 'TypeScript',
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-02T00:00:00.000Z',
+  pushed_at: '2026-01-03T00:00:00.000Z',
+  owner: { login: 'owner', avatar_url: 'https://example.com/avatar.png' },
+  topics: [],
+  ...overrides,
+});
+
+const createStoreState = () => ({
+  githubToken: 'github-token',
+  aiConfigs: [{
+    id: 'ai-config',
+    baseUrl: 'https://ai.example.com/v1',
+    apiKey: 'ai-key',
+    model: 'test-model',
+    concurrency: 1,
+  }],
+  activeAIConfig: 'ai-config',
+  language: 'zh' as const,
+  updateRepository: vi.fn(),
+  setLoading: vi.fn(),
+  setAnalysisProgress: vi.fn(),
+});
+
+let storeState = createStoreState();
+const mockUseAppStore = vi.mocked(useAppStore);
+const runOptions = (repositories: Repository[], syncOnComplete = false) => ({
+  repositories,
+  scope: 'all' as const,
+  syncOnComplete,
+});
+
+const renderJob = () => renderHook(() => useRepositoryAnalysisJob({ allCategories: [] }));
+
+describe('useRepositoryAnalysisJob', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeState = createStoreState();
+    mockUseAppStore.mockImplementation(((selector?: (state: typeof storeState) => unknown) => (
+      selector ? selector(storeState) : storeState
+    )) as typeof useAppStore);
+    mocks.confirm.mockResolvedValue(true);
+    mocks.forceSyncToBackend.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('stores successful analysis results without syncing toolbar jobs', async () => {
+    const target = repository(1, { custom_description: 'Keep me' });
+    mocks.analyzeRepositoriesPipelined.mockImplementation(async (...args: unknown[]) => {
+      const onProgress = args[5] as (current: number, total: number, concurrency: number) => void;
+      const onResult = args[6] as (result: Record<string, unknown>) => void;
+      onProgress(1, 1, 1);
+      onResult({ success: true, repo: target, summary: 'AI summary', tags: ['ai'], platforms: ['web'] });
+    });
+    const { result } = renderJob();
+
+    await act(async () => {
+      await result.current.run(runOptions([target]));
+    });
+
+    expect(storeState.updateRepository).toHaveBeenCalledWith(expect.objectContaining({
+      id: target.id,
+      ai_summary: 'AI summary',
+      ai_tags: ['ai'],
+      custom_description: 'Keep me',
+      analysis_failed: false,
+    }));
+    expect(mocks.forceSyncToBackend).not.toHaveBeenCalled();
+    expect(result.current).toMatchObject({ isRunning: false, isPaused: false, progress: { current: 0, total: 0 } });
+  });
+
+  it('stores both successful and failed results from a partially failing job and syncs once when requested', async () => {
+    const successful = repository(1);
+    const failed = repository(2, { custom_tags: ['user-tag'] });
+    mocks.analyzeRepositoriesPipelined.mockImplementation(async (...args: unknown[]) => {
+      const onResult = args[6] as (result: Record<string, unknown>) => void;
+      onResult({ success: true, repo: successful, summary: 'done', tags: [], platforms: [] });
+      onResult({ success: false, repo: failed, error: new Error('model unavailable') });
+    });
+    const { result } = renderJob();
+
+    await act(async () => {
+      await result.current.run(runOptions([successful, failed], true));
+    });
+
+    expect(storeState.updateRepository).toHaveBeenCalledTimes(2);
+    expect(storeState.updateRepository).toHaveBeenCalledWith(expect.objectContaining({ id: failed.id, analysis_failed: true, analysis_error: 'model unavailable', custom_tags: ['user-tag'] }));
+    expect(mocks.forceSyncToBackend).toHaveBeenCalledTimes(1);
+  });
+
+  it('pauses and resumes the active optimizer without starting a second job', async () => {
+    const target = repository(1);
+    let finishPipeline: (() => void) | undefined;
+    mocks.analyzeRepositoriesPipelined.mockImplementation(() => new Promise<void>((resolve) => {
+      finishPipeline = resolve;
+    }));
+    const { result } = renderJob();
+    let runningJob!: Promise<boolean>;
+
+    act(() => {
+      runningJob = result.current.run(runOptions([target]));
+    });
+    await waitFor(() => expect(result.current.isRunning).toBe(true));
+
+    act(() => result.current.pause());
+    expect(mocks.pause).toHaveBeenCalledTimes(1);
+    expect(result.current.isPaused).toBe(true);
+
+    act(() => result.current.resume());
+    expect(mocks.resume).toHaveBeenCalledTimes(1);
+    expect(result.current.isPaused).toBe(false);
+
+    await act(async () => {
+      finishPipeline?.();
+      await runningJob;
+    });
+    expect(mocks.analyzeRepositoriesPipelined).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves results written before a confirmed stop intact and resets task state', async () => {
+    const target = repository(1, { custom_description: 'User value' });
+    let finishPipeline: (() => void) | undefined;
+    mocks.analyzeRepositoriesPipelined.mockImplementation((...args: unknown[]) => {
+      const onResult = args[6] as (result: Record<string, unknown>) => void;
+      onResult({ success: true, repo: target, summary: 'Completed before stop', tags: [], platforms: [] });
+      return new Promise<void>((resolve) => {
+        finishPipeline = resolve;
+      });
+    });
+    mocks.abort.mockImplementation(() => finishPipeline?.());
+    const { result } = renderJob();
+    let runningJob!: Promise<boolean>;
+
+    act(() => {
+      runningJob = result.current.run(runOptions([target]));
+    });
+    await waitFor(() => expect(storeState.updateRepository).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      await result.current.requestStop();
+      await runningJob;
+    });
+
+    expect(mocks.abort).toHaveBeenCalledTimes(1);
+    expect(storeState.updateRepository).toHaveBeenCalledWith(expect.objectContaining({ id: target.id, ai_summary: 'Completed before stop', custom_description: 'User value' }));
+    expect(result.current).toMatchObject({ isRunning: false, isPaused: false });
+  });
+
+  it('does not abort or change task state when stop confirmation is cancelled', async () => {
+    const target = repository(1);
+    let finishPipeline: (() => void) | undefined;
+    mocks.analyzeRepositoriesPipelined.mockImplementation(() => new Promise<void>((resolve) => {
+      finishPipeline = resolve;
+    }));
+    const { result } = renderJob();
+    let runningJob!: Promise<boolean>;
+
+    act(() => {
+      runningJob = result.current.run(runOptions([target]));
+    });
+    await waitFor(() => expect(result.current.isRunning).toBe(true));
+    mocks.confirm.mockResolvedValueOnce(false);
+
+    await act(async () => {
+      await result.current.requestStop();
+    });
+    expect(mocks.abort).not.toHaveBeenCalled();
+    expect(result.current.isRunning).toBe(true);
+
+    await act(async () => {
+      finishPipeline?.();
+      await runningJob;
+    });
+  });
+
+  it('reports optimizer exceptions and resets state', async () => {
+    mocks.analyzeRepositoriesPipelined.mockRejectedValue(new Error('network unavailable'));
+    const { result } = renderJob();
+
+    await act(async () => {
+      await result.current.run(runOptions([repository(1)]));
+    });
+
+    expect(mocks.toast).toHaveBeenCalledWith('AI分析失败，请检查AI配置和网络连接。', 'error');
+    expect(result.current).toMatchObject({ isRunning: false, isPaused: false, progress: { current: 0, total: 0 } });
+  });
+
+  it('aborts an active job on unmount and prevents further result writes', async () => {
+    const target = repository(1);
+    let onResult: ((result: Record<string, unknown>) => void) | undefined;
+    mocks.analyzeRepositoriesPipelined.mockImplementation((...args: unknown[]) => {
+      onResult = args[6] as (result: Record<string, unknown>) => void;
+      return new Promise<void>(() => undefined);
+    });
+    const { result, unmount } = renderJob();
+
+    act(() => {
+      void result.current.run(runOptions([target]));
+    });
+    await waitFor(() => expect(mocks.analyzeRepositoriesPipelined).toHaveBeenCalledTimes(1));
+    unmount();
+    onResult?.({ success: true, repo: target, summary: 'late result', tags: [], platforms: [] });
+
+    expect(mocks.abort).toHaveBeenCalledTimes(1);
+    expect(storeState.updateRepository).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/repositories/hooks/useRepositoryAnalysisJob.ts
+++ b/src/features/repositories/hooks/useRepositoryAnalysisJob.ts
@@ -1,0 +1,327 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { shallow } from 'zustand/shallow';
+import type { Category, Repository } from '../../../types';
+import { useAppStore } from '../../../store/useAppStore';
+import { useDialog } from '../../../hooks/useDialog';
+import { AIAnalysisOptimizer, type AnalysisResult } from '../../../services/aiAnalysisOptimizer';
+import { AIService } from '../../../services/aiService';
+import { GitHubApiService } from '../../../services/githubApi';
+import { forceSyncToBackend } from '../../../services/autoSync';
+import { buildCategoryHints, resolveCategoryAssignment } from '../../../utils/categoryUtils';
+import { applyAnalysisFailure, applyAnalysisSuccess } from '../application/repositoryPatches';
+
+export type RepositoryAnalysisScope = 'all' | 'unanalyzed' | 'failed' | 'selected';
+
+interface UseRepositoryAnalysisJobOptions {
+  allCategories: Category[];
+}
+
+interface RunRepositoryAnalysisOptions {
+  repositories: Repository[];
+  scope: RepositoryAnalysisScope;
+  syncOnComplete: boolean;
+}
+
+export interface RepositoryAnalysisJob {
+  run: (options: RunRepositoryAnalysisOptions) => Promise<boolean>;
+  pause: () => void;
+  resume: () => void;
+  requestStop: () => Promise<boolean>;
+  isRunning: boolean;
+  isPaused: boolean;
+  progress: { current: number; total: number };
+}
+
+const createOptimizer = (concurrency?: number, requestsPerMinute?: number) => new AIAnalysisOptimizer({
+  initialConcurrency: concurrency || 3,
+  maxConcurrency: 10,
+  minConcurrency: 1,
+  targetResponseTime: 5000,
+  batchDelayMs: 100,
+  maxRetries: 3,
+  retryDelayBaseMs: 1000,
+  enableAdaptiveConcurrency: true,
+  rateLimiter: {
+    maxConcurrency: 0,
+    requestsPerMinute: requestsPerMinute || 0,
+  },
+});
+
+/**
+ * Owns the lifecycle of one RepositoryList batch-analysis job. The hook keeps
+ * the optimizer instance in a ref so pause, resume, stop, and unmount cleanup
+ * always affect the active job without putting a mutable job in the store.
+ */
+export const useRepositoryAnalysisJob = ({
+  allCategories,
+}: UseRepositoryAnalysisJobOptions): RepositoryAnalysisJob => {
+  const {
+    githubToken,
+    aiConfigs,
+    activeAIConfig,
+    language,
+    updateRepository,
+    setLoading,
+    setAnalysisProgress,
+  } = useAppStore(
+    useCallback((state) => ({
+      githubToken: state.githubToken,
+      aiConfigs: state.aiConfigs,
+      activeAIConfig: state.activeAIConfig,
+      language: state.language,
+      updateRepository: state.updateRepository,
+      setLoading: state.setLoading,
+      setAnalysisProgress: state.setAnalysisProgress,
+    }), []),
+    shallow,
+  );
+  const { toast, confirm } = useDialog();
+  const optimizerRef = useRef<AIAnalysisOptimizer | null>(null);
+  const isRunningRef = useRef(false);
+  const isPausedRef = useRef(false);
+  const stopRequestedRef = useRef(false);
+  const mountedRef = useRef(true);
+  const [isRunning, setIsRunning] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
+  const [progress, setProgress] = useState({ current: 0, total: 0 });
+
+  const t = useCallback((zh: string, en: string) => language === 'zh' ? zh : en, [language]);
+
+  const resetVisibleState = useCallback(() => {
+    setLoading(false);
+    setAnalysisProgress({ current: 0, total: 0 });
+    if (mountedRef.current) {
+      setIsRunning(false);
+      isPausedRef.current = false;
+      setIsPaused(false);
+      setProgress({ current: 0, total: 0 });
+    }
+  }, [setAnalysisProgress, setLoading]);
+
+  useEffect(() => () => {
+    mountedRef.current = false;
+    optimizerRef.current?.abort();
+    optimizerRef.current = null;
+    isRunningRef.current = false;
+    isPausedRef.current = false;
+    stopRequestedRef.current = false;
+    setLoading(false);
+    setAnalysisProgress({ current: 0, total: 0 });
+  }, [setAnalysisProgress, setLoading]);
+
+  const pause = useCallback(() => {
+    const optimizer = optimizerRef.current;
+    if (!isRunningRef.current || !optimizer || isPausedRef.current) return;
+    optimizer.pause();
+    isPausedRef.current = true;
+    setIsPaused(true);
+    console.log('Analysis paused');
+  }, []);
+
+  const resume = useCallback(() => {
+    const optimizer = optimizerRef.current;
+    if (!isRunningRef.current || !optimizer || !isPausedRef.current) return;
+    optimizer.resume();
+    isPausedRef.current = false;
+    setIsPaused(false);
+    console.log('Analysis resumed');
+  }, []);
+
+  const requestStop = useCallback(async () => {
+    if (!isRunningRef.current) return false;
+
+    const confirmed = await confirm(
+      t('停止AI分析', 'Stop AI Analysis'),
+      t('确定要停止 AI 分析吗？已分析的结果将会保存。', 'Are you sure you want to stop AI analysis? Analyzed results will be saved.'),
+      { type: 'warning' },
+    );
+    if (!confirmed || !isRunningRef.current) return false;
+
+    stopRequestedRef.current = true;
+    optimizerRef.current?.abort();
+    isPausedRef.current = false;
+    if (mountedRef.current) {
+      setIsPaused(false);
+    }
+    console.log('Stop requested by user');
+    return true;
+  }, [confirm, t]);
+
+  const run = useCallback(async ({
+    repositories,
+    scope,
+    syncOnComplete,
+  }: RunRepositoryAnalysisOptions) => {
+    if (isRunningRef.current) return false;
+
+    if (!githubToken) {
+      toast(language === 'zh' ? 'GitHub token 未找到，请重新登录。' : 'GitHub token not found. Please login again.', 'error');
+      return false;
+    }
+
+    const activeConfig = aiConfigs.find((config) => config.id === activeAIConfig);
+    if (!activeConfig) {
+      toast(language === 'zh' ? '请先在设置中配置AI服务。' : 'Please configure AI service in settings first.', 'error');
+      return false;
+    }
+
+    if (scope !== 'selected' && (activeConfig.apiKeyStatus === 'decrypt_failed' || activeConfig.apiKeyStatus === 'empty')) {
+      toast(language === 'zh' ? 'AI服务的API密钥无法解密或为空，请在设置中重新输入并保存该配置。' : 'The AI service API key could not be decrypted or is empty. Please re-enter and save the configuration in settings.', 'error');
+      return false;
+    }
+
+    if (scope !== 'selected' && (!activeConfig.baseUrl || !activeConfig.apiKey || !activeConfig.model)) {
+      toast(language === 'zh' ? 'AI服务配置不完整，请检查API端点、密钥和模型名称。' : 'AI service configuration is incomplete. Please check the API endpoint, key, and model name.', 'error');
+      return false;
+    }
+
+    if (repositories.length === 0) {
+      const message = scope === 'failed'
+        ? t('没有分析失败的仓库！', 'No failed repositories to re-analyze!')
+        : scope === 'unanalyzed'
+          ? t('所有仓库都已经分析过了！', 'All repositories have been analyzed!')
+          : t('没有可分析的仓库！', 'No repositories to analyze!');
+      toast(message, 'info');
+      return false;
+    }
+
+    const actionText = scope === 'failed'
+      ? (language === 'zh' ? '失败' : 'failed')
+      : scope === 'unanalyzed'
+        ? (language === 'zh' ? '未分析' : 'unanalyzed')
+        : (language === 'zh' ? '全部' : 'all');
+    const confirmationMessage = scope === 'selected'
+      ? (language === 'zh'
+        ? `将对 ${repositories.length} 个仓库进行 AI 分析，这可能需要几分钟时间。是否继续？`
+        : `Will analyze ${repositories.length} repositories with AI. This may take several minutes. Continue?`)
+      : (language === 'zh'
+        ? `将对 ${repositories.length} 个${actionText}仓库进行AI分析，这可能需要几分钟时间。是否继续？`
+        : `Will analyze ${repositories.length} ${actionText} repositories with AI. This may take several minutes. Continue?`);
+
+    const confirmed = await confirm(
+      t('AI分析确认', 'AI Analysis Confirmation'),
+      confirmationMessage,
+      { type: 'warning' },
+    );
+    if (!confirmed) return false;
+
+    const optimizer = createOptimizer(activeConfig.concurrency, activeConfig.requestsPerMinute);
+    optimizerRef.current = optimizer;
+    stopRequestedRef.current = false;
+    isPausedRef.current = false;
+    isRunningRef.current = true;
+    setLoading(true);
+    setAnalysisProgress({ current: 0, total: repositories.length });
+    if (mountedRef.current) {
+      setIsRunning(true);
+      setIsPaused(false);
+      setProgress({ current: 0, total: repositories.length });
+    }
+
+    let successCount = 0;
+    let failedCount = 0;
+
+    try {
+      const githubApi = new GitHubApiService(githubToken);
+      const aiService = new AIService(activeConfig, language);
+      const categoryNames = allCategories.filter((category) => category.id !== 'all').map((category) => category.name);
+      const aiCategoryHints = buildCategoryHints(allCategories);
+      const onResult = (result: AnalysisResult) => {
+        if (!mountedRef.current || optimizerRef.current !== optimizer) return;
+
+        if (result.success) {
+          const resolvedCategory = resolveCategoryAssignment(
+            { ...result.repo, ai_summary: result.summary },
+            result.tags || [],
+            allCategories,
+          );
+          const wasCategoryLocked = !!result.repo.category_locked;
+          updateRepository(applyAnalysisSuccess(result.repo, {
+            summary: result.summary,
+            tags: result.tags,
+            platforms: result.platforms,
+            category: resolvedCategory,
+            categoryLocked: wasCategoryLocked,
+            analyzedAt: new Date().toISOString(),
+          }));
+          successCount += 1;
+          return;
+        }
+
+        updateRepository(applyAnalysisFailure(result.repo, {
+          analyzedAt: new Date().toISOString(),
+          error: result.error?.message || undefined,
+        }));
+        failedCount += 1;
+      };
+
+      await optimizer.analyzeRepositoriesPipelined(
+        repositories,
+        githubApi,
+        aiService,
+        categoryNames,
+        aiCategoryHints,
+        (current, total, currentConcurrency) => {
+          if (!mountedRef.current || optimizerRef.current !== optimizer) return;
+          setAnalysisProgress({ current, total });
+          setProgress({ current, total });
+          console.log(`AI Analysis Progress: ${current}/${total}, Concurrency: ${currentConcurrency}`);
+        },
+        onResult,
+      );
+
+      const stats = optimizer.getStats();
+      console.log('AI Analysis Stats:', stats);
+      if (syncOnComplete) {
+        await forceSyncToBackend();
+      }
+
+      if (scope === 'selected') {
+        toast(
+          language === 'zh'
+            ? `成功分析 ${successCount} 个仓库，失败 ${failedCount} 个 (平均响应: ${stats.averageResponseTime}ms)`
+            : `Successfully analyzed ${successCount} repositories, ${failedCount} failed (avg: ${stats.averageResponseTime}ms)`,
+          failedCount > 0 ? 'error' : 'success',
+        );
+      } else {
+        toast(
+          stopRequestedRef.current
+            ? (language === 'zh'
+              ? `AI分析已停止！成功: ${successCount}, 失败: ${failedCount}`
+              : `AI analysis stopped! Success: ${successCount}, Failed: ${failedCount}`)
+            : (language === 'zh'
+              ? `AI分析完成！成功: ${successCount}, 失败: ${failedCount} (平均响应: ${stats.averageResponseTime}ms)`
+              : `AI analysis completed! Success: ${successCount}, Failed: ${failedCount} (avg: ${stats.averageResponseTime}ms)`),
+          'success',
+        );
+      }
+      return true;
+    } catch (error) {
+      console.error(scope === 'selected' ? 'Bulk AI analysis failed:' : 'AI analysis failed:', error);
+      toast(
+        scope === 'selected'
+          ? (language === 'zh' ? '批量AI分析失败' : 'Bulk AI analysis failed')
+          : (language === 'zh' ? 'AI分析失败，请检查AI配置和网络连接。' : 'AI analysis failed. Please check AI configuration and network connection.'),
+        'error',
+      );
+      return false;
+    } finally {
+      if (optimizerRef.current === optimizer) {
+        optimizerRef.current = null;
+        isRunningRef.current = false;
+        stopRequestedRef.current = false;
+        resetVisibleState();
+      }
+    }
+  }, [aiConfigs, activeAIConfig, allCategories, confirm, githubToken, language, resetVisibleState, setAnalysisProgress, setLoading, t, toast, updateRepository]);
+
+  return useMemo(() => ({
+    run,
+    pause,
+    resume,
+    requestStop,
+    isRunning,
+    isPaused,
+    progress,
+  }), [isPaused, isRunning, pause, progress, requestStop, resume, run]);
+};

--- a/src/features/repositories/hooks/useRepositoryAnalysisJob.ts
+++ b/src/features/repositories/hooks/useRepositoryAnalysisJob.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { shallow } from 'zustand/shallow';
+import { useShallow } from 'zustand/react/shallow';
 import type { Category, Repository } from '../../../types';
 import { useAppStore } from '../../../store/useAppStore';
 import { useDialog } from '../../../hooks/useDialog';
@@ -63,18 +63,16 @@ export const useRepositoryAnalysisJob = ({
     updateRepository,
     setLoading,
     setAnalysisProgress,
-  } = useAppStore(
-    useCallback((state) => ({
-      githubToken: state.githubToken,
-      aiConfigs: state.aiConfigs,
-      activeAIConfig: state.activeAIConfig,
-      language: state.language,
-      updateRepository: state.updateRepository,
-      setLoading: state.setLoading,
-      setAnalysisProgress: state.setAnalysisProgress,
-    }), []),
-    shallow,
-  );
+  } = useAppStore(useShallow((state) => ({
+    githubToken: state.githubToken,
+    aiConfigs: state.aiConfigs,
+    activeAIConfig: state.activeAIConfig,
+    language: state.language,
+    updateRepository: state.updateRepository,
+    setLoading: state.setLoading,
+    setAnalysisProgress: state.setAnalysisProgress,
+  })));
+
   const { toast, confirm } = useDialog();
   const optimizerRef = useRef<AIAnalysisOptimizer | null>(null);
   const isRunningRef = useRef(false);
@@ -98,15 +96,18 @@ export const useRepositoryAnalysisJob = ({
     }
   }, [setAnalysisProgress, setLoading]);
 
-  useEffect(() => () => {
-    mountedRef.current = false;
-    optimizerRef.current?.abort();
-    optimizerRef.current = null;
-    isRunningRef.current = false;
-    isPausedRef.current = false;
-    stopRequestedRef.current = false;
-    setLoading(false);
-    setAnalysisProgress({ current: 0, total: 0 });
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      optimizerRef.current?.abort();
+      optimizerRef.current = null;
+      isRunningRef.current = false;
+      isPausedRef.current = false;
+      stopRequestedRef.current = false;
+      setLoading(false);
+      setAnalysisProgress({ current: 0, total: 0 });
+    };
   }, [setAnalysisProgress, setLoading]);
 
   const pause = useCallback(() => {


### PR DESCRIPTION
## Summary

Moves `RepositoryList` batch AI orchestration and non-AI batch workflows into focused repository domain hooks while preserving UI layout, persistence, selection interactions, and the existing data contracts.

- Adds `useRepositoryAnalysisJob` for the ref-owned `AIAnalysisOptimizer` lifecycle: validation, confirmation, progress, pause/resume, confirmed stop, cleanup, and unmount abort.
- Adds `useBulkRepositoryActions` for batch unstar, restore, categorize, subscribe/unsubscribe, and category lock/unlock. The hook reuses the PR-03 pure repository patches.
- Converts `RepositoryList` to explicit Zustand selectors with `shallow`; it no longer imports `githubApi`, `aiService`, `aiAnalysisOptimizer`, or `autoSync`, and has no bare `useAppStore()` subscription.

## Workflow ordering and failure semantics

| Action | Service/state ordering | Failure behavior | Sync count |
| --- | --- | --- | ---: |
| Toolbar AI analysis | confirm -> optimizer -> per-result pure patch -> cleanup | completed success/failure patches remain after confirmed stop; cancel has no side effects | 0 |
| Selected batch AI | confirm -> optimizer -> per-result pure patch -> one backend sync -> cleanup | per-repository analysis failures are retained; operation reports error on pipeline/sync exception | 1 |
| Batch unstar | confirm -> remote unstar per repo -> delete only remote-successful ids -> one backend sync | failed remote items remain locally and are summarized | 1 |
| Restore / categorize / lock / unlock | apply PR-03 pure patch per repo -> one backend sync | local per-item failures are summarized | 1 |
| Subscribe / unsubscribe | reconcile marker with release subscription state -> one backend sync | retains existing subscription targeting and per-item error reporting | 1 |

## Validation

- `npm run lint` passed.
- `npm run typecheck` passed.
- `npm run test:run` passed: 43 files / 447 tests.
- `git diff --check` passed.
- Added lifecycle tests for success, partial failures, pause/resume, stop/cancel, exceptions, unmount, and sync-count contracts.
- Added bulk-action tests for cancel, partial remote unstar failure, restore/category/lock semantics, release subscription consistency, and exactly-once synchronization.

## Build note

`npm run build` was attempted on both the unmodified baseline and this branch. The sandbox terminated Vite during `rendering chunks` with exit 143 under high memory pressure, before `check:bundle-size` ran. Please rely on the established GitHub CI build/bundle gate for this environment-specific limitation.

## Scope guardrails

No persistence key/schema/version, backend secret flow, backend/proxy/RPC asymmetry, infinite scrolling, scroll-restoration behavior, selection animation, or JSX appearance was intentionally changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI repository analysis with progress tracking and controls to pause, resume, or stop processing.
  * Added support for analyzing all, unanalyzed, failed, or selected repositories.
  * Expanded bulk actions to restore, categorize, lock or unlock categories, subscribe or unsubscribe to releases, and unstar repositories.
  * Added confirmations, validation, synchronization, and notifications for batch operations.
* **Bug Fixes**
  * Improved handling of partial failures, interrupted analysis jobs, and cancelled actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->