### PR TITLE
fix: stabilize repository edit modal interactions

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -5,6 +5,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from './ui/dialog';
+import { cn } from '../lib/utils';
+
+type DialogContentPointerDownOutsideHandler = NonNullable<
+  React.ComponentProps<typeof DialogContent>['onPointerDownOutside']
+>;
 
 interface ModalProps {
   isOpen: boolean;
@@ -12,6 +17,10 @@ interface ModalProps {
   title: string;
   children: React.ReactNode;
   maxWidth?: string;
+  footer?: React.ReactNode;
+  scrollable?: boolean;
+  onPointerDownOutside?: DialogContentPointerDownOutsideHandler;
+  onOverlayPointerDown?: React.PointerEventHandler<HTMLDivElement>;
 }
 
 export const Modal: React.FC<ModalProps> = ({
@@ -20,13 +29,66 @@ export const Modal: React.FC<ModalProps> = ({
   title,
   children,
   maxWidth = 'max-w-md',
-}) => (
-  <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-    <DialogContent aria-describedby={undefined} className={maxWidth}>
+  footer,
+  scrollable = false,
+  onPointerDownOutside,
+  onOverlayPointerDown,
+}) => {
+  const [isScrolling, setIsScrolling] = React.useState(false);
+  const scrollStopTimerRef = React.useRef<number | null>(null);
+
+  React.useEffect(() => () => {
+    if (scrollStopTimerRef.current) window.clearTimeout(scrollStopTimerRef.current);
+  }, []);
+
+  const handleScroll = () => {
+    setIsScrolling(true);
+    if (scrollStopTimerRef.current) window.clearTimeout(scrollStopTimerRef.current);
+    scrollStopTimerRef.current = window.setTimeout(() => {
+      setIsScrolling(false);
+      scrollStopTimerRef.current = null;
+    }, 700);
+  };
+
+  const content = scrollable ? (
+    <>
+      <DialogHeader className="shrink-0 border-b border-border px-6 py-5 pr-12">
+        <DialogTitle>{title}</DialogTitle>
+      </DialogHeader>
+      <div
+        data-testid="modal-scroll-area"
+        className={cn('min-h-0 flex-1 overflow-y-auto px-6 py-5 scrollbar-on-scroll', isScrolling && 'scrolling')}
+        onScroll={handleScroll}
+      >
+        {children}
+      </div>
+      {footer && (
+        <div data-testid="modal-footer" className="shrink-0 border-t border-border px-6 py-4">
+          {footer}
+        </div>
+      )}
+    </>
+  ) : (
+    <>
       <DialogHeader>
         <DialogTitle>{title}</DialogTitle>
       </DialogHeader>
       <div className="min-w-0">{children}</div>
-    </DialogContent>
-  </Dialog>
-);
+    </>
+  );
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent
+        aria-describedby={undefined}
+        className={cn(maxWidth, scrollable && 'flex max-h-[85vh] flex-col gap-0 overflow-hidden p-0')}
+        onPointerDown={(event) => event.stopPropagation()}
+        onClick={(event) => event.stopPropagation()}
+        onPointerDownOutside={onPointerDownOutside}
+        onOverlayPointerDown={onOverlayPointerDown}
+      >
+        {content}
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -41,6 +41,15 @@ export const Modal: React.FC<ModalProps> = ({
     if (scrollStopTimerRef.current) window.clearTimeout(scrollStopTimerRef.current);
   }, []);
 
+  React.useEffect(() => {
+    if (isOpen) return;
+    if (scrollStopTimerRef.current) {
+      window.clearTimeout(scrollStopTimerRef.current);
+      scrollStopTimerRef.current = null;
+    }
+    setIsScrolling(false);
+  }, [isOpen]);
+
   const handleScroll = () => {
     setIsScrolling(true);
     if (scrollStopTimerRef.current) window.clearTimeout(scrollStopTimerRef.current);

--- a/src/components/RepositoryCard.test.tsx
+++ b/src/components/RepositoryCard.test.tsx
@@ -36,8 +36,14 @@ vi.mock('./FloatingTooltip', () => ({
 }));
 
 vi.mock('./RepositoryEditModal', () => ({
-  RepositoryEditModal: ({ isOpen }: { isOpen: boolean }) => (
-    isOpen ? <div data-testid="repository-edit-modal" /> : null
+  RepositoryEditModal: ({
+    isOpen,
+    onOutsideDismiss,
+  }: {
+    isOpen: boolean;
+    onOutsideDismiss?: () => void;
+  }) => (
+    isOpen ? <div data-testid="repository-edit-modal" onPointerDown={onOutsideDismiss} /> : null
   ),
 }));
 
@@ -303,6 +309,22 @@ describe('RepositoryCard view modes', () => {
 
     await act(async () => {
       fireEvent.pointerDown(document.body);
+      fireEvent.click(card);
+    });
+
+    expect(screen.queryByTestId('readme-modal')).not.toBeInTheDocument();
+  });
+
+  it('does not open README when an outside click closes the edit modal', async () => {
+    const user = userEvent.setup();
+    const { container } = renderRepositoryCard('grid');
+    const card = container.firstElementChild as HTMLElement;
+
+    await user.click(screen.getByTitle('编辑仓库信息'));
+    const editModal = screen.getByTestId('repository-edit-modal');
+
+    await act(async () => {
+      fireEvent.pointerDown(editModal);
       fireEvent.click(card);
     });
 

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -173,6 +173,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
   const cardRef = useRef<HTMLDivElement>(null);
   const menuDismissedByPointerDownRef = useRef(false);
   const releaseSheetOutsideDismissedAtRef = useRef<number | null>(null);
+  const editModalOutsideDismissedAtRef = useRef<number | null>(null);
   const gridActionRowRef = useRef<HTMLDivElement>(null);
   const [visibleGridActionCount, setVisibleGridActionCount] = useState(8);
 
@@ -584,12 +585,26 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
     window.setTimeout(() => setReleaseSheetOpen(false), 0);
   }, []);
 
+  const handleEditModalOutsideDismiss = useCallback(() => {
+    editModalOutsideDismissedAtRef.current = Date.now();
+  }, []);
+
   // 使用 useCallback 优化事件处理函数
   const handleCardClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
     const releaseSheetDismissedAt = releaseSheetOutsideDismissedAtRef.current;
     if (releaseSheetDismissedAt !== null) {
       releaseSheetOutsideDismissedAtRef.current = null;
       if (Date.now() - releaseSheetDismissedAt < 250) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+    }
+
+    const editModalDismissedAt = editModalOutsideDismissedAtRef.current;
+    if (editModalDismissedAt !== null) {
+      editModalOutsideDismissedAtRef.current = null;
+      if (Date.now() - editModalDismissedAt < 250) {
         event.preventDefault();
         event.stopPropagation();
         return;
@@ -1234,6 +1249,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
         <RepositoryEditModal
           isOpen={editModalOpen}
           onClose={() => setEditModalOpen(false)}
+          onOutsideDismiss={handleEditModalOutsideDismiss}
           repository={repository}
         />,
         document.body

--- a/src/components/RepositoryEditModal.test.tsx
+++ b/src/components/RepositoryEditModal.test.tsx
@@ -125,6 +125,31 @@ describe("RepositoryEditModal", () => {
     }
   });
 
+  it("clears pending scroll state when the modal closes and reopens", () => {
+    vi.useFakeTimers();
+    try {
+      const { rerender } = render(
+        <RepositoryEditModal isOpen onClose={vi.fn()} repository={repository} />,
+      );
+      const scrollArea = screen.getByTestId("modal-scroll-area");
+      fireEvent.scroll(scrollArea);
+      expect(scrollArea).toHaveClass("scrolling");
+
+      rerender(
+        <RepositoryEditModal isOpen={false} onClose={vi.fn()} repository={repository} />,
+      );
+      rerender(
+        <RepositoryEditModal isOpen onClose={vi.fn()} repository={repository} />,
+      );
+
+      expect(screen.getByTestId("modal-scroll-area")).not.toHaveClass("scrolling");
+      act(() => vi.runOnlyPendingTimers());
+      expect(screen.getByTestId("modal-scroll-area")).not.toHaveClass("scrolling");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps the overlay mounted until its outside-click sequence finishes", () => {
     vi.useFakeTimers();
     try {

--- a/src/components/RepositoryEditModal.test.tsx
+++ b/src/components/RepositoryEditModal.test.tsx
@@ -1,0 +1,144 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RepositoryEditModal } from "./RepositoryEditModal";
+import { deferOutsideDismiss } from "./modalDismiss";
+import type { Repository } from "../types";
+import { useAppStore } from "../store/useAppStore";
+
+vi.mock("../store/useAppStore", () => ({
+  useAppStore: vi.fn(),
+  getAllCategories: () => [],
+}));
+
+vi.mock("../services/autoSync", () => ({
+  forceSyncToBackend: vi.fn(),
+}));
+
+const repository: Repository = {
+  id: 1,
+  name: "example-repository",
+  full_name: "owner/example-repository",
+  description: "Original repository description",
+  html_url: "https://github.com/owner/example-repository",
+  stargazers_count: 128,
+  forks_count: 3,
+  forks: 3,
+  language: "TypeScript",
+  created_at: "2026-01-01T00:00:00.000Z",
+  updated_at: "2026-01-02T00:00:00.000Z",
+  pushed_at: "2026-01-03T00:00:00.000Z",
+  owner: {
+    login: "owner",
+    avatar_url: "https://example.com/avatar.png",
+  },
+  topics: ["test"],
+  ai_platforms: ["web"],
+};
+
+const storeState = {
+  updateRepository: vi.fn(),
+  language: "zh" as const,
+  customCategories: [],
+  hiddenDefaultCategoryIds: [],
+  defaultCategoryOverrides: {},
+};
+
+const mockUseAppStore = vi.mocked(useAppStore);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseAppStore.mockImplementation(((
+    selector?: (state: typeof storeState) => unknown,
+  ) => (selector ? selector(storeState) : storeState)) as typeof useAppStore);
+});
+
+describe("RepositoryEditModal", () => {
+  it("preserves an in-progress draft when polling replaces the repository object", () => {
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <RepositoryEditModal isOpen onClose={onClose} repository={repository} />,
+    );
+
+    const description = screen.getByLabelText("自定义描述");
+    fireEvent.change(description, {
+      target: { value: "Draft that must survive sync" },
+    });
+    expect(description).toHaveValue("Draft that must survive sync");
+
+    rerender(
+      <RepositoryEditModal
+        isOpen
+        onClose={onClose}
+        repository={{ ...repository, updated_at: "2026-02-01T00:00:00.000Z" }}
+      />,
+    );
+
+    expect(screen.getByLabelText("自定义描述")).toHaveValue(
+      "Draft that must survive sync",
+    );
+  });
+
+  it("renders a fixed shell with an independently scrollable content region and footer", () => {
+    render(
+      <RepositoryEditModal isOpen onClose={vi.fn()} repository={repository} />,
+    );
+
+    const dialog = screen.getByRole("dialog");
+    const scrollArea = screen.getByTestId("modal-scroll-area");
+    const footer = screen.getByTestId("modal-footer");
+
+    expect(dialog).toHaveClass("flex", "flex-col", "overflow-hidden");
+    expect(scrollArea).toHaveClass(
+      "min-h-0",
+      "flex-1",
+      "overflow-y-auto",
+      "scrollbar-on-scroll",
+    );
+    expect(footer).toHaveClass("shrink-0");
+    expect(
+      screen
+        .getByText("编辑仓库信息")
+        .closest('[data-testid="modal-scroll-area"]'),
+    ).toBeNull();
+  });
+
+  it("shows the modal scrollbar only during active scrolling", () => {
+    vi.useFakeTimers();
+    try {
+      render(
+        <RepositoryEditModal
+          isOpen
+          onClose={vi.fn()}
+          repository={repository}
+        />,
+      );
+      const scrollArea = screen.getByTestId("modal-scroll-area");
+
+      expect(scrollArea).not.toHaveClass("scrolling");
+      fireEvent.scroll(scrollArea);
+      expect(scrollArea).toHaveClass("scrolling");
+
+      act(() => vi.advanceTimersByTime(700));
+      expect(scrollArea).not.toHaveClass("scrolling");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the overlay mounted until its outside-click sequence finishes", () => {
+    vi.useFakeTimers();
+    try {
+      const onClose = vi.fn();
+      const preventDefault = vi.fn();
+
+      deferOutsideDismiss({ preventDefault }, onClose);
+      expect(preventDefault).toHaveBeenCalledOnce();
+      expect(onClose).not.toHaveBeenCalled();
+
+      act(() => vi.runOnlyPendingTimers());
+      expect(onClose).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/components/RepositoryEditModal.tsx
+++ b/src/components/RepositoryEditModal.tsx
@@ -11,10 +11,12 @@ import { useAppStore, getAllCategories } from '../store/useAppStore';
 import { useShallow } from 'zustand/react/shallow';
 import { forceSyncToBackend } from '../services/autoSync';
 import { computeCustomCategory, getAICategory, getDefaultCategory } from '../utils/categoryUtils';
+import { deferOutsideDismiss } from './modalDismiss';
 
 interface RepositoryEditModalProps {
   isOpen: boolean;
   onClose: () => void;
+  onOutsideDismiss?: () => void;
   repository: Repository | null;
 }
 
@@ -58,6 +60,7 @@ interface SourceInfo {
 export const RepositoryEditModal: React.FC<RepositoryEditModalProps> = ({
   isOpen,
   onClose,
+  onOutsideDismiss,
   repository
 }) => {
   const { updateRepository, language, customCategories, hiddenDefaultCategoryIds, defaultCategoryOverrides } = useAppStore(useShallow((state) => ({
@@ -99,8 +102,7 @@ export const RepositoryEditModal: React.FC<RepositoryEditModalProps> = ({
     tags: 'keep-custom',
     category: 'keep-custom'
   });
-
-
+  const initializedRepositoryIdRef = useRef<number | null>(null);
 
   const allCategories = useMemo(() => getAllCategories(customCategories, language, hiddenDefaultCategoryIds, defaultCategoryOverrides), [customCategories, language, hiddenDefaultCategoryIds, defaultCategoryOverrides]);
 
@@ -216,8 +218,17 @@ export const RepositoryEditModal: React.FC<RepositoryEditModalProps> = ({
    * 当模态框打开时，根据仓库当前状态初始化表单
    */
   useEffect(() => {
-    if (repository && isOpen) {
-      const currentCategory = getCurrentCategory(repository);
+    if (!repository || !isOpen) {
+      initializedRepositoryIdRef.current = null;
+      return;
+    }
+
+    // Polling replaces repository object references every few seconds. Preserve the
+    // user's in-progress draft when that happens; initialize only once per open.
+    if (initializedRepositoryIdRef.current === repository.id) return;
+    initializedRepositoryIdRef.current = repository.id;
+
+    const currentCategory = getCurrentCategory(repository);
       const source = determineSource(repository);
 
       // 获取当前实际显示的内容
@@ -251,7 +262,6 @@ export const RepositoryEditModal: React.FC<RepositoryEditModalProps> = ({
 
       setFormData(initialData);
       initialDataRef.current = JSON.parse(JSON.stringify(initialData));
-    }
   }, [repository, isOpen, allCategories, determineSource, getEffectiveDisplayContent, getCurrentCategory]);
 
   /**
@@ -618,12 +628,35 @@ export const RepositoryEditModal: React.FC<RepositoryEditModalProps> = ({
       onClose={handleClose}
       title={t('编辑仓库信息', 'Edit Repository Info')}
       maxWidth="max-w-2xl"
+      scrollable
+      onOverlayPointerDown={onOutsideDismiss}
+      onPointerDownOutside={(event) => {
+        // Keep the overlay mounted through this click sequence. Otherwise the
+        // follow-up click can be retargeted to the repository card and open README.
+        onOutsideDismiss?.();
+        deferOutsideDismiss(event, handleClose);
+      }}
+      footer={(
+        <div className="flex justify-end space-x-3">
+          <Button
+            onClick={handleCloseWithConfirm}
+            className="flex items-center space-x-2 px-4 py-2.5 text-muted-foreground dark:text-foreground bg-card dark:bg-muted/40 rounded-xl hover:bg-accent dark:hover:bg-accent border border-border dark:border-border transition-all duration-200 shadow-sm"
+          >
+            <X className="w-4 h-4" />
+            <span className="font-medium">{t('取消', 'Cancel')}</span>
+          </Button>
+          <Button
+            onClick={() => void handleSave()}
+            disabled={!hasChanges}
+            className="flex items-center space-x-2 px-5 py-2.5 bg-primary text-primary-foreground rounded-xl hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 shadow-sm font-medium"
+          >
+            <Save className="w-4 h-4" />
+            <span>{t('保存', 'Save')}</span>
+          </Button>
+        </div>
+      )}
     >
-      <div
-        className="space-y-5"
-        onClick={(event) => event.stopPropagation()}
-        onPointerDown={(event) => event.stopPropagation()}
-      >
+      <div className="space-y-5">
         {/* Repository Info Header */}
         <div className="flex items-center space-x-3 p-4 bg-gradient-to-r from-accent/60 to-background dark:bg-primary/10 dark:from-transparent dark:to-transparent rounded-xl border border-border dark:border-primary/20">
           <img
@@ -1173,30 +1206,6 @@ export const RepositoryEditModal: React.FC<RepositoryEditModalProps> = ({
 
         </div>
 
-        {/* Action Buttons - Enhanced */}
-        <div className="flex justify-end space-x-3 pt-4 border-t border-border dark:border-border">
-          <Button
-            onClick={(e) => {
-              e.stopPropagation();
-              handleCloseWithConfirm();
-            }}
-            className="flex items-center space-x-2 px-4 py-2.5 text-muted-foreground dark:text-foreground bg-card dark:bg-muted/40 rounded-xl hover:bg-accent dark:hover:bg-accent border border-border dark:border-border transition-all duration-200 shadow-sm"
-          >
-            <X className="w-4 h-4" />
-            <span className="font-medium">{t('取消', 'Cancel')}</span>
-          </Button>
-          <Button
-            onClick={(e) => {
-              e.stopPropagation();
-              void handleSave();
-            }}
-            disabled={!hasChanges}
-            className="flex items-center space-x-2 px-5 py-2.5 bg-primary text-primary-foreground rounded-xl hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-200 shadow-sm font-medium"
-          >
-            <Save className="w-4 h-4" />
-            <span>{t('保存', 'Save')}</span>
-          </Button>
-        </div>
       </div>
     </Modal>
   );

--- a/src/components/modalDismiss.ts
+++ b/src/components/modalDismiss.ts
@@ -1,0 +1,7 @@
+export const deferOutsideDismiss = (
+  event: Pick<Event, "preventDefault">,
+  onClose: () => void,
+) => {
+  event.preventDefault();
+  window.setTimeout(onClose, 0);
+};

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -22,10 +22,14 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & { showClose?: boolean; closeLabel?: string }
->(({ className, children, showClose = true, closeLabel = 'Close', ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    showClose?: boolean;
+    closeLabel?: string;
+    onOverlayPointerDown?: React.PointerEventHandler<HTMLDivElement>;
+  }
+>(({ className, children, showClose = true, closeLabel = 'Close', onOverlayPointerDown, ...props }, ref) => (
   <DialogPortal>
-    <DialogOverlay />
+    <DialogOverlay onPointerDown={onOverlayPointerDown} />
     <DialogPrimitive.Content
       ref={ref}
       className={cn('fixed left-1/2 top-1/2 z-50 grid max-h-[85vh] w-[calc(100%_-_2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto rounded-lg border bg-background p-6 text-foreground shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0 data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95', className)}

--- a/src/index.css
+++ b/src/index.css
@@ -61,6 +61,40 @@
     transition: background 0.3s ease;
   }
 
+  .scrollbar-on-scroll {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+
+  .scrollbar-on-scroll::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  .scrollbar-on-scroll::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .scrollbar-on-scroll::-webkit-scrollbar-thumb {
+    background: transparent;
+    border-radius: 4px;
+    border: 2px solid transparent;
+    background-clip: padding-box;
+  }
+
+  .scrollbar-on-scroll.scrolling {
+    scrollbar-width: thin;
+    scrollbar-color: hsl(var(--foreground) / 0.25) transparent;
+  }
+
+  .scrollbar-on-scroll.scrolling::-webkit-scrollbar-thumb {
+    background: hsl(var(--foreground) / 0.25);
+  }
+
+  .scrollbar-on-scroll.scrolling::-webkit-scrollbar-thumb:hover {
+    background: hsl(var(--foreground) / 0.4);
+  }
+
   .touch-manipulation {
     touch-action: manipulation;
   }


### PR DESCRIPTION
## Summary

Fixes #304.

- Preserve an in-progress edit draft when background sync replaces the repository object.
- Prevent an edit-modal overlay click from retargeting to the underlying repository card and opening its README.
- Split the edit modal into fixed header/footer regions with a dedicated scrollable content area.
- Hide the modal scrollbar while idle and show it only during active scrolling.

## Validation

- Verified locally in a real browser with authenticated GitHub star data.
- Confirmed draft persistence, overlay dismissal without README fallback, and fixed header/close/footer while content scrolls.
- `npm run test:run` — 60 files / 530 tests passed.
- `npm run typecheck`, `npm run lint`, and `npm run check:boundaries` passed.

> Note: production bundling was attempted three times with different Node heap limits but was terminated by the constrained sandbox memory limit after Vite transformed all 5,293 modules. This is unrelated to the TypeScript, lint, boundary, and full test results above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scrollable modal layouts with sticky headers and footers.
  * Scrollbars now appear temporarily while scrolling.
  * Added customizable modal footers and accessible close-button labels.

* **Bug Fixes**
  * Preserved in-progress repository edits during background updates.
  * Prevented outside-click dismissal of the edit modal from triggering the underlying repository card.
  * Improved modal overlay interactions and dismissal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->