### PR TITLE
fix(ci): stabilize multi-arch Docker publishing

### DIFF
--- a/.github/workflows/docker-publish-frontend.yml
+++ b/.github/workflows/docker-publish-frontend.yml
@@ -6,6 +6,12 @@ on:
     tags: ['v*']
   workflow_dispatch:
 
+# Keep only the newest run for each branch or tag, while allowing release tags
+# and main to publish independently.
+concurrency:
+  group: frontend-image-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/github-stars-manager-frontend
@@ -13,6 +19,8 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    # Avoid an unbounded blocked cache or registry operation.
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -59,5 +67,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Do not share the default `buildkit` scope with the backend image.
+          cache-from: type=gha,scope=github-stars-manager-frontend-${{ github.ref_type }},timeout=5m
+          cache-to: type=gha,scope=github-stars-manager-frontend-${{ github.ref_type }},mode=max,timeout=5m,ignore-error=true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,6 +6,12 @@ on:
     tags: ['v*']
   workflow_dispatch:
 
+# Keep only the newest run for each branch or tag, while allowing release tags
+# and main to publish independently.
+concurrency:
+  group: server-image-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/github-stars-manager-server
@@ -13,6 +19,8 @@ env:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    # Avoid an unbounded blocked cache or registry operation.
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -59,5 +67,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Do not share the default `buildkit` scope with the frontend image.
+          cache-from: type=gha,scope=github-stars-manager-server-${{ github.ref_type }},timeout=5m
+          cache-to: type=gha,scope=github-stars-manager-server-${{ github.ref_type }},mode=max,timeout=5m,ignore-error=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-# Build stage
-FROM node:22-alpine AS build
+# syntax=docker/dockerfile:1
+# `dist` only contains static assets, so build it once on the native builder.
+# The final nginx stage remains target-platform aware for amd64 and arm64.
+FROM --platform=$BUILDPLATFORM node:22-alpine AS build
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

This PR keeps publishing one frontend and one backend image with both `linux/amd64` and `linux/arm64` variants, while removing the QEMU bottleneck for the frontend's architecture-independent static build.

- Build frontend `dist` once on the native BuildKit platform; keep `nginx:alpine` target-platform aware so the published OCI image index still contains both amd64 and arm64 runtime images.
- Cancel superseded branch/tag publishing runs to prevent stale multi-architecture builds from accumulating.
- Give frontend and backend separate GitHub Actions BuildKit cache scopes, with bounded cache operations and job timeouts.

## Validation

- `npm ci`
- `npm run lint`
- `npm run typecheck`
- `npm run test:run`
- `npm run build`
- Structured workflow and Dockerfile audit: 14/14 checks passed.
- Remote frontend workflow audit: [successful in 2m32s](https://github.com/AmintaCCCP/GithubStarsManager/actions/runs/33076647310). Its published OCI index tag `sha-b78b68e` contains `linux/amd64` and `linux/arm64`; the Node build only ran in the native amd64 build stage.
- Remote backend workflow audit: [successful in 3m03s](https://github.com/AmintaCCCP/GithubStarsManager/actions/runs/33076957468). Its published OCI index tag `sha-b78b68e` contains `linux/amd64` and `linux/arm64`.

## Notes

The existing Docker action pins emitted a GitHub-hosted runner warning about Node 20 being forced onto Node 24. This does not affect the passed multi-architecture audit and is intentionally left out of this focused reliability fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated container builds by canceling outdated runs when newer builds are available.
  * Added build time limits and more reliable caching for container publishing workflows.
  * Updated container builds to run consistently on the intended build platform while preserving production deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->