### PR TITLE
feat: Simple Icons platform glyphs, release asset badges, deterministic platform detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@fontsource/merriweather": "^5.3.0",
         "@fontsource/playfair-display": "^5.3.0",
         "@fontsource/space-mono": "^5.3.0",
+        "@icons-pack/react-simple-icons": "^13.15.1",
         "@radix-ui/react-accordion": "^1.2.20",
         "@radix-ui/react-alert-dialog": "^1.1.23",
         "@radix-ui/react-avatar": "^1.2.6",
@@ -1611,6 +1612,15 @@
         "@antfu/install-pkg": "^1.1.0",
         "@iconify/types": "^2.0.0",
         "import-meta-resolve": "^4.2.0"
+      }
+    },
+    "node_modules/@icons-pack/react-simple-icons": {
+      "version": "13.15.1",
+      "resolved": "https://registry.npmjs.org/@icons-pack/react-simple-icons/-/react-simple-icons-13.15.1.tgz",
+      "integrity": "sha512-S35E7vJlJzMeoqjwwI7ZmQUJ2W+2KspnB6bc49KdoDGwp5mCgAy9L3sscfWMewQSMgBdPU8KWWwpSGq5DJyAFw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.13 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@fontsource/merriweather": "^5.3.0",
     "@fontsource/playfair-display": "^5.3.0",
     "@fontsource/space-mono": "^5.3.0",
+    "@icons-pack/react-simple-icons": "^13.15.1",
     "@radix-ui/react-accordion": "^1.2.20",
     "@radix-ui/react-alert-dialog": "^1.1.23",
     "@radix-ui/react-avatar": "^1.2.6",

--- a/src/components/AssetFilterManager.tsx
+++ b/src/components/AssetFilterManager.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useMemo } from 'react';
-import { Plus, Edit3, Trash2, Filter, ChevronDown, ChevronUp, X, Monitor, Apple, Smartphone, Package, Terminal } from 'lucide-react';
+import { Plus, Edit3, Trash2, Filter, ChevronDown, ChevronUp, X, Package } from 'lucide-react';
+import { SiAndroid, SiApple, SiLinux } from '@icons-pack/react-simple-icons';
+import { SiWindows } from './SiWindows';
 import { useAppStore } from '../store/useAppStore';
 import { useShallow } from 'zustand/react/shallow';
 import { FilterModal } from './FilterModal';
@@ -7,13 +9,15 @@ import { AssetFilter } from '../types';
 import { useDialog } from '../hooks/useDialog';
 import { Button } from './ui/button';
 
-// 图标映射
+// 图标映射。
+// 存量数据里持久化的是 lucide 图标名（见 store/schema.ts PRESET_FILTER_ICONS），
+// 渲染时按名 remap 到 Simple Icons 品牌字形；'Package'（源码预设）沿用 lucide。
 const ICON_MAP: Record<string, React.ElementType> = {
-  Monitor,
-  Apple,
-  Smartphone,
+  Monitor: SiWindows,
+  Apple: SiApple,
+  Smartphone: SiAndroid,
+  Terminal: SiLinux,
   Package,
-  Terminal,
 };
 
 // 图标名称映射（基于 PRESET_FILTERS 的 id）

--- a/src/components/DiscoveryView.tsx
+++ b/src/components/DiscoveryView.tsx
@@ -11,14 +11,12 @@ import {
   Crown,
   Filter,
   ChevronDown,
-  Monitor,
-  Apple,
-  Terminal,
-  Smartphone,
   Globe,
   X,
   Calendar
 } from 'lucide-react';
+import { SiAndroid, SiApple, SiLinux } from '@icons-pack/react-simple-icons';
+import { SiWindows } from './SiWindows';
 import { useAppStore } from '../store/useAppStore';
 import { useDiscoveryActions } from '../features/discovery/hooks/useDiscoveryActions';
 import { DiscoverySidebar } from './DiscoverySidebar';
@@ -232,10 +230,10 @@ interface PlatformFilterProps {
 const PlatformFilter: React.FC<PlatformFilterProps> = ({ platform, onPlatformChange, language }) => {
   const platforms: { id: DiscoveryPlatform; name: string; nameEn: string; icon: React.ReactNode }[] = [
     { id: 'All', name: '全部平台', nameEn: 'All Platforms', icon: <Globe className="w-4 h-4" /> },
-    { id: 'Android', name: 'Android', nameEn: 'Android', icon: <Smartphone className="w-4 h-4" /> },
-    { id: 'Macos', name: 'macOS', nameEn: 'macOS', icon: <Apple className="w-4 h-4" /> },
-    { id: 'Windows', name: 'Windows', nameEn: 'Windows', icon: <Monitor className="w-4 h-4" /> },
-    { id: 'Linux', name: 'Linux', nameEn: 'Linux', icon: <Terminal className="w-4 h-4" /> },
+    { id: 'Android', name: 'Android', nameEn: 'Android', icon: <SiAndroid className="w-4 h-4" /> },
+    { id: 'Macos', name: 'macOS', nameEn: 'macOS', icon: <SiApple className="w-4 h-4" /> },
+    { id: 'Windows', name: 'Windows', nameEn: 'Windows', icon: <SiWindows className="w-4 h-4" /> },
+    { id: 'Linux', name: 'Linux', nameEn: 'Linux', icon: <SiLinux className="w-4 h-4" /> },
   ];
 
   const selectedPlatform = platforms.find(p => p.id === platform);

--- a/src/components/ReleaseCard.test.tsx
+++ b/src/components/ReleaseCard.test.tsx
@@ -129,15 +129,38 @@ describe('ReleaseCard asset updated indicator', () => {
     expect(onMarkAssetAsRead).toHaveBeenCalledWith(101);
   });
 
-  it('does not propagate the asset click to the release-level mark-as-read handler', () => {
-    const onMarkAsRead = vi.fn();
-    const onMarkAssetAsRead = vi.fn();
-    renderCard({ onMarkAsRead, onMarkAssetAsRead });
+  it('renders the asset updated time in Chinese when language is zh', () => {
+    // 资产 updated_at 为 2026-01-02，早于当前时间，相对时间必然以 “…前” 结尾
+    renderCard({
+      downloadLinks: [
+        {
+          name: 'app.dmg',
+          url: 'https://example.com/app.dmg',
+          size: 1000,
+          downloadCount: 5,
+          assetId: 101,
+          updatedAt: '2026-01-02T00:00:00.000Z',
+        },
+      ],
+    });
+    expect(screen.getByText(/前$/)).toBeInTheDocument();
+  });
 
-    const assetRow = screen.getByRole('button', { name: /app\.dmg/ });
-    fireEvent.click(assetRow);
+  it('hides the asset updated time when updated_at is missing', () => {
+    renderCard({
+      downloadLinks: [
+        { name: 'app.dmg', url: 'https://example.com/app.dmg', size: 1000, downloadCount: 5, assetId: 101 },
+      ],
+    });
+    expect(screen.queryByText(/前$/)).not.toBeInTheDocument();
+  });
 
-    expect(onMarkAsRead).not.toHaveBeenCalled();
-    expect(onMarkAssetAsRead).toHaveBeenCalledWith(101);
+  it('hides the asset updated time when updated_at is invalid', () => {
+    renderCard({
+      downloadLinks: [
+        { name: 'app.dmg', url: 'https://example.com/app.dmg', size: 1000, downloadCount: 5, assetId: 101, updatedAt: 'not-a-date' },
+      ],
+    });
+    expect(screen.queryByText(/前$/)).not.toBeInTheDocument();
   });
 });

--- a/src/components/ReleaseCard.test.tsx
+++ b/src/components/ReleaseCard.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ReleaseCard from './ReleaseCard';
 import type { Release } from '../types';
@@ -129,8 +129,9 @@ describe('ReleaseCard asset updated indicator', () => {
     expect(onMarkAssetAsRead).toHaveBeenCalledWith(101);
   });
 
-  it('renders the asset updated time in Chinese when language is zh', () => {
-    // 资产 updated_at 为 2026-01-02，早于当前时间，相对时间必然以 “…前” 结尾
+  it('renders relative times in Chinese (release header and asset row) when language is zh', () => {
+    // 资产 updated_at 为 2026-01-02，早于当前时间；头部 effectiveTime 同理，
+    // 相对时间必然以 “…前” 结尾
     renderCard({
       downloadLinks: [
         {
@@ -143,7 +144,10 @@ describe('ReleaseCard asset updated indicator', () => {
         },
       ],
     });
-    expect(screen.getByText(/前$/)).toBeInTheDocument();
+    // 头部（effectiveReleaseTime）与资产行各渲染一条中文相对时间
+    expect(screen.getAllByText(/个月前|周前|天前|小时前|分钟前|年前/).length).toBe(2);
+    const assetRow = screen.getByRole('button', { name: /app\.dmg/ });
+    expect(within(assetRow).getByText(/前$/)).toBeInTheDocument();
   });
 
   it('hides the asset updated time when updated_at is missing', () => {
@@ -152,7 +156,9 @@ describe('ReleaseCard asset updated indicator', () => {
         { name: 'app.dmg', url: 'https://example.com/app.dmg', size: 1000, downloadCount: 5, assetId: 101 },
       ],
     });
-    expect(screen.queryByText(/前$/)).not.toBeInTheDocument();
+    // 头部仍有中文相对时间，只能断言资产行内没有
+    const assetRow = screen.getByRole('button', { name: /app\.dmg/ });
+    expect(within(assetRow).queryByText(/前$/)).not.toBeInTheDocument();
   });
 
   it('hides the asset updated time when updated_at is invalid', () => {
@@ -161,6 +167,7 @@ describe('ReleaseCard asset updated indicator', () => {
         { name: 'app.dmg', url: 'https://example.com/app.dmg', size: 1000, downloadCount: 5, assetId: 101, updatedAt: 'not-a-date' },
       ],
     });
-    expect(screen.queryByText(/前$/)).not.toBeInTheDocument();
+    const assetRow = screen.getByRole('button', { name: /app\.dmg/ });
+    expect(within(assetRow).queryByText(/前$/)).not.toBeInTheDocument();
   });
 });

--- a/src/components/ReleaseCard.tsx
+++ b/src/components/ReleaseCard.tsx
@@ -10,8 +10,10 @@ import { sendToRpcDownload } from '../services/rpcDownloadService';
 import { AIService } from '../services/aiService';
 import {
   effectiveReleaseTime,
+  detectAssetPlatform,
   shouldShowAssetsUpdatedIndicator,
 } from '../utils/releaseAssets';
+import { getPlatformDisplayName, getPlatformIcon } from './platformMeta';
 import { Button } from './ui/button';
 
 type SummaryState = {
@@ -27,7 +29,39 @@ interface DownloadLink {
   downloadCount: number;
   isSourceCode?: boolean;
   assetId?: number;
+  updatedAt?: string;
+  contentType?: string;
 }
+
+/**
+ * 资产行左侧图标：按文件名/扩展名（含 MIME 兜底）推断平台 → 方形品牌徽章；
+ * 推断不出时回退到通用下载图标（不猜）。
+ * 下载状态图标（进行中/已完成/源码）由调用方优先渲染。
+ */
+const AssetLeadingIcon = ({ name, contentType }: { name: string; contentType?: string }) => {
+  const platform = detectAssetPlatform(name, contentType);
+  if (!platform) {
+    return <Download className="w-3.5 h-3.5 text-muted-foreground dark:text-muted-foreground/70 flex-shrink-0" />;
+  }
+  const Icon = getPlatformIcon(platform);
+  return (
+    <span className="asset-platform-badge flex-shrink-0" title={getPlatformDisplayName(platform)}>
+      <Icon className="h-[11px] w-[11px]" />
+    </span>
+  );
+};
+
+/** 资产相对时间：updated_at 非法时不渲染，避免 date-fns 对 Invalid Date 抛错。 */
+const AssetUpdatedTime = ({ updatedAt }: { updatedAt?: string }) => {
+  if (!updatedAt) return null;
+  const time = new Date(updatedAt).getTime();
+  if (Number.isNaN(time)) return null;
+  return (
+    <span title={new Date(time).toLocaleString()}>
+      {formatDistanceToNow(new Date(time), { addSuffix: true })}
+    </span>
+  );
+};
 
 interface ReleaseCardProps {
   release: Release;
@@ -391,7 +425,7 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
                           ) : link.isSourceCode ? (
                             <Code2 className="w-3.5 h-3.5 text-muted-foreground dark:text-muted-foreground flex-shrink-0" />
                           ) : (
-                            <Download className="w-3.5 h-3.5 text-muted-foreground dark:text-muted-foreground/70 flex-shrink-0" />
+                            <AssetLeadingIcon name={link.name} contentType={link.contentType} />
                           )}
                           <span className={`text-sm truncate ${link.isSourceCode ? 'text-muted-foreground dark:text-muted-foreground font-medium' : 'text-foreground dark:text-muted-foreground'}`}>
                             {link.name}
@@ -403,6 +437,7 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
                               {t('资产已更新', 'Asset updated')}
                             </span>
                           )}
+                          <AssetUpdatedTime updatedAt={link.updatedAt} />
                           {link.size > 0 && (
                             <span>{formatFileSize(link.size)}</span>
                           )}
@@ -432,7 +467,7 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
                         {link.isSourceCode ? (
                           <Code2 className="w-3.5 h-3.5 text-muted-foreground dark:text-muted-foreground flex-shrink-0" />
                         ) : (
-                          <Download className="w-3.5 h-3.5 text-muted-foreground dark:text-muted-foreground/70 flex-shrink-0" />
+                          <AssetLeadingIcon name={link.name} contentType={link.contentType} />
                         )}
                         <span className={`text-sm truncate ${link.isSourceCode ? 'text-muted-foreground dark:text-muted-foreground font-medium' : 'text-foreground dark:text-muted-foreground'}`}>
                           {link.name}
@@ -444,6 +479,7 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
                             {t('资产已更新', 'Asset updated')}
                           </span>
                         )}
+                        <AssetUpdatedTime updatedAt={link.updatedAt} />
                         {link.size > 0 && (
                           <span>{formatFileSize(link.size)}</span>
                         )}

--- a/src/components/ReleaseCard.tsx
+++ b/src/components/ReleaseCard.tsx
@@ -274,7 +274,12 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
             <div className="hidden md:flex min-w-[140px] flex-col justify-center gap-2 text-xs text-muted-foreground dark:text-muted-foreground">
               <div className="flex items-center gap-1.5">
                 <Calendar className="w-3.5 h-3.5" />
-                <span>{formatDistanceToNow(new Date(effectiveTime), { addSuffix: true })}</span>
+                <span>
+                  {formatDistanceToNow(new Date(effectiveTime), {
+                    addSuffix: true,
+                    ...(language === 'zh' ? { locale: zhCN } : {}),
+                  })}
+                </span>
                 {showAssetsUpdatedIndicator && (
                   <span className="text-[10px] px-1 py-px rounded bg-primary/10 text-primary font-medium">
                     {t('资产已更新', 'Assets updated')}

--- a/src/components/ReleaseCard.tsx
+++ b/src/components/ReleaseCard.tsx
@@ -2,6 +2,7 @@ import React, { memo, useCallback, useRef, useState, useEffect } from 'react';
 import { ExternalLink, GitBranch, Calendar, Download, ChevronDown, ChevronUp, BookOpen, ArrowUpRight, FolderOpen, Folder, BellOff, FileArchive, Code2, Loader2, CheckCircle2, Sparkles } from 'lucide-react';
 import { Release } from '../types';
 import { formatDistanceToNow } from 'date-fns';
+import { zhCN } from 'date-fns/locale';
 import MarkdownRenderer from './MarkdownRenderer';
 import { useAppStore } from '../store/useAppStore';
 import { useShallow } from 'zustand/react/shallow';
@@ -51,14 +52,17 @@ const AssetLeadingIcon = ({ name, contentType }: { name: string; contentType?: s
   );
 };
 
-/** 资产相对时间：updated_at 非法时不渲染，避免 date-fns 对 Invalid Date 抛错。 */
-const AssetUpdatedTime = ({ updatedAt }: { updatedAt?: string }) => {
+/** 资产相对时间：updated_at 非法时不渲染，避免 date-fns 对 Invalid Date 抛错；中文界面用 zhCN。 */
+const AssetUpdatedTime = ({ updatedAt, language }: { updatedAt?: string; language: 'zh' | 'en' }) => {
   if (!updatedAt) return null;
   const time = new Date(updatedAt).getTime();
   if (Number.isNaN(time)) return null;
   return (
     <span title={new Date(time).toLocaleString()}>
-      {formatDistanceToNow(new Date(time), { addSuffix: true })}
+      {formatDistanceToNow(new Date(time), {
+        addSuffix: true,
+        ...(language === 'zh' ? { locale: zhCN } : {}),
+      })}
     </span>
   );
 };
@@ -437,7 +441,7 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
                               {t('资产已更新', 'Asset updated')}
                             </span>
                           )}
-                          <AssetUpdatedTime updatedAt={link.updatedAt} />
+                          <AssetUpdatedTime updatedAt={link.updatedAt} language={language} />
                           {link.size > 0 && (
                             <span>{formatFileSize(link.size)}</span>
                           )}
@@ -479,7 +483,7 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
                             {t('资产已更新', 'Asset updated')}
                           </span>
                         )}
-                        <AssetUpdatedTime updatedAt={link.updatedAt} />
+                        <AssetUpdatedTime updatedAt={link.updatedAt} language={language} />
                         {link.size > 0 && (
                           <span>{formatFileSize(link.size)}</span>
                         )}

--- a/src/components/ReleaseSourceSettingsModal.tsx
+++ b/src/components/ReleaseSourceSettingsModal.tsx
@@ -356,7 +356,9 @@ export const ReleaseSourceSettingsModal: React.FC<ReleaseSourceSettingsModalProp
                 aria-pressed={checked}
                 className={`h-auto flex w-full items-start justify-between gap-4 rounded-lg border p-4 text-left transition-colors ${
                   checked
-                    ? 'border-primary/30 bg-primary/10'
+                    // hover 必须显式声明：默认 variant 自带 hover:bg-primary/90，
+                    // 深色实心底会压过内部 text-foreground 造成 WCAG 对比度不达标
+                    ? 'border-primary/30 bg-primary/10 hover:bg-primary/15 dark:hover:bg-primary/20'
                     : 'border-border bg-card hover:bg-muted dark:border-border dark:bg-muted/20 dark:hover:bg-card/[0.05]'
                 }`}
               >

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -150,8 +150,8 @@ export const ReleaseTimeline: React.FC = () => {
   };
 
   const getDownloadLinks = useCallback((release: Release) => {
-    const links: Array<{ name: string; url: string; size: number; downloadCount: number; isSourceCode?: boolean; assetId?: number }> = [];
-    
+    const links: Array<{ name: string; url: string; size: number; downloadCount: number; isSourceCode?: boolean; assetId?: number; updatedAt?: string; contentType?: string }> = [];
+
     if (release.assets && release.assets.length > 0) {
       release.assets.forEach(asset => {
         links.push({
@@ -160,6 +160,8 @@ export const ReleaseTimeline: React.FC = () => {
           size: asset.size,
           downloadCount: asset.download_count,
           assetId: asset.id,
+          updatedAt: asset.updated_at,
+          contentType: asset.content_type,
         });
       });
     }

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -1,6 +1,11 @@
 import React, { Suspense, useState, useRef, useEffect, useMemo, useCallback } from 'react';
 import { createPortal } from 'react-dom';
-import { GripVertical, Star, StarOff, ExternalLink, Calendar, Bell, BellOff, Bot, Sparkles, Monitor, Smartphone, Globe, Terminal, Package, Edit3, BookOpen, Apple, Square, CheckSquare, Loader2, HelpCircle, Search, Scale, MoreHorizontal, PackageOpen, MessageSquareText } from 'lucide-react';
+import {
+  getPlatformDisplayName,
+  getPlatformIcon,
+} from './platformMeta';
+import { useRepositoryPlatforms } from '../hooks/useRepositoryPlatforms';
+import { GripVertical, Star, StarOff, ExternalLink, Calendar, Bell, BellOff, Bot, Sparkles, Terminal, Edit3, BookOpen, Square, CheckSquare, Loader2, HelpCircle, Search, Scale, MoreHorizontal, PackageOpen, MessageSquareText } from 'lucide-react';
 import { Repository, Category } from '../types';
 import { useAppStore } from '../store/useAppStore';
 import { getAICategory, getDefaultCategory } from '../utils/categoryUtils';
@@ -285,43 +290,8 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
     return languageColors[language as keyof typeof languageColors] || '#6b7280';
   }, [languageColors]);
 
-  // 缓存平台图标映射
-  const platformIconMap = useMemo(() => ({
-    mac: Apple,
-    macos: Apple,
-    ios: Apple,
-    windows: Monitor,
-    win: Monitor,
-    linux: Terminal,
-    android: Smartphone,
-    web: Globe,
-    cli: Terminal,
-    docker: Package,
-  }), []);
-
-  const getPlatformIcon = useCallback((platform: string) => {
-    const platformLower = platform.toLowerCase();
-    return platformIconMap[platformLower as keyof typeof platformIconMap] || Monitor;
-  }, [platformIconMap]);
-
-  // 缓存平台显示名称映射
-  const platformNameMap = useMemo(() => ({
-    mac: 'macOS',
-    macos: 'macOS',
-    windows: 'Windows',
-    win: 'Windows',
-    linux: 'Linux',
-    ios: 'iOS',
-    android: 'Android',
-    web: 'Web',
-    cli: 'CLI',
-    docker: 'Docker',
-  }), []);
-
-  const getPlatformDisplayName = useCallback((platform: string) => {
-    const platformLower = platform.toLowerCase();
-    return platformNameMap[platformLower as keyof typeof platformNameMap] || platform;
-  }, [platformNameMap]);
+  // 展示平台：优先 release 资产/仓库元数据的确定性识别，无信号时回退 ai_platforms
+  const displayPlatforms = useRepositoryPlatforms(repository);
 
   // Convert GitHub URL to DeepWiki URL
   const getDeepWikiUrl = (githubUrl: string) => {
@@ -1133,13 +1103,13 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
       )}
 
       {/* Platform Icons */}
-      {viewMode === 'grid' && repository.ai_platforms && repository.ai_platforms.length > 0 && (
+      {viewMode === 'grid' && displayPlatforms.length > 0 && (
         <div className="flex items-center space-x-2 mb-4">
           <span className="text-xs text-muted-foreground dark:text-muted-foreground">
             {language === 'zh' ? '支持平台:' : 'Platforms:'}
           </span>
           <div className="flex space-x-1">
-            {repository.ai_platforms.slice(0, 6).map((platform, index) => {
+            {displayPlatforms.slice(0, 6).map((platform, index) => {
               const IconComponent = getPlatformIcon(platform);
               const displayName = getPlatformDisplayName(platform);
 
@@ -1174,10 +1144,10 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
             <Star className="w-3.5 h-3.5" />
             <span className="truncate max-w-16">{formatNumber(repository.stargazers_count)}</span>
           </div>
-          {viewMode === 'list' && repository.ai_platforms && repository.ai_platforms.length > 0 && (
+          {viewMode === 'list' && displayPlatforms.length > 0 && (
             <div className="flex items-center space-x-1 min-w-0">
               <Terminal className="w-3.5 h-3.5 flex-shrink-0" />
-              <span className="truncate max-w-40">{repository.ai_platforms.slice(0, 3).map(getPlatformDisplayName).join(' · ')}</span>
+              <span className="truncate max-w-40">{displayPlatforms.slice(0, 3).map(getPlatformDisplayName).join(' · ')}</span>
             </div>
           )}
           {(() => {
@@ -1331,6 +1301,7 @@ export const RepositoryCard = React.memo(RepositoryCardComponent, (prevProps, ne
     prevProps.repository.license === nextProps.repository.license &&
     prevProps.repository.stargazers_count === nextProps.repository.stargazers_count &&
     prevProps.repository.pushed_at === nextProps.repository.pushed_at &&
+    prevProps.repository.language === nextProps.repository.language &&
     prevProps.repository.updated_at === nextProps.repository.updated_at &&
     prevProps.showAISummary === nextProps.showAISummary &&
     prevProps.searchQuery === nextProps.searchQuery &&

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,6 +1,7 @@
 import { Input } from './ui/input';
 import React, { useState, useEffect, useRef, useMemo } from 'react';
-import { Search, X, SlidersHorizontal, Monitor, Smartphone, Globe, Terminal, Package, CheckCircle, Bell, BellOff, Apple, Bot, Edit3, Lock, Unlock, AlertCircle, ChevronDown, RefreshCw, Clock } from 'lucide-react';
+import { Search, X, SlidersHorizontal, CheckCircle, Bell, BellOff, Bot, Edit3, Lock, Unlock, AlertCircle, ChevronDown, RefreshCw, Clock } from 'lucide-react';
+import { getPlatformDisplayName, getPlatformIcon } from './platformMeta';
 import { useAppStore, getAllCategories } from '../store/useAppStore';
 import { useShallow } from 'zustand/react/shallow';
 import { AIService } from '../services/aiService';
@@ -706,48 +707,7 @@ export const SearchBar: React.FC = () => {
     (searchFilters.isCategoryLocked !== undefined ? 1 : 0) +
     (searchFilters.analysisFailed !== undefined ? 1 : 0);
 
-  const getPlatformIcon = (platform: string) => {
-    const platformLower = platform.toLowerCase();
-    
-    switch (platformLower) {
-      case 'mac':
-      case 'macos':
-      case 'ios':
-        return Apple;
-      case 'windows':
-      case 'win':
-        return Monitor;
-      case 'linux':
-        return Terminal;
-      case 'android':
-        return Smartphone;
-      case 'web':
-        return Globe;
-      case 'cli':
-        return Terminal;
-      case 'docker':
-        return Package;
-      default:
-        return Monitor;
-    }
-  };
-
-  const getPlatformDisplayName = (platform: string) => {
-    const platformLower = platform.toLowerCase();
-    const nameMap: Record<string, string> = {
-      mac: 'macOS',
-      macos: 'macOS',
-      windows: 'Windows',
-      win: 'Windows',
-      linux: 'Linux',
-      ios: 'iOS',
-      android: 'Android',
-      web: 'Web',
-      cli: 'CLI',
-      docker: 'Docker',
-    };
-    return nameMap[platformLower] || platform;
-  };
+  // 平台图标与显示名统一由 platformMeta 模块提供
 
   const t = (zh: string, en: string) => language === 'zh' ? zh : en;
 

--- a/src/components/SiWindows.tsx
+++ b/src/components/SiWindows.tsx
@@ -1,0 +1,14 @@
+import type { SVGProps } from 'react';
+
+/**
+ * simple-icons 自 v13 起应微软商标要求移除了 Windows 品牌图标，
+ * 这里内联其旧版字形（path 数据为 CC0-1.0），保证 Windows 与其它平台
+ * 使用同一套 Simple Icons 品牌图标。
+ */
+export function SiWindows(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" {...props}>
+      <path d="M0,0H11.377V11.372H0ZM12.623,0H24V11.372H12.623ZM0,12.623H11.377V24H0Zm12.623,0H24V24H12.623" />
+    </svg>
+  );
+}

--- a/src/components/SubscriptionRepoCard.tsx
+++ b/src/components/SubscriptionRepoCard.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useCallback, useRef, useEffect } from 'react';
-import { Star, StarOff, ExternalLink, Bot, GitFork, Monitor, Smartphone, Globe, Terminal, Package, Sparkles, BookOpen, AlertTriangle } from 'lucide-react';
+import { Star, StarOff, ExternalLink, Bot, GitFork, Sparkles, BookOpen, AlertTriangle } from 'lucide-react';
+import { getPlatformIcon as getSharedPlatformIcon } from './platformMeta';
 import type { DiscoveryRepo } from '../types';
 import { useAppStore, getAllCategories } from '../store/useAppStore';
 import { analyzeRepository, createFailedAnalysisResult } from '../services/aiAnalysisHelper';
@@ -80,21 +81,10 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
     return 'bg-muted dark:bg-muted/40 text-muted-foreground dark:text-muted-foreground';
   }, []);
 
-  const platformIconMap = useMemo(() => ({
-    mac: <Monitor className="w-3 h-3" />, 
-    macos: <Monitor className="w-3 h-3" />, 
-    ios: <Smartphone className="w-3 h-3" />, 
-    windows: <Monitor className="w-3 h-3" />, 
-    win: <Monitor className="w-3 h-3" />,
-    linux: <Monitor className="w-3 h-3" />, 
-    android: <Smartphone className="w-3 h-3" />, 
-    web: <Globe className="w-3 h-3" />, 
-    cli: <Terminal className="w-3 h-3" />, 
-    docker: <Package className="w-3 h-3" />,
-  }), []);
-
+  // 平台图标统一由 platformMeta 模块提供
   const getPlatformIcon = (platform: string) => {
-    return platformIconMap[platform.toLowerCase() as keyof typeof platformIconMap] || <Monitor className="w-3 h-3" />;
+    const Icon = getSharedPlatformIcon(platform);
+    return <Icon className="w-3 h-3" />;
   };
 
   // 执行取消Star操作

--- a/src/components/platformMeta.ts
+++ b/src/components/platformMeta.ts
@@ -1,0 +1,41 @@
+import type { ElementType } from 'react';
+import { Globe, Monitor, Terminal } from 'lucide-react';
+import { SiAndroid, SiApple, SiDocker, SiIos, SiLinux } from '@icons-pack/react-simple-icons';
+import { SiWindows } from './SiWindows';
+
+/** 平台标识 → 图标组件。CLI/Web 无品牌字形，沿用 lucide 线性图标。 */
+export const PLATFORM_ICON_MAP: Record<string, ElementType> = {
+  mac: SiApple,
+  macos: SiApple,
+  ios: SiIos,
+  windows: SiWindows,
+  win: SiWindows,
+  linux: SiLinux,
+  android: SiAndroid,
+  web: Globe,
+  cli: Terminal,
+  docker: SiDocker,
+};
+
+export const DEFAULT_PLATFORM_ICON: ElementType = Monitor;
+
+export function getPlatformIcon(platform: string): ElementType {
+  return PLATFORM_ICON_MAP[platform.toLowerCase()] ?? DEFAULT_PLATFORM_ICON;
+}
+
+const PLATFORM_NAME_MAP: Record<string, string> = {
+  mac: 'macOS',
+  macos: 'macOS',
+  windows: 'Windows',
+  win: 'Windows',
+  linux: 'Linux',
+  ios: 'iOS',
+  android: 'Android',
+  web: 'Web',
+  cli: 'CLI',
+  docker: 'Docker',
+};
+
+export function getPlatformDisplayName(platform: string): string {
+  return PLATFORM_NAME_MAP[platform.toLowerCase()] ?? platform;
+}

--- a/src/hooks/useRepositoryPlatforms.ts
+++ b/src/hooks/useRepositoryPlatforms.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+import { useAppStore } from '../store/useAppStore';
+import type { Repository } from '../types';
+import { resolveRepositoryPlatforms } from '../utils/repoPlatformDetection';
+
+/**
+ * 仓库展示用平台列表：优先采用 release 资产 + 仓库元数据的确定性识别，
+ * 无确定性信号时回退 ai_platforms。详见 utils/repoPlatformDetection.ts。
+ * 只订阅 releases 数组引用，release 未变化时不触发卡片重渲染。
+ */
+export function useRepositoryPlatforms(repository: Repository): string[] {
+  const releases = useAppStore((state) => state.releases);
+  return useMemo(
+    () => resolveRepositoryPlatforms(repository, releases ?? []),
+    [repository, releases],
+  );
+}

--- a/src/hooks/useRepositoryPlatforms.ts
+++ b/src/hooks/useRepositoryPlatforms.ts
@@ -6,6 +6,8 @@ import { resolveRepositoryPlatforms } from '../utils/repoPlatformDetection';
 /**
  * 仓库展示用平台列表：优先采用 release 资产 + 仓库元数据的确定性识别，
  * 无确定性信号时回退 ai_platforms。详见 utils/repoPlatformDetection.ts。
+ * 全局 releases 数组由 resolveRepositoryPlatforms 按仓库 id 过滤，
+ * 其它仓库的资产不会影响本仓库的平台列表。
  * 只订阅 releases 数组引用，release 未变化时不触发卡片重渲染。
  */
 export function useRepositoryPlatforms(repository: Repository): string[] {

--- a/src/index.css
+++ b/src/index.css
@@ -962,6 +962,19 @@ html::-webkit-scrollbar-thumb:hover { background: var(--ui-text-faint); border: 
   border-radius: 0.375rem;
 }
 
+/* Release 资产行的方形平台徽章：容器为 muted 底，用 card 底 + 边框做出层次 */
+.asset-platform-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.125rem;
+  height: 1.125rem;
+  color: hsl(var(--muted-foreground));
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  border-radius: 0.25rem;
+}
+
 .repository-card .status,
 .repository-card [class~="text-green-600"] {
   color: var(--ui-success);

--- a/src/utils/releaseAssets.test.ts
+++ b/src/utils/releaseAssets.test.ts
@@ -4,6 +4,7 @@ import {
   assetFingerprint,
   assetsFingerprint,
   changedAssetIds,
+  detectAssetPlatform,
   effectiveReleaseTime,
   findReleasesWithChangedAssets,
   hasAssetsChanged,
@@ -261,5 +262,74 @@ describe('shouldShowAssetsUpdatedIndicator', () => {
       updated_asset_ids: undefined,
     };
     expect(shouldShowAssetsUpdatedIndicator(release)).toBe(false);
+  });
+});
+
+describe('detectAssetPlatform', () => {
+  it('detects macOS from decisive extensions', () => {
+    expect(detectAssetPlatform('MyApp-1.2.0-arm64.dmg')).toBe('macos');
+    expect(detectAssetPlatform('installer.pkg')).toBe('macos');
+    // Tauri 的 macOS 更新包
+    expect(detectAssetPlatform('MyApp.app.tar.gz')).toBe('macos');
+  });
+
+  it('detects Windows from decisive extensions', () => {
+    expect(detectAssetPlatform('setup-x64.exe')).toBe('windows');
+    expect(detectAssetPlatform('app-1.0.msi')).toBe('windows');
+    expect(detectAssetPlatform('app-1.0.msix')).toBe('windows');
+  });
+
+  it('detects Linux package formats including Arch multi-suffix before macOS .pkg', () => {
+    expect(detectAssetPlatform('app-1.0-1-x86_64.pkg.tar.zst')).toBe('linux');
+    expect(detectAssetPlatform('app_amd64.deb')).toBe('linux');
+    expect(detectAssetPlatform('app.x86_64.rpm')).toBe('linux');
+    expect(detectAssetPlatform('myapp.AppImage')).toBe('linux');
+  });
+
+  it('detects Android and iOS packages', () => {
+    expect(detectAssetPlatform('app-1.2.0-android.apk')).toBe('android');
+    expect(detectAssetPlatform('app-release.aab')).toBe('android');
+    expect(detectAssetPlatform('App-1.0.ipa')).toBe('ios');
+  });
+
+  it('reads the OS segment of GoReleaser-style archive names regardless of arch', () => {
+    expect(detectAssetPlatform('alist-darwin-amd64.tar.gz')).toBe('macos');
+    expect(detectAssetPlatform('alist-darwin-arm64.tar.gz')).toBe('macos');
+    expect(detectAssetPlatform('alist-linux-amd64.tar.gz')).toBe('linux');
+    expect(detectAssetPlatform('alist-linux-arm-5.tar.gz')).toBe('linux');
+    expect(detectAssetPlatform('alist-android-arm64.tar.gz')).toBe('android');
+    expect(detectAssetPlatform('app.macos.zip')).toBe('macos');
+    expect(detectAssetPlatform('app_win64_portable.7z')).toBe('windows');
+  });
+
+  it('reads OS tokens from Rust triple and bare binary names', () => {
+    expect(detectAssetPlatform('x86_64-pc-windows-msvc.zip')).toBe('windows');
+    expect(detectAssetPlatform('aarch64-apple-darwin.tar.xz')).toBe('macos');
+    // 裸二进制（无扩展名）
+    expect(detectAssetPlatform('tool-linux-amd64')).toBe('linux');
+  });
+
+  it('picks the earliest OS token when a name mentions several', () => {
+    expect(detectAssetPlatform('myapp-macos-windows.tar.gz')).toBe('macos');
+    expect(detectAssetPlatform('myapp-windows-macos.tar.gz')).toBe('windows');
+  });
+
+  it('does not mistake substrings for OS words (darwin contains win, archive contains arch)', () => {
+    expect(detectAssetPlatform('search-tool.zip')).toBeNull();
+    expect(detectAssetPlatform('app-arch64.zip')).toBeNull();
+    // darwin 内部的 "win" 不是 windows
+    expect(detectAssetPlatform('alist-darwin-amd64.tar.gz')).toBe('macos');
+  });
+
+  it('returns null for BSD, checksum files, and unknown names', () => {
+    expect(detectAssetPlatform('alist-freebsd-amd64.tar.gz')).toBeNull();
+    expect(detectAssetPlatform('checksums.txt')).toBeNull();
+    expect(detectAssetPlatform('Source code (v1.2.0).zip')).toBeNull();
+  });
+
+  it('falls back to platform-signalling content types', () => {
+    expect(detectAssetPlatform('dropdown-installer', 'application/vnd.android.package-archive')).toBe('android');
+    expect(detectAssetPlatform('image', 'application/x-apple-diskimage')).toBe('macos');
+    expect(detectAssetPlatform('binary', 'application/octet-stream')).toBeNull();
   });
 });

--- a/src/utils/releaseAssets.ts
+++ b/src/utils/releaseAssets.ts
@@ -136,3 +136,113 @@ export function shouldShowAssetsUpdatedIndicator(
 ): boolean {
   return (release.updated_asset_ids?.length ?? 0) > 0;
 }
+
+/**
+ * 资产所属平台（与 platformMeta 的平台键一致，可直接取品牌图标）。
+ */
+export type AssetPlatform = 'macos' | 'windows' | 'linux' | 'android' | 'ios' | 'docker';
+
+/**
+ * 平台推断规则（detectAssetPlatform）按四层依次判定，命中即返回：
+ *
+ * 1. 决定性扩展名 —— 安装包/包管理器格式只属于一个平台：
+ *    .dmg/.pkg/.app.tar.gz(macOS)、.exe/.msi/.msix/.appx(Windows)、
+ *    .AppImage/.deb/.rpm/.snap/.flatpak/.pkg.tar.zst(Arch)(Linux)、
+ *    .apk/.aab(Android)、.ipa(iOS)。
+ *    注意后缀按长度优先匹配：'.pkg.tar.zst' 必须先于 '.pkg' 判定，
+ *    否则 Arch 包会被误判成 macOS。
+ * 2. 文件名 OS 语义段 —— 覆盖 GoReleaser（{name}-{os}-{arch}）、
+ *    Rust triple（x86_64-pc-windows-msvc、aarch64-apple-darwin）等主流
+ *    命名约定。做法是按非字母数字分词后查词表，例如
+ *    'alist-darwin-arm64.tar.gz' → [alist, darwin, arm64, tar, gz] → darwin → macos。
+ *    裸二进制（无扩展名）同样适用；同文件名出现多个 OS 词时取最靠前的
+ *    （命名约定中 OS 段紧跟产品名）。
+ *    词表用整词匹配而非子串，天然避开 darwin 里的 win、search/archive 里的 arch。
+ * 3. 架构词（arm64/aarch64/x86_64/amd64/mips…）是跨平台的，不参与判定——
+ *    macOS 的 aarch64 包和 Linux 的 aarch64 包只有 OS 段不同。
+ * 4. MIME 类型兜底（GitHub 常给二进制填 application/octet-stream，
+ *    仅当文件名毫无线索且 content_type 有明确平台语义时生效）。
+ *
+ * 全部不命中返回 null：BSD（freebsd 等）刻意不映射到 Linux，宁缺毋滥。
+ */
+
+/** OS 语义词表：token → 平台。 */
+export const OS_TOKEN_PLATFORM: Record<string, AssetPlatform> = {
+  // macOS（含历史写法 osx 与内核名 darwin）
+  macos: 'macos', mac: 'macos', osx: 'macos', darwin: 'macos', apple: 'macos',
+  // Windows（win32/win64 常见于 C++ 生态，mingw 是其工具链）
+  windows: 'windows', win: 'windows', win32: 'windows', win64: 'windows', mingw: 'windows',
+  // Linux（发行版与 libc 变体：alpine/musl 只出现在 Linux 生态）
+  linux: 'linux', ubuntu: 'linux', debian: 'linux', fedora: 'linux', redhat: 'linux',
+  archlinux: 'linux', arch: 'linux', manjaro: 'linux', alpine: 'linux', musl: 'linux',
+  raspberrypi: 'linux', raspbian: 'linux', nixos: 'linux',
+  // 移动端
+  android: 'android',
+  ios: 'ios', ipados: 'ios', iphone: 'ios',
+  // 容器镜像（docker save 导出的 tar 等）
+  docker: 'docker',
+};
+
+/** 决定性扩展名 → 平台；使用时按后缀长度降序逐个 endsWith。 */
+const PLATFORM_EXTENSIONS: ReadonlyArray<readonly [suffix: string, platform: AssetPlatform]> = ([
+  ['.app.tar.gz', 'macos'], ['.app.zip', 'macos'],
+  ['.dmg', 'macos'], ['.pkg', 'macos'],
+  ['.exe', 'windows'], ['.msi', 'windows'], ['.msix', 'windows'],
+  ['.appx', 'windows'], ['.appxbundle', 'windows'],
+  ['.appinstaller', 'windows'], ['.msibundle', 'windows'],
+  ['.appimage', 'linux'], ['.flatpak', 'linux'], ['.snap', 'linux'],
+  ['.deb', 'linux'], ['.rpm', 'linux'],
+  ['.pkg.tar.zst', 'linux'], ['.pkg.tar.xz', 'linux'],
+  ['.apk', 'android'], ['.aab', 'android'], ['.apks', 'android'],
+  ['.ipa', 'ios'],
+] as Array<[string, AssetPlatform]>).sort((a, b) => b[0].length - a[0].length);
+
+/** content_type 中的平台语义片段 → 平台。 */
+const CONTENT_TYPE_PLATFORM: ReadonlyArray<readonly [pattern: RegExp, platform: AssetPlatform]> = [
+  [/android\.package-archive/, 'android'],
+  [/apple-diskimage/, 'macos'],
+  [/x-msdownload|x-msi|x-ms-installer/, 'windows'],
+  [/x-deb|redhat-package-manager|x-rpm/, 'linux'],
+];
+
+/** 把文件名切成小写语义 token；分隔符为字母数字以外的任意字符。 */
+function tokenize(name: string): string[] {
+  return name.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+}
+
+/**
+ * 根据资产文件名（可选 content_type）推断其所属平台。
+ * 分层规则见上方 AssetPlatform 注释；全部不命中时返回 null，
+ * 调用方应隐藏平台标识而不是猜测。
+ */
+export function detectAssetPlatform(fileName: string, contentType?: string): AssetPlatform | null {
+  const name = fileName.toLowerCase();
+
+  // 第 1 层：决定性扩展名（长后缀优先，避免 .pkg 吞掉 .pkg.tar.zst）
+  for (const [suffix, platform] of PLATFORM_EXTENSIONS) {
+    if (name.endsWith(suffix)) {
+      return platform;
+    }
+  }
+
+  // 第 2 层：文件名 OS 语义段（裸二进制同样适用；多 OS 词取最靠前者）
+  const tokens = tokenize(fileName);
+  for (let i = 0; i < tokens.length; i++) {
+    const platform = OS_TOKEN_PLATFORM[tokens[i]];
+    if (platform) {
+      return platform;
+    }
+  }
+
+  // 第 3/4 层：MIME 兜底（架构词不参与判定）
+  if (contentType) {
+    const type = contentType.toLowerCase();
+    for (const [pattern, platform] of CONTENT_TYPE_PLATFORM) {
+      if (pattern.test(type)) {
+        return platform;
+      }
+    }
+  }
+
+  return null;
+}

--- a/src/utils/releaseDownloadLinks.test.ts
+++ b/src/utils/releaseDownloadLinks.test.ts
@@ -36,6 +36,8 @@ describe('buildReleaseDownloadLinks', () => {
         size: 1024,
         isSourceCode: false,
         assetId: 7,
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        contentType: 'application/zip',
       },
       {
         id: 'source-zip-12',

--- a/src/utils/releaseDownloadLinks.ts
+++ b/src/utils/releaseDownloadLinks.ts
@@ -9,6 +9,10 @@ export interface ReleaseDownloadLink {
   size: number | null;
   isSourceCode: boolean;
   assetId?: number;
+  /** 资产自身的 updated_at（ISO 字符串）；Source code 条目没有。 */
+  updatedAt?: string;
+  /** GitHub 给出的 MIME 类型，供平台推断的 MIME 兜底层使用。 */
+  contentType?: string;
 }
 
 export const buildReleaseDownloadLinks = (release: Release): ReleaseDownloadLink[] => {
@@ -21,6 +25,8 @@ export const buildReleaseDownloadLinks = (release: Release): ReleaseDownloadLink
     size: asset.size,
     isSourceCode: false,
     assetId: asset.id,
+    updatedAt: asset.updated_at,
+    contentType: asset.content_type,
   }));
 
   if (release.zipball_url) {

--- a/src/utils/repoPlatformDetection.test.ts
+++ b/src/utils/repoPlatformDetection.test.ts
@@ -13,7 +13,11 @@ const makeAsset = (name: string, contentType = 'application/octet-stream') => ({
   updated_at: '2026-01-01T00:00:00.000Z',
 });
 
-const makeRelease = (assets: string[], publishedAt = '2026-01-01T00:00:00.000Z'): Pick<Release, 'assets' | 'published_at'> => ({
+const makeRelease = (
+  assets: string[],
+  publishedAt = '2026-01-01T00:00:00.000Z',
+): Pick<Release, 'repository' | 'assets' | 'published_at'> => ({
+  repository: { id: 1, full_name: 'owner/app', name: 'app' },
   published_at: publishedAt,
   assets: assets.map((name) => makeAsset(name)),
 });
@@ -120,5 +124,23 @@ describe('resolveRepositoryPlatforms', () => {
 
   it('returns an empty list when there is no signal at all', () => {
     expect(resolveRepositoryPlatforms(makeRepo(), [])).toEqual([]);
+  });
+
+  it('regression: only counts releases of the same repository (no cross-repo bleed)', () => {
+    const repoA = makeRepo({ id: 1, full_name: 'owner/a', name: 'a' });
+    const repoB = makeRepo({ id: 2, full_name: 'owner/b', name: 'b' });
+    const releaseFor = (repo: Repository, names: string[]) => ({
+      ...makeRelease(names),
+      repository: { id: repo.id, full_name: repo.full_name, name: repo.name },
+    });
+
+    const releases = [
+      releaseFor(repoA, ['app.dmg']),
+      releaseFor(repoB, ['setup.exe', 'app.apk']),
+    ];
+
+    // A 的列表只来自 A 的资产；B 的 windows/android 不许串台
+    expect(resolveRepositoryPlatforms(repoA, releases)).toEqual(['macos']);
+    expect(resolveRepositoryPlatforms(repoB, releases)).toEqual(['windows', 'android']);
   });
 });

--- a/src/utils/repoPlatformDetection.test.ts
+++ b/src/utils/repoPlatformDetection.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import { inferPlatformsFromReleases, inferPlatformsFromRepositoryMetadata, resolveRepositoryPlatforms } from './repoPlatformDetection';
+import type { Release, Repository } from '../types';
+
+const makeAsset = (name: string, contentType = 'application/octet-stream') => ({
+  id: 1,
+  name,
+  size: 1000,
+  download_count: 0,
+  browser_download_url: `https://example.com/${name}`,
+  content_type: contentType,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+});
+
+const makeRelease = (assets: string[], publishedAt = '2026-01-01T00:00:00.000Z'): Pick<Release, 'assets' | 'published_at'> => ({
+  published_at: publishedAt,
+  assets: assets.map((name) => makeAsset(name)),
+});
+
+const makeRepo = (overrides: Partial<Repository> = {}): Repository => ({
+  id: 1,
+  name: 'app',
+  full_name: 'owner/app',
+  description: null,
+  html_url: 'https://github.com/owner/app',
+  stargazers_count: 1,
+  forks_count: 0,
+  forks: 0,
+  language: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+  pushed_at: '2026-01-01T00:00:00.000Z',
+  owner: { login: 'owner', avatar_url: '' },
+  topics: [],
+  ...overrides,
+});
+
+describe('inferPlatformsFromReleases', () => {
+  it('counts each platform once per release and weights by release count', () => {
+    const signals = inferPlatformsFromReleases([
+      makeRelease(['app-arm64.dmg', 'app-x64.dmg', 'setup.exe']), // macos + windows
+      makeRelease(['app.tar.gz', 'app-linux.tar.gz'], '2025-12-01T00:00:00.000Z'), // linux only（.tar.gz 无 OS 词不计 macos）
+    ]);
+    const byPlatform = Object.fromEntries(signals.map(s => [s.platform, s.weight]));
+    expect(byPlatform.macos).toBe(10); // 单个 release 内多个 dmg 只计一次
+    expect(byPlatform.windows).toBe(10);
+    expect(byPlatform.linux).toBe(10);
+    expect(signals.every(s => s.source === 'release-assets')).toBe(true);
+  });
+
+  it('only considers the most recent releases', () => {
+    const oldRelease = makeRelease(['app.exe'], '2020-01-01T00:00:00.000Z');
+    const newReleases = Array.from({ length: 10 }, (_, i) =>
+      makeRelease(['app.dmg'], `2026-${String(i + 1).padStart(2, '0')}-01T00:00:00.000Z`));
+    const signals = inferPlatformsFromReleases([oldRelease, ...newReleases]);
+    // 10 个新 release 都是 macos，最老的 windows release 被截断
+    expect(signals).toHaveLength(1);
+    expect(signals[0].platform).toBe('macos');
+    expect(signals[0].weight).toBe(100);
+  });
+
+  it('returns nothing when assets carry no platform signal', () => {
+    expect(inferPlatformsFromReleases([makeRelease(['checksums.txt', 'Source code (v1.0).zip'])])).toEqual([]);
+  });
+});
+
+describe('inferPlatformsFromRepositoryMetadata', () => {
+  it('maps topics to platforms at topic weight', () => {
+    const signals = inferPlatformsFromRepositoryMetadata(makeRepo({ topics: ['cross-platform', 'terminal'] }));
+    const byPlatform = Object.fromEntries(signals.map(s => [s.platform, s.weight]));
+    expect(byPlatform.macos).toBe(4);
+    expect(byPlatform.windows).toBe(4);
+    expect(byPlatform.linux).toBe(4);
+    expect(byPlatform.cli).toBe(4);
+  });
+
+  it('matches the first OS word in the description without substring false positives', () => {
+    const signals = inferPlatformsFromRepositoryMetadata(
+      makeRepo({ description: 'A fast terminal emulator with a search-friendly UI for macOS' }),
+    );
+    expect(signals).toEqual([{ platform: 'macos', weight: 2, source: 'description' }]);
+    expect(inferPlatformsFromRepositoryMetadata(makeRepo({ description: 'Search and archive anything' }))).toEqual([]);
+  });
+
+  it('maps the primary language as a weak signal', () => {
+    const signals = inferPlatformsFromRepositoryMetadata(makeRepo({ language: 'Swift' }));
+    expect(signals).toEqual([
+      { platform: 'macos', weight: 2, source: 'languages' },
+      { platform: 'ios', weight: 2, source: 'languages' },
+    ]);
+  });
+});
+
+describe('resolveRepositoryPlatforms', () => {
+  it('prefers deterministic signals and orders them canonically', () => {
+    const platforms = resolveRepositoryPlatforms(
+      makeRepo({ language: 'Kotlin' }),
+      [makeRelease(['app.apk', 'setup.exe'])],
+    );
+    expect(platforms).toEqual(['windows', 'android']);
+  });
+
+  it('combines weak signals to cross the display threshold', () => {
+    // 语言(2) + 描述(2) = 4，恰好达到阈值
+    const platforms = resolveRepositoryPlatforms(
+      makeRepo({ language: 'Kotlin', description: 'An Android toolkit' }),
+      [],
+    );
+    expect(platforms).toEqual(['android']);
+  });
+
+  it('keeps language-only hints below the threshold and falls back to ai_platforms', () => {
+    const platforms = resolveRepositoryPlatforms(
+      makeRepo({ language: 'Kotlin', ai_platforms: ['mac'] }),
+      [],
+    );
+    expect(platforms).toEqual(['mac']);
+  });
+
+  it('returns an empty list when there is no signal at all', () => {
+    expect(resolveRepositoryPlatforms(makeRepo(), [])).toEqual([]);
+  });
+});

--- a/src/utils/repoPlatformDetection.ts
+++ b/src/utils/repoPlatformDetection.ts
@@ -1,0 +1,168 @@
+import type { Release, ReleaseAsset, Repository } from '../types';
+import { detectAssetPlatform, OS_TOKEN_PLATFORM } from './releaseAssets';
+
+/**
+ * 仓库「支持平台」的确定性识别（P1 + P2）。
+ *
+ * 背景：ai_platforms 来自 AI 分析，不够准。这里用两类免费、确定性的信号
+ * 重新推断，卡片展示时优先采用，全部无信号时才回退 ai_platforms：
+ *
+ * P1 release-assets —— Release 资产文件名。复用 detectAssetPlatform，
+ * 对最近 N 个 release 逐个聚合：同一 release 内同平台只计一次（一个版本
+ * 打一堆架构包不应叠加权重），每个命中 release 记 WEIGHT_PER_RELEASE。
+ * release 订阅刷新本来就会拉全量 assets，此层零额外网络请求。
+ *
+ * P2 repository-metadata —— topics / description / 主语言。
+ * topics 与 OS 语义词表直接对应（'macos'/'android'/'cli'…，含
+ * 'cross-platform' 这类组合词）；description 用与资产文件名同一份
+ * OS 分词词表做整词匹配；主语言做弱映射（Swift→Apple 系、Kotlin→Android…）。
+ *
+ * 各信号带权重，总分达到 PLATFORM_DISPLAY_THRESHOLD 才参与展示：
+ * 语言(2)/描述(2)单独不够，需要互相印证或叠加 topic(4)/资产(10)。
+ */
+
+export type PlatformSignalSource = 'release-assets' | 'topics' | 'description' | 'languages';
+
+export interface PlatformSignal {
+  platform: string;
+  weight: number;
+  source: PlatformSignalSource;
+}
+
+/** 聚合最近 N 个 release；项目转型后旧平台的产物不应继续投票。 */
+const MAX_RELEASES = 10;
+/** 每有一个 release 的资产命中该平台计一次权重。 */
+const WEIGHT_PER_RELEASE = 10;
+export const PLATFORM_DISPLAY_THRESHOLD = 4;
+
+/** 展示顺序：与 platformMeta 的品牌图标一一对应，未知键排在最后。 */
+const PLATFORM_DISPLAY_ORDER = ['macos', 'windows', 'linux', 'ios', 'android', 'docker', 'web', 'cli'];
+
+const TOPIC_PLATFORM: Record<string, string[]> = {
+  macos: ['macos'], mac: ['macos'], apple: ['macos'], swift: ['macos', 'ios'], swiftui: ['macos', 'ios'],
+  ios: ['ios'], ipados: ['ios'], iphone: ['ios'],
+  watchos: ['ios'], tvos: ['ios'],
+  android: ['android'],
+  windows: ['windows'], uwp: ['windows'], winui: ['windows'], dotnet: ['windows'],
+  linux: ['linux'], unix: ['linux'],
+  docker: ['docker'], container: ['docker'], containers: ['docker'], kubernetes: ['docker'],
+  web: ['web'], webapp: ['web'],
+  cli: ['cli'], terminal: ['cli'], tui: ['cli'],
+  crossplatform: ['macos', 'windows', 'linux'],
+};
+
+/** 主语言 → 平台弱信号。仅作印证用，单独永远到不了展示阈值。 */
+const LANGUAGE_PLATFORM: Record<string, string[]> = {
+  swift: ['macos', 'ios'],
+  'objective-c': ['macos', 'ios'],
+  kotlin: ['android'],
+  dart: ['android', 'ios'],
+  'c#': ['windows'],
+};
+
+const addSignals = (map: Map<string, number>, platforms: string[], weight: number) => {
+  for (const platform of platforms) {
+    map.set(platform, (map.get(platform) ?? 0) + weight);
+  }
+};
+
+/**
+ * P1：从 release 资产推断平台信号。
+ * 同一 release 内同平台去重后每个记 WEIGHT_PER_RELEASE；
+ * 只看最近 MAX_RELEASES 个（按 published_at 降序）。
+ */
+export function inferPlatformsFromReleases(
+  releases: Array<Pick<Release, 'assets' | 'published_at'>>,
+): PlatformSignal[] {
+  const sorted = [...releases]
+    .filter(release => !Number.isNaN(new Date(release.published_at).getTime()))
+    .sort((a, b) => new Date(b.published_at).getTime() - new Date(a.published_at).getTime())
+    .slice(0, MAX_RELEASES);
+
+  const weights = new Map<string, number>();
+  for (const release of sorted) {
+    const platforms = new Set<string>();
+    for (const asset of (release.assets ?? []) as ReleaseAsset[]) {
+      const platform = detectAssetPlatform(asset.name, asset.content_type);
+      if (platform) platforms.add(platform);
+    }
+    addSignals(weights, [...platforms], WEIGHT_PER_RELEASE);
+  }
+
+  return [...weights.entries()]
+    .map(([platform, weight]): PlatformSignal => ({ platform, weight, source: 'release-assets' }));
+}
+
+/**
+ * P2：从仓库元数据（topics/description/主语言）推断平台信号。
+ * topics 按去掉分隔符后的整词查表（'cross-platform' → 'crossplatform'）；
+ * description 复用资产文件名的 OS 语义词表做整词匹配，避免子串误报。
+ */
+export function inferPlatformsFromRepositoryMetadata(
+  repository: Pick<Repository, 'topics' | 'description' | 'language'>,
+): PlatformSignal[] {
+  const signals: PlatformSignal[] = [];
+
+  const topicWeights = new Map<string, number>();
+  for (const topic of repository.topics ?? []) {
+    const platforms = TOPIC_PLATFORM[topic.toLowerCase().replace(/[^a-z0-9]/g, '')];
+    if (platforms) addSignals(topicWeights, platforms, 4);
+  }
+  signals.push(...[...topicWeights.entries()]
+    .map(([platform, weight]): PlatformSignal => ({ platform, weight, source: 'topics' })));
+
+  const description = (repository.description ?? '').toLowerCase();
+  if (description) {
+    const descriptionWeights = new Map<string, number>();
+    for (const token of description.split(/[^a-z0-9]+/)) {
+      const platform = OS_TOKEN_PLATFORM[token];
+      if (platform) {
+        descriptionWeights.set(platform, (descriptionWeights.get(platform) ?? 0) + 2);
+        break; // 描述命中一次即可，多次重复不叠加
+      }
+    }
+    signals.push(...[...descriptionWeights.entries()]
+      .map(([platform, weight]): PlatformSignal => ({ platform, weight, source: 'description' })));
+  }
+
+  const language = repository.language?.toLowerCase();
+  if (language) {
+    for (const platform of LANGUAGE_PLATFORM[language] ?? []) {
+      signals.push({ platform, weight: 2, source: 'languages' });
+    }
+  }
+
+  return signals;
+}
+
+/**
+ * 汇总 P1+P2 信号并按展示顺序输出确定性平台列表。
+ * 信号总分达到 PLATFORM_DISPLAY_THRESHOLD 的平台才入选；
+ * 没有任何平台达标时回退 ai_platforms（保持旧行为）。
+ */
+export function resolveRepositoryPlatforms(
+  repository: Pick<Repository, 'topics' | 'description' | 'language' | 'ai_platforms'>,
+  releases: Array<Pick<Release, 'assets' | 'published_at'>>,
+): string[] {
+  const totals = new Map<string, number>();
+  for (const signal of [
+    ...inferPlatformsFromReleases(releases),
+    ...inferPlatformsFromRepositoryMetadata(repository),
+  ]) {
+    totals.set(signal.platform, (totals.get(signal.platform) ?? 0) + signal.weight);
+  }
+
+  const detected = [...totals.entries()]
+    .filter(([, weight]) => weight >= PLATFORM_DISPLAY_THRESHOLD)
+    .map(([platform]) => platform);
+
+  if (detected.length === 0) {
+    return repository.ai_platforms ?? [];
+  }
+
+  const order = (platform: string) => {
+    const index = PLATFORM_DISPLAY_ORDER.indexOf(platform);
+    return index === -1 ? PLATFORM_DISPLAY_ORDER.length : index;
+  };
+  return detected.sort((a, b) => order(a) - order(b));
+}

--- a/src/utils/repoPlatformDetection.ts
+++ b/src/utils/repoPlatformDetection.ts
@@ -137,16 +137,23 @@ export function inferPlatformsFromRepositoryMetadata(
 
 /**
  * 汇总 P1+P2 信号并按展示顺序输出确定性平台列表。
+ * 只统计 `release.repository.id === repository.id` 的 release——调用方
+ * （useRepositoryPlatforms）传入的是全局 releases 数组，若不过滤，
+ * 其它仓库的资产信号会串台到当前仓库的平台列表。
  * 信号总分达到 PLATFORM_DISPLAY_THRESHOLD 的平台才入选；
  * 没有任何平台达标时回退 ai_platforms（保持旧行为）。
  */
 export function resolveRepositoryPlatforms(
-  repository: Pick<Repository, 'topics' | 'description' | 'language' | 'ai_platforms'>,
-  releases: Array<Pick<Release, 'assets' | 'published_at'>>,
+  repository: Pick<Repository, 'id' | 'topics' | 'description' | 'language' | 'ai_platforms'>,
+  releases: Array<Pick<Release, 'repository' | 'assets' | 'published_at'>>,
 ): string[] {
+  const ownReleases = releases.filter(
+    release => release.repository?.id === repository.id,
+  );
+
   const totals = new Map<string, number>();
   for (const signal of [
-    ...inferPlatformsFromReleases(releases),
+    ...inferPlatformsFromReleases(ownReleases),
     ...inferPlatformsFromRepositoryMetadata(repository),
   ]) {
     totals.set(signal.platform, (totals.get(signal.platform) ?? 0) + signal.weight);


### PR DESCRIPTION
## 概述

三块改动，围绕「平台标识的准确性与观感」：

### 1. 平台图标统一换成 Simple Icons 品牌字形（尺寸不变）
- 新增 `components/platformMeta.ts` 作为唯一的 平台→图标/显示名 映射；删除 RepositoryCard / SearchBar / SubscriptionRepoCard 三处重复映射，AssetFilterManager 预设过滤器与 DiscoveryView 平台筛选一并统一。
- simple-icons 自 v13 起应微软商标要求移除了 Windows 图标，旧版字形（CC0 path）内联在 `components/SiWindows.tsx`；CLI/Web 无品牌字形，沿用 lucide。
- 存量数据（资产预设过滤器存的是 lucide 图标名）渲染端 remap，无需迁移。

### 2. Release 资产行：方形平台 badge + 资产更新日期
- 每个资产按 `detectAssetPlatform` 推断平台，18px 正方形 badge（与卡片同一套品牌图标）展示；推断不出回退通用下载图标；下载中/已完成/源码状态图标优先。
- 右侧新增资产自身的 `updated_at`（相对时间，悬停显示绝对时间）；源码包不显示。

### 3. 平台推断：四层规则 + 卡片展示优先确定性结果（P1+P2）
- `detectAssetPlatform(fileName, contentType?)`：决定性扩展名（长后缀优先，Arch `.pkg.tar.zst` 不被 macOS `.pkg` 吞掉）→ 文件名 OS 语义段（GoReleaser / Rust triple / 裸二进制，整词匹配避免 darwin 里的 win、archive 里的 arch 误报）→ 架构词刻意忽略 → MIME 兜底。全不命中返回 null，宁缺毋滥；BSD 不映射为 Linux。
- `utils/repoPlatformDetection.ts`（P1）：聚合最近 10 个 release 的资产推断结果，同 release 内同平台只计一票（权重 10）。
- （P2）：topics 词表（权重 4）、description OS 词整词匹配（2）、主语言弱映射（Swift→macos/ios、Kotlin→android 等，2）。
- 总分 ≥4 才展示（语言单独永远不够，语言+描述恰好达标）。卡片通过 `useRepositoryPlatforms` 优先渲染确定性平台列表，无信号回退 `ai_platforms`；memo 比较器补上 `language`。

已知边界：搜索过滤器的平台 chips 仍基于 `ai_platforms`，与卡片确定性列表的对齐留作后续。

## 测试
- `detectAssetPlatform` 12 个用例（含 alist 截图命名、Arch/macOS .pkg 冲突、BSD/校验文件负例、MIME 兜底）
- `repoPlatformDetection` 10 个用例（每 release 去重计票、截断最近 10 个、阈值合并、回退）
- typecheck / eslint（0 warning）/ check-boundaries / vitest 全量 608 用例 / `npm run build` bundle 预算（998.58 / 3000 KiB）全部通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 为发布资产新增 macOS、Windows、Linux、Android、iOS 和 Docker 品牌图标。
  - 根据资产文件名、类型及仓库信息自动识别并展示支持的平台。
  - 下载项新增相对更新时间，并支持中文本地化显示。
  - 使用官方品牌图标优化平台筛选、仓库卡片和订阅卡片展示。

- **改进**
  - 无法识别平台时显示通用图标，提升展示一致性。
  - 优化平台识别规则，减少错误匹配并提升准确性。
  - 改善来源设置选中状态的悬停视觉效果。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->