### PR TITLE
fix: keep active searchResults during background sync; constant scrollbar gutter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,29 +19,8 @@ import { logger } from './services/logger';
 import { UpdateNotificationBanner } from './components/UpdateNotificationBanner';
 import { ListsPushIndicator } from './components/ListsPushIndicator';
 import { useBackendLifecycle } from './features/lifecycle/useBackendLifecycle';
-import type { AppState, SearchFilters } from './types';
-
-/**
- * Check if any search/filter/sort condition is active (non-default).
- * Used to decide whether to display searchResults or the full repository list.
- */
-function hasActiveSearchFilters(filters: SearchFilters): boolean {
-  return (
-    !!filters.query.trim() ||
-    filters.languages.length > 0 ||
-    filters.tags.length > 0 ||
-    filters.platforms.length > 0 ||
-    filters.minStars !== undefined ||
-    filters.maxStars !== undefined ||
-    filters.isAnalyzed !== undefined ||
-    filters.isSubscribed !== undefined ||
-    filters.isEdited !== undefined ||
-    filters.isCategoryLocked !== undefined ||
-    filters.analysisFailed !== undefined ||
-    filters.sortBy !== 'stars' ||
-    filters.sortOrder !== 'desc'
-  );
-}
+import type { AppState } from './types';
+import { hasActiveSearchFilters } from './utils/repoSearch';
 
 const LazyReleaseTimeline = React.lazy(() =>
   import('./components/ReleaseTimeline').then((module) => ({ default: module.ReleaseTimeline }))

--- a/src/index.css
+++ b/src/index.css
@@ -61,9 +61,12 @@
     transition: background 0.3s ease;
   }
 
+  /* Scrollbar layout is constant: the gutter is always reserved and only the
+     thumb's color toggles on scroll. Toggling scrollbar-width/overflow instead
+     changed the content width mid-scroll and jittered text and borders (#309). */
   .scrollbar-on-scroll {
-    -ms-overflow-style: none;
-    scrollbar-width: none;
+    scrollbar-width: thin;
+    scrollbar-color: transparent transparent;
   }
 
   .scrollbar-on-scroll::-webkit-scrollbar {
@@ -83,7 +86,6 @@
   }
 
   .scrollbar-on-scroll.scrolling {
-    scrollbar-width: thin;
     scrollbar-color: hsl(var(--foreground) / 0.25) transparent;
   }
 

--- a/src/services/autoSync.repoHash.test.ts
+++ b/src/services/autoSync.repoHash.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { Repository } from '../types';
 import { mergeRepositoriesPreservingLocalMetadata } from '../utils/repositoryMerge';
 import { hasActiveSearchFilters } from '../utils/repoSearch';
+import { repositoryPayloadHash } from './autoSync';
 
 // Regression for Issue #304: the repos hash committed after a pull must be the
 // RAW backend hash. Committing quickHash(merged) instead made the next poll's
@@ -69,6 +70,17 @@ describe('backend sync hash convergence (Issue #304 loop-breaker)', () => {
 
     expect(JSON.stringify(secondMerge)).toBe(JSON.stringify(firstMerge));
   });
+
+  it('omits client-only fields from both pull and successful-push hashes', () => {
+    const backendPayload = [createRepository(1)];
+    const localRepositories = [createRepository(1, {
+      analysis_error: 'temporary failure detail',
+      has_fetched_releases: true,
+      last_release_fetch_time: '2026-08-01T00:00:00.000Z',
+    })];
+
+    expect(repositoryPayloadHash(localRepositories)).toBe(repositoryPayloadHash(backendPayload));
+  });
 });
 
 describe('hasActiveSearchFilters (Issue #304 searchResults guard)', () => {
@@ -93,5 +105,6 @@ describe('hasActiveSearchFilters (Issue #304 searchResults guard)', () => {
 
   it('treats facet selections as active', () => {
     expect(hasActiveSearchFilters({ ...baseFilters(), languages: ['TypeScript'] })).toBe(true);
+    expect(hasActiveSearchFilters({ ...baseFilters(), licenses: ['MIT'] })).toBe(true);
   });
 });

--- a/src/services/autoSync.repoHash.test.ts
+++ b/src/services/autoSync.repoHash.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import type { Repository } from '../types';
+import { mergeRepositoriesPreservingLocalMetadata } from '../utils/repositoryMerge';
+import { hasActiveSearchFilters } from '../utils/repoSearch';
+
+// Regression for Issue #304: the repos hash committed after a pull must be the
+// RAW backend hash. Committing quickHash(merged) instead made the next poll's
+// backend hash differ forever (the merge injects local-only metadata such as
+// vector_indexed_at that the backend never returns), so setRepositories —
+// which used to reset searchResults — fired on every 5s poll cycle and
+// unmounted the card whose edit modal was open.
+
+const createRepository = (id: number, overrides: Partial<Repository> = {}): Repository => ({
+  id,
+  name: `repo-${id}`,
+  full_name: `owner/repo-${id}`,
+  description: 'A test repository',
+  html_url: `https://github.com/owner/repo-${id}`,
+  stargazers_count: 10,
+  forks_count: 1,
+  forks: 1,
+  language: 'TypeScript',
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-02T00:00:00.000Z',
+  pushed_at: '2026-01-03T00:00:00.000Z',
+  owner: {
+    login: 'owner',
+    avatar_url: 'https://github.com/avatar.png',
+  },
+  topics: ['test'],
+  ...overrides,
+});
+
+describe('backend sync hash convergence (Issue #304 loop-breaker)', () => {
+  it('merge output differs from the backend payload when local metadata exists', () => {
+    const backendRepos = [createRepository(1)];
+    const localRepos = [createRepository(1, { vector_indexed_at: '2026-08-01T00:00:00.000Z' })];
+
+    const merged = mergeRepositoriesPreservingLocalMetadata(backendRepos, localRepos);
+
+    // This inequality is exactly why hashing the merged result never converged.
+    expect(JSON.stringify(merged)).not.toBe(JSON.stringify(backendRepos));
+    // The local-only field survives the merge.
+    expect(merged[0].vector_indexed_at).toBe('2026-08-01T00:00:00.000Z');
+  });
+
+  it('two consecutive pulls of an unchanged backend hash identically', () => {
+    // Mirrors the poll loop: pull → commit hashes.repos → next pull compares
+    // against that value. With the raw backend hash committed, the second pull
+    // sees no change and skips setRepositories.
+    const backendPayload = [createRepository(1, { ai_summary: 'from backend' })];
+    const localRepos = [createRepository(1, { ai_summary: 'from backend', ai_tags: ['ai-tag'] })];
+
+    const firstPullHash = JSON.stringify(backendPayload);
+    const merged = mergeRepositoriesPreservingLocalMetadata(backendPayload, localRepos);
+
+    // The fix commits the raw backend hash (firstPullHash), not quickHash(merged).
+    expect(firstPullHash).not.toBe(JSON.stringify(merged));
+    // Second poll re-hashes the same backend payload → equals the committed hash.
+    expect(JSON.stringify(backendPayload)).toBe(firstPullHash);
+  });
+
+  it('merged output is stable across repeated merges of the same inputs', () => {
+    const backendRepos = [createRepository(1)];
+    const localRepos = [createRepository(1, { subscribed_to_releases: true })];
+
+    const firstMerge = mergeRepositoriesPreservingLocalMetadata(backendRepos, localRepos);
+    const secondMerge = mergeRepositoriesPreservingLocalMetadata(backendRepos, localRepos);
+
+    expect(JSON.stringify(secondMerge)).toBe(JSON.stringify(firstMerge));
+  });
+});
+
+describe('hasActiveSearchFilters (Issue #304 searchResults guard)', () => {
+  const baseFilters = (): import('../types').SearchFilters => ({
+    query: '',
+    languages: [],
+    tags: [],
+    platforms: [],
+    licenses: [],
+    sortBy: 'stars',
+    sortOrder: 'desc',
+  });
+
+  it('treats a non-empty query as active', () => {
+    expect(hasActiveSearchFilters({ ...baseFilters(), query: 'react' })).toBe(true);
+  });
+
+  it('treats default sort as inactive and a changed sort as active', () => {
+    expect(hasActiveSearchFilters(baseFilters())).toBe(false);
+    expect(hasActiveSearchFilters({ ...baseFilters(), sortBy: 'updated' })).toBe(true);
+  });
+
+  it('treats facet selections as active', () => {
+    expect(hasActiveSearchFilters({ ...baseFilters(), languages: ['TypeScript'] })).toBe(true);
+  });
+});

--- a/src/services/autoSync.repoHash.test.ts
+++ b/src/services/autoSync.repoHash.test.ts
@@ -6,10 +6,15 @@ import { repositoryPayloadHash } from './autoSync';
 
 // Regression for Issue #304: the repos hash committed after a pull must be the
 // RAW backend hash. Committing quickHash(merged) instead made the next poll's
-// backend hash differ forever (the merge injects local-only metadata such as
-// vector_indexed_at that the backend never returns), so setRepositories —
-// which used to reset searchResults — fired on every 5s poll cycle and
-// unmounted the card whose edit modal was open.
+// backend hash differ forever (the merge injects client-only metadata such as
+// analysis_error / has_fetched_releases that the backend never stores), so
+// setRepositories — which used to reset searchResults — fired on every 5s poll
+// cycle and unmounted the card whose edit modal was open.
+//
+// The same loop-breaker applies to the push side: syncToBackend commits the
+// hash through stripLocalRepositoryFields, the identical projection the pull
+// side uses (repositoryPayloadHash delegates to it), so a successful push and
+// the next pull always agree.
 
 const createRepository = (id: number, overrides: Partial<Repository> = {}): Repository => ({
   id,
@@ -82,30 +87,23 @@ it('omits client-only fields from both pull and successful-push hashes', () => {
     expect(repositoryPayloadHash(localRepositories)).toBe(repositoryPayloadHash(backendPayload));
   });
 
-  it('stripLocalRepositoryFields removes all local-only fields (CodeRabbit push-hash fix)', () => {
+  it('stripLocalRepositoryFields removes every client-only field (CodeRabbit push-hash fix)', () => {
     const repo = createRepository(1, {
-      vector_indexed_at: '2026-08-01T00:00:00.000Z',
-      ai_summary: 'summary',
-      ai_tags: ['tag'],
-      ai_platforms: ['github'],
-      analyzed_at: '2026-08-01T00:00:00.000Z',
-      analysis_failed: false,
-      subscribed_to_releases: true,
-      custom_description: 'desc',
-      custom_tags: ['custom'],
-      custom_category: 'cat',
-      category_locked: true,
-      last_edited: '2026-08-01T00:00:00.000Z',
+      analysis_error: 'model unavailable',
       has_fetched_releases: true,
       last_release_fetch_time: '2026-08-01T00:00:00.000Z',
+      vector_indexed_at: '2026-08-01T00:00:00.000Z',
+      ai_summary: 'summary',
     });
 
     const stripped = stripLocalRepositoryFields([repo]);
 
-    // All local-only fields are gone
-    expect(stripped[0].vector_indexed_at).toBeUndefined();
-    expect(stripped[0].ai_summary).toBeUndefined();
+    // All client-only fields are gone
+    expect(stripped[0].analysis_error).toBeUndefined();
     expect(stripped[0].has_fetched_releases).toBeUndefined();
+    expect(stripped[0].last_release_fetch_time).toBeUndefined();
+    expect(stripped[0].forks_count).toBeUndefined();
+    expect(stripped[0].forks).toBeUndefined();
     // Backend-owned fields survive
     expect(stripped[0].id).toBe(1);
     expect(stripped[0].name).toBe('repo-1');
@@ -113,22 +111,42 @@ it('omits client-only fields from both pull and successful-push hashes', () => {
   });
 
   it('stripLocalRepositoryFields hash matches the backend pull payload hash (CodeRabbit convergence)', () => {
-    // The backend stores only GitHub API data — local-only fields (ai_summary,
-    // ai_tags, vector_indexed_at…) never appear in its payload.
-    const backendPayload = [createRepository(1)];
+    // Model what the server actually returns: no forks_count/forks (not stored),
+    // no analysis_error / has_fetched_releases (client-only), but vector_indexed_at
+    // IS round-tripped (stored + returned by GET /api/repositories).
+    const backendPayload = [createRepository(1, {
+      forks_count: undefined,
+      forks: undefined,
+      vector_indexed_at: '2026-08-01T00:00:00.000Z',
+    })];
     const localRepos = [createRepository(1, {
-      ai_summary: 'local summary',
-      ai_tags: ['ai-tag'],
+      analysis_error: 'model unavailable',
+      has_fetched_releases: true,
       vector_indexed_at: '2026-08-01T00:00:00.000Z',
     })];
 
     // After push, we hash stripLocalRepositoryFields(state.repositories) — the
-    // state has local-only fields injected by the merge. After pull, we hash the
-    // raw backend payload. These must be equal so the next poll skips the merge.
+    // state has client-only fields injected by the merge. After pull, we hash
+    // the raw backend payload. These must be equal so the next poll skips the
+    // merge.
     const pushHash = JSON.stringify(stripLocalRepositoryFields(localRepos));
     const pullHash = JSON.stringify(backendPayload);
 
     expect(pushHash).toBe(pullHash);
+  });
+
+  it('push and pull fingerprints share the same projection even with analysis_error (CodeRabbit)', () => {
+    // analysis_error is client-only: the backend never stores it. The push side
+    // hashes the store (which may carry analysis_error) through
+    // stripLocalRepositoryFields; the pull side hashes the backend payload
+    // through repositoryPayloadHash (which delegates to the same projection).
+    // Both must yield the same hash so a repo with a local analysis_error
+    // doesn't re-trigger setRepositories forever.
+    const backendPayload = [createRepository(1, { forks_count: undefined, forks: undefined })];
+    const localRepos = [createRepository(1, { analysis_error: 'model unavailable' })];
+
+    expect(repositoryPayloadHash(localRepos)).toBe(repositoryPayloadHash(backendPayload));
+    expect(JSON.stringify(stripLocalRepositoryFields(localRepos))).toBe(JSON.stringify(backendPayload));
   });
 });
 

--- a/src/services/autoSync.repoHash.test.ts
+++ b/src/services/autoSync.repoHash.test.ts
@@ -1,8 +1,28 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Repository } from '../types';
 import { mergeRepositoriesPreservingLocalMetadata, stripLocalRepositoryFields } from '../utils/repositoryMerge';
 import { hasActiveSearchFilters } from '../utils/repoSearch';
-import { repositoryPayloadHash } from './autoSync';
+import { repositoryPayloadHash, syncFromBackend } from './autoSync';
+import { backend } from './backendAdapter';
+import { useAppStore } from '../store/useAppStore';
+
+vi.mock('./backendAdapter', () => ({
+  backend: {
+    isAvailable: true,
+    fetchRepositories: vi.fn(),
+    fetchReleases: vi.fn(),
+    fetchAIConfigs: vi.fn(),
+    fetchWebDAVConfigs: vi.fn(),
+    fetchEmbeddingConfigs: vi.fn(),
+    fetchVectorSearchConfig: vi.fn(),
+    fetchSettings: vi.fn(),
+  },
+}));
+
+// src/test/setup.ts replaces the store with a hook-level mock for component
+// tests. syncFromBackend drives the real store directly (setRepositories,
+// getState), so restore the actual module for this file.
+vi.mock('../store/useAppStore', async () => await vi.importActual('../store/useAppStore'));
 
 // Regression for Issue #304: the repos hash committed after a pull must be the
 // RAW backend hash. Committing quickHash(merged) instead made the next poll's
@@ -147,6 +167,59 @@ it('omits client-only fields from both pull and successful-push hashes', () => {
 
     expect(repositoryPayloadHash(localRepos)).toBe(repositoryPayloadHash(backendPayload));
     expect(JSON.stringify(stripLocalRepositoryFields(localRepos))).toBe(JSON.stringify(backendPayload));
+  });
+});
+
+describe('syncFromBackend two-pull loop (Issue #304 end-to-end)', () => {
+  const backendPayload = [createRepository(1, { ai_summary: 'from backend' })];
+
+  beforeEach(() => {
+    vi.mocked(backend.fetchRepositories).mockResolvedValue({ repositories: backendPayload, total: 1 });
+    vi.mocked(backend.fetchReleases).mockResolvedValue({ releases: [], total: 0 });
+    vi.mocked(backend.fetchAIConfigs).mockResolvedValue([]);
+    vi.mocked(backend.fetchWebDAVConfigs).mockResolvedValue([]);
+    vi.mocked(backend.fetchEmbeddingConfigs).mockResolvedValue([]);
+    vi.mocked(backend.fetchVectorSearchConfig).mockResolvedValue({
+      enabled: false,
+      workerUrl: '',
+      authToken: '',
+      embeddingConfigId: '',
+      indexMode: 'readme',
+      readmeMaxChars: 6000,
+    });
+    vi.mocked(backend.fetchSettings).mockResolvedValue({});
+  });
+
+  it('applies a changed backend payload once; an unchanged second pull is a no-op', async () => {
+    // The local repo carries client-only metadata (analysis_error) the backend
+    // never stores, so quickHash(merged) — the pre-fix commit value — can never
+    // equal the raw backend hash. If the pull side ever reverts to committing
+    // quickHash(merged), the second pull below re-applies setRepositories
+    // (new repositories reference) and this test fails.
+    const localRepo = createRepository(1, { ai_summary: 'from backend', analysis_error: 'stale local error' });
+    useAppStore.setState({
+      repositories: [localRepo],
+      searchResults: [localRepo],
+      searchFilters: { ...useAppStore.getState().searchFilters, query: 'repo' },
+    });
+    const searchResultsBeforePull = useAppStore.getState().searchResults;
+
+    await syncFromBackend(); // pull 1 — payload differs from the initial hash → applied
+
+    const afterFirstPull = useAppStore.getState();
+    expect(afterFirstPull.repositories).toHaveLength(1);
+    expect(afterFirstPull.repositories[0].ai_summary).toBe('from backend');
+    // Local-only metadata survives the merge.
+    expect(afterFirstPull.repositories[0].analysis_error).toBe('stale local error');
+    // Active search filters: the searchResults reference is preserved so the
+    // card being edited stays mounted.
+    expect(afterFirstPull.searchResults).toBe(searchResultsBeforePull);
+
+    const repositoriesAfterFirstPull = afterFirstPull.repositories;
+    await syncFromBackend(); // pull 2 — identical backend payload
+
+    expect(useAppStore.getState().repositories).toBe(repositoriesAfterFirstPull);
+    expect(useAppStore.getState().searchResults).toBe(searchResultsBeforePull);
   });
 });
 

--- a/src/services/autoSync.repoHash.test.ts
+++ b/src/services/autoSync.repoHash.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Repository } from '../types';
-import { mergeRepositoriesPreservingLocalMetadata } from '../utils/repositoryMerge';
+import { mergeRepositoriesPreservingLocalMetadata, stripLocalRepositoryFields } from '../utils/repositoryMerge';
 import { hasActiveSearchFilters } from '../utils/repoSearch';
 import { repositoryPayloadHash } from './autoSync';
 
@@ -71,7 +71,7 @@ describe('backend sync hash convergence (Issue #304 loop-breaker)', () => {
     expect(JSON.stringify(secondMerge)).toBe(JSON.stringify(firstMerge));
   });
 
-  it('omits client-only fields from both pull and successful-push hashes', () => {
+it('omits client-only fields from both pull and successful-push hashes', () => {
     const backendPayload = [createRepository(1)];
     const localRepositories = [createRepository(1, {
       analysis_error: 'temporary failure detail',
@@ -80,6 +80,55 @@ describe('backend sync hash convergence (Issue #304 loop-breaker)', () => {
     })];
 
     expect(repositoryPayloadHash(localRepositories)).toBe(repositoryPayloadHash(backendPayload));
+  });
+
+  it('stripLocalRepositoryFields removes all local-only fields (CodeRabbit push-hash fix)', () => {
+    const repo = createRepository(1, {
+      vector_indexed_at: '2026-08-01T00:00:00.000Z',
+      ai_summary: 'summary',
+      ai_tags: ['tag'],
+      ai_platforms: ['github'],
+      analyzed_at: '2026-08-01T00:00:00.000Z',
+      analysis_failed: false,
+      subscribed_to_releases: true,
+      custom_description: 'desc',
+      custom_tags: ['custom'],
+      custom_category: 'cat',
+      category_locked: true,
+      last_edited: '2026-08-01T00:00:00.000Z',
+      has_fetched_releases: true,
+      last_release_fetch_time: '2026-08-01T00:00:00.000Z',
+    });
+
+    const stripped = stripLocalRepositoryFields([repo]);
+
+    // All local-only fields are gone
+    expect(stripped[0].vector_indexed_at).toBeUndefined();
+    expect(stripped[0].ai_summary).toBeUndefined();
+    expect(stripped[0].has_fetched_releases).toBeUndefined();
+    // Backend-owned fields survive
+    expect(stripped[0].id).toBe(1);
+    expect(stripped[0].name).toBe('repo-1');
+    expect(stripped[0].stargazers_count).toBe(10);
+  });
+
+  it('stripLocalRepositoryFields hash matches the backend pull payload hash (CodeRabbit convergence)', () => {
+    // The backend stores only GitHub API data — local-only fields (ai_summary,
+    // ai_tags, vector_indexed_at…) never appear in its payload.
+    const backendPayload = [createRepository(1)];
+    const localRepos = [createRepository(1, {
+      ai_summary: 'local summary',
+      ai_tags: ['ai-tag'],
+      vector_indexed_at: '2026-08-01T00:00:00.000Z',
+    })];
+
+    // After push, we hash stripLocalRepositoryFields(state.repositories) — the
+    // state has local-only fields injected by the merge. After pull, we hash the
+    // raw backend payload. These must be equal so the next poll skips the merge.
+    const pushHash = JSON.stringify(stripLocalRepositoryFields(localRepos));
+    const pullHash = JSON.stringify(backendPayload);
+
+    expect(pushHash).toBe(pullHash);
   });
 });
 
@@ -105,6 +154,10 @@ describe('hasActiveSearchFilters (Issue #304 searchResults guard)', () => {
 
   it('treats facet selections as active', () => {
     expect(hasActiveSearchFilters({ ...baseFilters(), languages: ['TypeScript'] })).toBe(true);
+    expect(hasActiveSearchFilters({ ...baseFilters(), licenses: ['MIT'] })).toBe(true);
+  });
+
+  it('treats a license-only selection as active (CodeRabbit)', () => {
     expect(hasActiveSearchFilters({ ...baseFilters(), licenses: ['MIT'] })).toBe(true);
   });
 });

--- a/src/services/autoSync.ts
+++ b/src/services/autoSync.ts
@@ -1,6 +1,7 @@
 import { backend } from './backendAdapter';
 import { useAppStore } from '../store/useAppStore';
 import { mergeRepositoriesPreservingLocalMetadata } from '../utils/repositoryMerge';
+import { stripLocalRepositoryFields } from '../utils/repositoryMerge';
 import { GitHubApiService } from './githubApi';
 import { logger } from './logger';
 import type { Repository } from '../types';
@@ -45,11 +46,10 @@ function quickHash(data: unknown): string {
 }
 
 const LOCAL_ONLY_REPOSITORY_FIELDS = new Set<keyof Repository>([
-  'forks_count',
-  'forks',
   'analysis_error',
   'has_fetched_releases',
   'last_release_fetch_time',
+  'vector_indexed_at',
 ]);
 
 /**
@@ -533,8 +533,11 @@ export async function syncToBackend(): Promise<void> {
       _hasPendingLocalChanges = false;
     }
 
-    // Only update _lastHash for successfully synced slices
-    if (reposSync.status === 'fulfilled') _lastHash.repos = repositoryPayloadHash(state.repositories);
+    // Only update _lastHash for successfully synced slices.
+    // Hash the raw pushed payload (local-only fields like vector_indexed_at are
+    // never stored by the backend), so the next pull compares against the same
+    // projection and doesn't re-apply setRepositories after a push.
+    if (reposSync.status === 'fulfilled') _lastHash.repos = quickHash(stripLocalRepositoryFields(state.repositories));
     if (releasesSync.status === 'fulfilled') _lastHash.releases = quickHash(state.releases);
     if (aiSync.status === 'fulfilled') _lastHash.ai = quickHash(state.aiConfigs);
     if (webdavSync.status === 'fulfilled') _lastHash.webdav = quickHash(state.webdavConfigs);

--- a/src/services/autoSync.ts
+++ b/src/services/autoSync.ts
@@ -1,7 +1,6 @@
 import { backend } from './backendAdapter';
 import { useAppStore } from '../store/useAppStore';
-import { mergeRepositoriesPreservingLocalMetadata } from '../utils/repositoryMerge';
-import { stripLocalRepositoryFields } from '../utils/repositoryMerge';
+import { mergeRepositoriesPreservingLocalMetadata, stripLocalRepositoryFields } from '../utils/repositoryMerge';
 import { GitHubApiService } from './githubApi';
 import { logger } from './logger';
 import type { Repository } from '../types';
@@ -45,25 +44,14 @@ function quickHash(data: unknown): string {
   return JSON.stringify(data);
 }
 
-const LOCAL_ONLY_REPOSITORY_FIELDS = new Set<keyof Repository>([
-  'analysis_error',
-  'has_fetched_releases',
-  'last_release_fetch_time',
-  'vector_indexed_at',
-]);
-
 /**
- * The repository endpoint does not round-trip these client-only fields. Keep
- * them out of sync fingerprints while still sending the unchanged store value.
+ * The repository endpoint does not round-trip client-only fields. Keep them
+ * out of sync fingerprints while still sending the unchanged store value.
+ * Uses the same field set as stripLocalRepositoryFields so the pull and push
+ * fingerprints always project the identical shape (Issue #304 loop-breaker).
  */
 export function repositoryPayloadHash(repositories: Repository[]): string {
-  return quickHash(repositories.map(repository =>
-    Object.fromEntries(
-      Object.entries(repository).filter(([field]) =>
-        !LOCAL_ONLY_REPOSITORY_FIELDS.has(field as keyof Repository)
-      )
-    )
-  ));
+  return quickHash(stripLocalRepositoryFields(repositories));
 }
 
 /** Canonical fingerprint for the vector search config.

--- a/src/services/autoSync.ts
+++ b/src/services/autoSync.ts
@@ -3,6 +3,7 @@ import { useAppStore } from '../store/useAppStore';
 import { mergeRepositoriesPreservingLocalMetadata } from '../utils/repositoryMerge';
 import { GitHubApiService } from './githubApi';
 import { logger } from './logger';
+import type { Repository } from '../types';
 
 // Prevent sync loops: when we pull data FROM backend and update store,
 // the store subscription would trigger a push TO backend. This flag blocks that.
@@ -41,6 +42,28 @@ const _lastHash = {
 
 function quickHash(data: unknown): string {
   return JSON.stringify(data);
+}
+
+const LOCAL_ONLY_REPOSITORY_FIELDS = new Set<keyof Repository>([
+  'forks_count',
+  'forks',
+  'analysis_error',
+  'has_fetched_releases',
+  'last_release_fetch_time',
+]);
+
+/**
+ * The repository endpoint does not round-trip these client-only fields. Keep
+ * them out of sync fingerprints while still sending the unchanged store value.
+ */
+export function repositoryPayloadHash(repositories: Repository[]): string {
+  return quickHash(repositories.map(repository =>
+    Object.fromEntries(
+      Object.entries(repository).filter(([field]) =>
+        !LOCAL_ONLY_REPOSITORY_FIELDS.has(field as keyof Repository)
+      )
+    )
+  ));
 }
 
 /** Canonical fingerprint for the vector search config.
@@ -229,7 +252,7 @@ export async function syncFromBackend(): Promise<void> {
     // Compute hashes for each slice — only mark changed if hash differs
     const hashes: Record<string, string> = {};
     if (reposResult.status === 'fulfilled') {
-      const hash = quickHash(reposResult.value.repositories);
+      const hash = repositoryPayloadHash(reposResult.value.repositories);
       if (hash !== _lastHash.repos) {
         hashes.repos = hash;
         changed.repos = true;
@@ -511,7 +534,7 @@ export async function syncToBackend(): Promise<void> {
     }
 
     // Only update _lastHash for successfully synced slices
-    if (reposSync.status === 'fulfilled') _lastHash.repos = quickHash(state.repositories);
+    if (reposSync.status === 'fulfilled') _lastHash.repos = repositoryPayloadHash(state.repositories);
     if (releasesSync.status === 'fulfilled') _lastHash.releases = quickHash(state.releases);
     if (aiSync.status === 'fulfilled') _lastHash.ai = quickHash(state.aiConfigs);
     if (webdavSync.status === 'fulfilled') _lastHash.webdav = quickHash(state.webdavConfigs);

--- a/src/services/autoSync.ts
+++ b/src/services/autoSync.ts
@@ -310,7 +310,11 @@ export async function syncFromBackend(): Promise<void> {
       } else {
         const merged = mergeRepositoriesPreservingLocalMetadata(backendRepos, localRepos);
         state.setRepositories(merged);
-        _lastHash.repos = quickHash(merged);
+        // Commit the RAW backend hash, not the merged one. The merge preserves
+        // local-only metadata (e.g. vector_indexed_at) the backend never stores,
+        // so hashing `merged` here made the next poll's backend hash differ
+        // forever — re-applying setRepositories every poll cycle.
+        _lastHash.repos = hashes.repos;
       }
     }
     if (changed.releases && releasesResult.status === 'fulfilled') {

--- a/src/store/slices/repositorySlice.ts
+++ b/src/store/slices/repositorySlice.ts
@@ -133,7 +133,13 @@ export const createRepositorySlice: AppStoreSlice<Pick<import('../types').AppAct
 
         return {
           repositories: updatedRepositories,
-          searchResults: updatedRepositories
+          // Same guard as setRepositories: while search filters are active the
+          // visible list is searchResults, and swapping in the full list would
+          // unmount filtered cards (closing their edit modal). SearchBar
+          // recomputes results from the updated repositories on its own effect.
+          searchResults: hasActiveSearchFilters(state.searchFilters)
+            ? state.searchResults
+            : updatedRepositories
         };
       }),
       setLoading: (isLoading) => set({ isLoading }),

--- a/src/store/slices/repositorySlice.ts
+++ b/src/store/slices/repositorySlice.ts
@@ -4,6 +4,7 @@ import { matchesCategory } from '../../utils/categoryUtils';
 import type { AppStoreSlice } from '../types';
 import { defaultCategories, initialSearchFilters } from '../schema';
 import { getAllCategories, getCategoryNameVariants } from '../helpers/categoryHelpers';
+import { hasActiveSearchFilters } from '../../utils/repoSearch';
 import { areRepositoryRecordsEqual, replaceRepositoryInList } from '../helpers/repositoryRecords';
 
 export const createRepositorySlice: AppStoreSlice<Pick<import('../types').AppActions,
@@ -29,7 +30,14 @@ export const createRepositorySlice: AppStoreSlice<Pick<import('../types').AppAct
   | 'setSearchResults'
 >> = (set, get) => ({
       // Repository actions
-      setRepositories: (repositories) => set({ repositories, searchResults: repositories }),
+      setRepositories: (repositories) => set((state) => ({
+        repositories,
+        // Background sync must not wipe an active search result set: replacing
+        // it with the full list shrinks the visible slice and unmounts the card
+        // being edited (closing its edit modal). SearchBar recomputes results
+        // from the new repositories on its own effect.
+        searchResults: hasActiveSearchFilters(state.searchFilters) ? state.searchResults : repositories,
+      })),
       updateRepository: (repo) => set((state) => {
         const repositoriesResult = replaceRepositoryInList(state.repositories, repo);
         const searchResultsResult = state.searchResults === state.repositories

--- a/src/store/useAppStore.test.ts
+++ b/src/store/useAppStore.test.ts
@@ -584,7 +584,26 @@ describe('useAppStore repository performance guards', () => {
     expect(useAppStore.getState().repositories).toBe(refreshed);
   });
 
+  it('preserves an active search result set when only a license filter is active', () => {
+    const first = createRepository(1);
+    const second = createRepository(2);
+    useAppStore.setState({
+      repositories: [first, second],
+      searchResults: [second],
+      searchFilters: { ...useAppStore.getState().searchFilters, licenses: ['MIT'] },
+    });
+    const previousSearchResults = useAppStore.getState().searchResults;
+
+    const refreshed = [createRepository(1), createRepository(2), createRepository(3)];
+    useAppStore.getState().setRepositories(refreshed);
+
+    expect(useAppStore.getState().searchResults).toBe(previousSearchResults);
+  });
+
   it('resets searchResults to the full list when no search filter is active', () => {
+    // Reset searchFilters to defaults before the test; the license-only test above
+    // may have left licenses set, which would keep hasActiveSearchFilters true.
+    useAppStore.setState({ searchFilters: { ...useAppStore.getState().searchFilters, licenses: [] } });
     const repo = createRepository(1);
     useAppStore.setState({
       repositories: [repo],

--- a/src/store/useAppStore.test.ts
+++ b/src/store/useAppStore.test.ts
@@ -564,6 +564,39 @@ describe('useAppStore repository performance guards', () => {
     expect(notifications).toBe(0);
     expect(useAppStore.getState().analyzingRepositoryIds).toBe(previousAnalyzingIds);
   });
+
+  it('preserves an active search result set when setRepositories runs (Issue #304)', () => {
+    const first = createRepository(1);
+    const second = createRepository(2);
+    useAppStore.setState({
+      repositories: [first, second],
+      searchResults: [second],
+      searchFilters: { ...useAppStore.getState().searchFilters, query: 'repo-2' },
+    });
+    const previousSearchResults = useAppStore.getState().searchResults;
+
+    const refreshed = [createRepository(1), createRepository(2), createRepository(3)];
+    useAppStore.getState().setRepositories(refreshed);
+
+    // The stale searchResults reference is kept so the filtered card (and its
+    // open edit modal) stays mounted; SearchBar recomputes results afterwards.
+    expect(useAppStore.getState().searchResults).toBe(previousSearchResults);
+    expect(useAppStore.getState().repositories).toBe(refreshed);
+  });
+
+  it('resets searchResults to the full list when no search filter is active', () => {
+    const repo = createRepository(1);
+    useAppStore.setState({
+      repositories: [repo],
+      searchResults: [repo],
+      searchFilters: { ...useAppStore.getState().searchFilters, query: '' },
+    });
+
+    const refreshed = [repo, createRepository(2)];
+    useAppStore.getState().setRepositories(refreshed);
+
+    expect(useAppStore.getState().searchResults).toBe(refreshed);
+  });
 });
 
 describe('useAppStore auth localStorage mirror (Issue #259)', () => {

--- a/src/store/useAppStore.test.ts
+++ b/src/store/useAppStore.test.ts
@@ -616,6 +616,29 @@ describe('useAppStore repository performance guards', () => {
 
     expect(useAppStore.getState().searchResults).toBe(refreshed);
   });
+
+  it('preserves an active search result set when addRepository runs (Issue #304)', () => {
+    const existing = createRepository(2);
+    useAppStore.setState({
+      repositories: [existing],
+      searchResults: [existing],
+      searchFilters: { ...useAppStore.getState().searchFilters, query: 'repo-2' },
+    });
+    const previousSearchResults = useAppStore.getState().searchResults;
+
+    useAppStore.getState().addRepository(createRepository(3));
+
+    // Same guard as setRepositories: swapping the full list into searchResults
+    // while filters are active would unmount the filtered card being edited.
+    expect(useAppStore.getState().searchResults).toBe(previousSearchResults);
+    expect(useAppStore.getState().repositories).toHaveLength(2);
+
+    // Without active filters, the full list is published to searchResults.
+    useAppStore.setState({ searchFilters: { ...useAppStore.getState().searchFilters, query: '' } });
+    useAppStore.getState().addRepository(createRepository(4));
+
+    expect(useAppStore.getState().searchResults).toBe(useAppStore.getState().repositories);
+  });
 });
 
 describe('useAppStore auth localStorage mirror (Issue #259)', () => {

--- a/src/utils/repoSearch.ts
+++ b/src/utils/repoSearch.ts
@@ -195,6 +195,7 @@ export function hasActiveSearchFilters(filters: SearchFilters): boolean {
     filters.languages.length > 0 ||
     filters.tags.length > 0 ||
     filters.platforms.length > 0 ||
+    filters.licenses.length > 0 ||
     filters.minStars !== undefined ||
     filters.maxStars !== undefined ||
     filters.isAnalyzed !== undefined ||

--- a/src/utils/repoSearch.ts
+++ b/src/utils/repoSearch.ts
@@ -185,6 +185,28 @@ export function applyRepoFilters<T extends Repository>(
   return sortRepositories(filtered, sortBy, sortOrder);
 }
 
+/**
+ * Check if any search/filter/sort condition is active (non-default).
+ * Used to decide whether to display searchResults or the full repository list.
+ */
+export function hasActiveSearchFilters(filters: SearchFilters): boolean {
+  return (
+    !!filters.query.trim() ||
+    filters.languages.length > 0 ||
+    filters.tags.length > 0 ||
+    filters.platforms.length > 0 ||
+    filters.minStars !== undefined ||
+    filters.maxStars !== undefined ||
+    filters.isAnalyzed !== undefined ||
+    filters.isSubscribed !== undefined ||
+    filters.isEdited !== undefined ||
+    filters.isCategoryLocked !== undefined ||
+    filters.analysisFailed !== undefined ||
+    filters.sortBy !== 'stars' ||
+    filters.sortOrder !== 'desc'
+  );
+}
+
 /** Full text search + filters + optional category + pagination for MCP/API use. */
 export function searchRepositories<T extends Repository>(
   repos: T[],

--- a/src/utils/repositoryMerge.ts
+++ b/src/utils/repositoryMerge.ts
@@ -1,6 +1,7 @@
 import type { Repository } from '../types';
 
 const LOCAL_REPOSITORY_FIELDS: Array<keyof Repository> = [
+  'analysis_error',
   'has_fetched_releases',
   'last_release_fetch_time',
   'ai_summary',
@@ -17,14 +18,28 @@ const LOCAL_REPOSITORY_FIELDS: Array<keyof Repository> = [
   'vector_indexed_at',
 ];
 
-/** Drop the local-only fields from a repo list — the projection the backend
- * actually stores. Used to hash the push payload so the next pull compares
- * against the same raw shape (same class of loop-breaker as the pull path).
+/**
+ * Fields the repository endpoint never stores or returns (client-only state).
+ * This is the projection both sync fingerprints must agree on: the pull side
+ * hashes the backend payload through it, the successful-push side hashes the
+ * store through it, so the next pull sees no change (Issue #304 loop-breaker).
+ */
+export const CLIENT_ONLY_REPOSITORY_FIELDS: ReadonlySet<keyof Repository> = new Set([
+  'forks_count',
+  'forks',
+  'analysis_error',
+  'has_fetched_releases',
+  'last_release_fetch_time',
+]);
+
+/** Drop client-only fields from a repo list, projecting the shape the backend
+ * actually stores/returns. Shared by the pull and push fingerprint paths so
+ * the two hashes always use the same field set.
  */
 export function stripLocalRepositoryFields(repos: Repository[]): Repository[] {
   return repos.map(repo => {
     const stripped: Repository = { ...repo };
-    for (const field of LOCAL_REPOSITORY_FIELDS) {
+    for (const field of CLIENT_ONLY_REPOSITORY_FIELDS) {
       delete (stripped as Record<keyof Repository, unknown>)[field];
     }
     return stripped;

--- a/src/utils/repositoryMerge.ts
+++ b/src/utils/repositoryMerge.ts
@@ -17,6 +17,20 @@ const LOCAL_REPOSITORY_FIELDS: Array<keyof Repository> = [
   'vector_indexed_at',
 ];
 
+/** Drop the local-only fields from a repo list — the projection the backend
+ * actually stores. Used to hash the push payload so the next pull compares
+ * against the same raw shape (same class of loop-breaker as the pull path).
+ */
+export function stripLocalRepositoryFields(repos: Repository[]): Repository[] {
+  return repos.map(repo => {
+    const stripped: Repository = { ...repo };
+    for (const field of LOCAL_REPOSITORY_FIELDS) {
+      delete (stripped as Record<keyof Repository, unknown>)[field];
+    }
+    return stripped;
+  });
+}
+
 export function mergeRepositoriesPreservingLocalMetadata(
   incomingRepositories: Repository[],
   localRepositories: Repository[]


### PR DESCRIPTION
## Fixes

- Fixes #304 — edit modal auto-closes seconds after opening it from a keyword-searched list
- Fixes #309 — scrollbar show/hide toggles page width, causing content jitter (and perceived font clarity changes)

## Root causes

### #304 (search + edit modal auto-close)

1. `repositorySlice.setRepositories` unconditionally overwrote `searchResults` with the full list. Background autoSync fires every 5s, so while a search was active, `App` (which renders `searchResults` when filters are active) received the full list — the visible slice (already clamped to the small search result count) recomputed, the card being edited fell outside it and unmounted.
2. `editModalOpen` is card-local state in `RepositoryCard`, so unmounting the card destroyed the portal-mounted edit modal → "auto close".
3. SearchBar's `performSearch` effect then recomputed results from the new repositories and remounted the card — without the modal.

**Amplifier:** `autoSync` committed `quickHash(merged)` but compared the next poll against the **raw backend** hash. The merge preserves local-only metadata (e.g. `vector_indexed_at`) that the backend never stores, so the hashes never converged → `setRepositories` fired on **every** 5s poll. This also explains why "all categories" view looked fixed (list reads `repositories` directly; stable `key=repo.id` keeps the card mounted) while search reliably reproduced.

### #309 (scrollbar width toggling)

`.scrollbar-on-scroll` used `scrollbar-width: none` at rest and `thin` while scrolling, so the ~8px gutter was repeatedly taken/released — content width shifted and text re-rasterized (perceived font clarity change). The codebase already had the correct constant-gutter pattern (`.category-scrollbar`, `.scrollbar-auto`).

## Changes

- **`src/store/slices/repositorySlice.ts`** — `setRepositories` preserves the `searchResults` reference when `hasActiveSearchFilters` is true; resets to the full list otherwise. SearchBar's effect recomputes from the new data on its own.
- **`src/utils/repoSearch.ts`** — hosts the moved `hasActiveSearchFilters` helper (was a local function in `App.tsx`).
- **`src/App.tsx`** — imports the helper instead of defining it locally.
- **`src/services/autoSync.ts`** — commit `hashes.repos` (raw backend payload) instead of `quickHash(merged)`, cutting the hash non-convergence loop (same class of fix as the earlier `vectorSearchFingerprint` one).
- **`src/index.css`** — `.scrollbar-on-scroll` now uses a constant gutter: `scrollbar-width: thin` + `scrollbar-color: transparent transparent`, toggling only the thumb color while scrolling. All `::-webkit-scrollbar` fallback rules (constant 8px, transparent→colored thumb) kept.

## Tests

- Store: `setRepositories` preserves an active search result set (Issue #304) and resets to the full list when no filter is active.
- New `src/services/autoSync.repoHash.test.ts`: hash-convergence regressions (merge output differs from backend payload when local metadata exists; consecutive pulls of unchanged backend hash apply identically/stably) + `hasActiveSearchFilters` unit cases.

## Validation

- `npm run test:run` — 538 passed / 1 pre-existing unrelated failure (`sessionRepository.test.ts` localStorage test, fails identically on clean `main`)
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run check:boundaries` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 防止仓库同步在数据未变化时重复刷新，提升同步稳定性。
  * 仓库更新或新增时保留有效的搜索、筛选和排序结果；无条件时正确显示完整列表。
  * 改善滚动条显示，滚动时保持页面布局稳定，减少布局跳动。
  * 优化本地仓库信息与同步数据的处理，避免客户端状态被错误覆盖。

* **测试**
  * 新增同步一致性、筛选结果保留及本地数据处理的回归测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->