### PR TITLE
fix(ui): 修复搜索栏盖住顶栏与弹层背景可滚动两个问题

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -56,7 +56,7 @@ export const Header: React.FC = () => {
   const t = (zh: string, en: string) => language === 'zh' ? zh : en;
 
   return (
-    <header className="linear-header sticky top-0 z-40 hd-drag lg:hd-drag relative">
+    <header className="linear-header sticky top-0 z-50 hd-drag lg:hd-drag relative">
       <div className="max-w-[1440px] mx-auto px-4 sm:px-6 lg:px-8">
         <div className="linear-header-inner flex h-14 items-center justify-between">
           {/* Logo and Title */}

--- a/src/index.css
+++ b/src/index.css
@@ -455,6 +455,15 @@ html body[data-scroll-locked] {
   overflow: clip !important;
 }
 
+/* body's overflow never propagates to the viewport (html owns overflow), so the
+   root scroller must be locked directly or the page behind a modal overlay keeps
+   scrolling (scrollbar drag + wheel). hidden — not clip — keeps the viewport a
+   scroll container, so the scroll offset, the sticky header's anchor and the
+   scrollbar-gutter: stable reservation all survive the lock. */
+html:has(body[data-scroll-locked]) {
+  overflow: hidden !important;
+}
+
 /* 窗口滚动条颜色由 --ui-line-strong 等 token 统一驱动（见文件底部 Linear 段落）。 */
 
 


### PR DESCRIPTION
## 问题

1. **仓库页 AI 搜索栏滚动到顶栏位置时会盖住顶栏**
   - 根因：`Header` 为 `sticky top-0 z-40`，而 `SearchBar` 输入行为 `relative z-40`。两者同一层叠级别（z-40），搜索栏在 DOM 中靠后，同层级后者胜出，因此页面滚动使搜索栏进入顶栏区域时直接绘制在顶栏之上。
   - 修复：顶栏提升到 `z-50`。顶栏属于页面 chrome，应始终高于文档流内容；Radix portal 弹层（z-50、挂在 body 末尾）仍按文档顺序盖在顶栏之上，层叠关系不受影响。

2. **仓库问答边栏出现两个滚动条，最右侧滚动条在边栏弹出时仍能滚动遮罩下层的仓库列表**
   - 根因：Radix Dialog 的 `react-remove-scroll` 只把 `overflow` 写在 `body` 上；但本应用视口滚动条属于 `html`（`overflow-y: scroll`），body 的 overflow 不会传播到视口，所以遮罩下层的页面依旧可以被滚动（滚动条拖拽 + 滚轮）。边栏内消息列表自带一条滚动条，加上仍然可用的视口滚动条，视觉上就是“两个滚动条”。
   - 修复：`index.css` 增加 `html:has(body[data-scroll-locked]) { overflow: hidden !important; }`，在任意 Radix 模态打开期间直接锁住真正的根滚动容器。选用 `hidden` 而非 `clip`：hidden 下视口仍是 scroll container，滚动偏移、`position: sticky` 顶栏锚点与 `scrollbar-gutter: stable` 预留槽位在锁定期间全部保持不变，关闭后原位恢复。原有 `body[data-scroll-locked] { overflow: clip }` 规则保留（继续压制库内联写入的 body overflow，避免 body 变成 scroll container 导致 sticky 失锚）。

## 验证

- Playwright E2E（dev server + mock GitHub API，含登录态注入）：**12/12 断言通过**
  - 页面滚动使搜索栏与顶栏重叠时，`elementFromPoint` 命中 header 而非搜索框；header z-index 为 50
  - 打开仓库问答：`data-scroll-locked` 生效、`html` overflow 为 hidden、滚动偏移保持、锁定前后 `clientWidth` 不变（无布局抖动）、在遮罩上滚轮无法滚动背景
  - 关闭后：锁定解除、overflow 恢复 `scroll`、偏移保持、页面可继续滚动
- 有头 Chromium 受控实验确认：`overflow: hidden` 下 `scrollbar-gutter: stable` 的槽位不会塌陷，无需额外补偿
- `npm run typecheck`、`eslint`、`vitest`（65 个文件 / 588 个用例）全部通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 修复弹窗或覆盖层打开时页面仍可通过滚轮或滚动条继续滚动的问题。
  - 保留页面滚动位置、吸顶元素定位及滚动条占位，改善弹窗交互体验。

- **样式**
  - 提升页面顶部导航层级，确保其显示在其他内容和覆盖层之上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->