### PR TITLE
ci(docker)+fix(release): 升级 Docker Actions 至 Node 24，统一 Release 资产平台图标

### DIFF
--- a/.github/workflows/docker-publish-frontend.yml
+++ b/.github/workflows/docker-publish-frontend.yml
@@ -36,13 +36,13 @@ jobs:
         run: node scripts/check-release-version.cjs "$GITHUB_REF_NAME"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -50,7 +50,7 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -65,7 +65,7 @@ jobs:
             type=sha,prefix=sha-
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-publish-fullstack.yml
+++ b/.github/workflows/docker-publish-fullstack.yml
@@ -48,13 +48,13 @@ jobs:
           persist-credentials: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Validate full-stack multi-architecture image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./Dockerfile.fullstack
@@ -84,13 +84,13 @@ jobs:
         run: node scripts/check-release-version.cjs "$GITHUB_REF_NAME"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -98,7 +98,7 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -113,7 +113,7 @@ jobs:
             type=sha,prefix=sha-
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./Dockerfile.fullstack

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,13 +38,13 @@ jobs:
         run: node scripts/check-release-version.cjs "$GITHUB_REF_NAME"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -52,7 +52,7 @@ jobs:
 
       - name: Extract metadata (tags, labels)
         id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -69,7 +69,7 @@ jobs:
             type=sha,prefix=sha-
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./server
           platforms: linux/amd64,linux/arm64

--- a/src/components/AssetLeadingIcon.tsx
+++ b/src/components/AssetLeadingIcon.tsx
@@ -1,0 +1,25 @@
+import { Download } from 'lucide-react';
+import { detectAssetPlatform } from '../utils/releaseAssets';
+import { getPlatformDisplayName, getPlatformIcon } from './platformMeta';
+
+/**
+ * 资产行左侧图标：按文件名/扩展名（含 MIME 兜底）推断平台 → 方形品牌徽章；
+ * 推断不出时回退到通用下载图标（不猜）。
+ * 下载状态图标（进行中/已完成/源码）由调用方优先渲染。
+ * Release 页（ReleaseCard）与仓库 Release 边栏（RepositoryReleaseSheet）共用，
+ * 保证两处资产的平台图标一致。
+ */
+const AssetLeadingIcon = ({ name, contentType }: { name: string; contentType?: string }) => {
+  const platform = detectAssetPlatform(name, contentType);
+  if (!platform) {
+    return <Download className="w-3.5 h-3.5 text-muted-foreground dark:text-muted-foreground/70 flex-shrink-0" aria-hidden="true" />;
+  }
+  const Icon = getPlatformIcon(platform);
+  return (
+    <span className="asset-platform-badge flex-shrink-0" title={getPlatformDisplayName(platform)}>
+      <Icon className="h-[11px] w-[11px]" aria-hidden="true" />
+    </span>
+  );
+};
+
+export default AssetLeadingIcon;

--- a/src/components/ReleaseCard.tsx
+++ b/src/components/ReleaseCard.tsx
@@ -4,6 +4,7 @@ import { Release } from '../types';
 import { formatDistanceToNow } from 'date-fns';
 import { zhCN } from 'date-fns/locale';
 import MarkdownRenderer from './MarkdownRenderer';
+import AssetLeadingIcon from './AssetLeadingIcon';
 import { useAppStore } from '../store/useAppStore';
 import { useShallow } from 'zustand/react/shallow';
 import { useDialog } from '../hooks/useDialog';
@@ -11,10 +12,8 @@ import { sendToRpcDownload } from '../services/rpcDownloadService';
 import { AIService } from '../services/aiService';
 import {
   effectiveReleaseTime,
-  detectAssetPlatform,
   shouldShowAssetsUpdatedIndicator,
 } from '../utils/releaseAssets';
-import { getPlatformDisplayName, getPlatformIcon } from './platformMeta';
 import { Button } from './ui/button';
 
 type SummaryState = {
@@ -33,24 +32,6 @@ interface DownloadLink {
   updatedAt?: string;
   contentType?: string;
 }
-
-/**
- * 资产行左侧图标：按文件名/扩展名（含 MIME 兜底）推断平台 → 方形品牌徽章；
- * 推断不出时回退到通用下载图标（不猜）。
- * 下载状态图标（进行中/已完成/源码）由调用方优先渲染。
- */
-const AssetLeadingIcon = ({ name, contentType }: { name: string; contentType?: string }) => {
-  const platform = detectAssetPlatform(name, contentType);
-  if (!platform) {
-    return <Download className="w-3.5 h-3.5 text-muted-foreground dark:text-muted-foreground/70 flex-shrink-0" />;
-  }
-  const Icon = getPlatformIcon(platform);
-  return (
-    <span className="asset-platform-badge flex-shrink-0" title={getPlatformDisplayName(platform)}>
-      <Icon className="h-[11px] w-[11px]" />
-    </span>
-  );
-};
 
 /** 资产相对时间：updated_at 非法时不渲染，避免 date-fns 对 Invalid Date 抛错；中文界面用 zhCN。 */
 const AssetUpdatedTime = ({ updatedAt, language }: { updatedAt?: string; language: 'zh' | 'en' }) => {

--- a/src/components/RepositoryReleaseSheet.test.tsx
+++ b/src/components/RepositoryReleaseSheet.test.tsx
@@ -140,6 +140,36 @@ describe('RepositoryReleaseSheet', () => {
     expect(hookMocks.generateSummary).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }));
   });
 
+  it('shows the same platform badges as the Release page for asset icons', async () => {
+    const user = userEvent.setup();
+    hookMocks.state.releases = [{
+      ...createRelease(1, 0),
+      assets: [
+        { id: 901, name: 'MyApp-1.0.dmg', size: 1024, download_count: 0, browser_download_url: 'https://example.com/MyApp-1.0.dmg', content_type: 'application/x-apple-diskimage', created_at: '2026-01-01T00:00:00.000Z', updated_at: '2026-01-01T00:00:00.000Z' },
+        { id: 902, name: 'MyApp-1.0-setup.exe', size: 2048, download_count: 0, browser_download_url: 'https://example.com/MyApp-1.0-setup.exe', content_type: 'application/x-msdownload', created_at: '2026-01-01T00:00:00.000Z', updated_at: '2026-01-01T00:00:00.000Z' },
+        { id: 903, name: 'myapp-1.0-linux-amd64.tar.gz', size: 4096, download_count: 0, browser_download_url: 'https://example.com/myapp-1.0-linux-amd64.tar.gz', content_type: 'application/gzip', created_at: '2026-01-01T00:00:00.000Z', updated_at: '2026-01-01T00:00:00.000Z' },
+        { id: 904, name: 'myapp-1.0.zip', size: 8192, download_count: 0, browser_download_url: 'https://example.com/myapp-1.0.zip', content_type: 'application/zip', created_at: '2026-01-01T00:00:00.000Z', updated_at: '2026-01-01T00:00:00.000Z' },
+      ],
+    }];
+    renderSheet();
+
+    await user.click(screen.getByText('v1').closest('button')!);
+
+    // 可识别平台的资产渲染品牌徽章（与 ReleaseCard 的 AssetLeadingIcon 一致）。
+    // getAllByTitle：simple-icons 的 svg 内部也带 <title>，需按徽章 class 过滤出外层 span。
+    const getBadge = (title: string) =>
+      screen.getAllByTitle(title).find((el) => el.classList.contains('asset-platform-badge'));
+    expect(getBadge('macOS')).toBeDefined();
+    expect(getBadge('Windows')).toBeDefined();
+    expect(getBadge('Linux')).toBeDefined();
+
+    // 平台不可识别的资产回退到通用下载图标，不猜平台
+    const zipRow = screen.getByText('myapp-1.0.zip').closest('tr');
+    expect(zipRow).not.toBeNull();
+    expect(zipRow!.querySelector('.asset-platform-badge')).toBeNull();
+    expect(zipRow!.querySelector('svg.lucide-download')).not.toBeNull();
+  });
+
   it('delegates asset download to the authenticated hook action when RPC is enabled', async () => {
     const user = userEvent.setup();
     hookMocks.state.isRpcEnabled = true;

--- a/src/components/RepositoryReleaseSheet.tsx
+++ b/src/components/RepositoryReleaseSheet.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Calendar, CheckCircle2, ChevronLeft, ChevronRight, Download, ExternalLink, FileArchive, FileCode2, Loader2, PackageOpen, RefreshCw, Sparkles } from 'lucide-react';
+import { Calendar, CheckCircle2, ChevronLeft, ChevronRight, Code2, Download, ExternalLink, Loader2, PackageOpen, RefreshCw, Sparkles } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { zhCN } from 'date-fns/locale';
 import type { Release, Repository } from '../types';
 import MarkdownRenderer from './MarkdownRenderer';
+import AssetLeadingIcon from './AssetLeadingIcon';
 import { useAppStore } from '../store/useAppStore';
 import { useRepositoryReleaseSheet } from '../features/repositories/hooks/useRepositoryReleaseSheet';
 import { buildReleaseDownloadLinks, type ReleaseDownloadLink } from '../utils/releaseDownloadLinks';
@@ -111,7 +112,7 @@ const ReleaseAssetsTable: React.FC<{
               <TableRow key={link.id} className={link.isSourceCode ? 'bg-muted/30' : undefined}>
                 <TableCell className="max-w-0">
                   <div className="flex min-w-0 items-center gap-2">
-                    {link.isSourceCode ? <FileCode2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" /> : <FileArchive className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />}
+                    {link.isSourceCode ? <Code2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" /> : <AssetLeadingIcon name={link.name} contentType={link.contentType} />}
                     <span className="truncate text-xs" title={link.name}>{link.name}</span>
                   </div>
                 </TableCell>


### PR DESCRIPTION
## 背景

1. **CI 告警**：三个 Docker 镜像 workflow 每次运行都提示 Node.js 20 弃用——钉住的 docker actions SHA 仍基于 Node 20，被 runner 强制跑在 Node 24 上。
2. **UI 不一致**：仓库卡片"查看 Release"边栏的资产列表用通用文件图标（FileCode2/FileArchive），而 Release 页按文件扩展名/文件名/MIME 推断平台并显示品牌徽章（Apple/Windows/Linux…），两处视觉不一致。

## 方案

### 1. Docker Actions 升级（消除 Node 20 弃用告警）

`docker-publish.yml` / `docker-publish-frontend.yml` / `docker-publish-fullstack.yml` 全部 18 处引用升级到官方已迁移 Node 24 的新版本（已逐一核对新版 `action.yml` 声明 `using: node24`，并反向验证 SHA 指向对应 tag）：

| Action | 旧版本 | 新版本 |
|---|---|---|
| build-push-action | v6.19.2 | v7.3.0 |
| setup-buildx-action | v3.12.0 | v4.3.0 |
| setup-qemu-action | v3.7.0 | v4.2.0 |
| login-action | v3.7.0 | v4.6.0 |
| metadata-action | v5.10.0 | v6.2.0 |

已核对 major 版本 release notes：workflow 用到的 inputs（context/platforms/push/tags/labels/cache-from/to）无变化；metadata-action v6 的列表 `#` 注释语法与现有 tags 写法兼容；build-push-action v7 移除的两个 env 本项目未使用。

### 2. 资产平台图标统一（以 Release 页为准）

- 将 Release 页 `ReleaseCard` 的 `AssetLeadingIcon`（平台推断 → 品牌徽章，推断不出回退通用下载图标）抽取为共享组件，边栏 `RepositoryReleaseSheet` 资产列表改用同一组件；
- 源码 zip/tar 条目两处统一使用 `Code2` 图标；
- 共享组件内图标补 `aria-hidden="true"`（simple-icons 的 SVG 自带 `<title>`，避免屏幕阅读器读出冗余内容）。

## 改动面

| 文件 | 内容 |
|---|---|
| `AssetLeadingIcon.tsx`（新） | 共享的平台徽章/回退图标组件 |
| `ReleaseCard.tsx` | 改用共享组件，删除本地定义 |
| `RepositoryReleaseSheet.tsx` | 资产列表改用平台徽章图标 |
| `RepositoryReleaseSheet.test.tsx` | 新增用例：.dmg/.exe/linux tar.gz 渲染对应徽章、不可识别的 .zip 回退通用图标 |
| 三个 docker workflow | docker actions 升级至 Node 24 版本 |

## 验证

- [x] `node scripts/check-boundaries.cjs` 无分层违规
- [x] `npm run lint` 通过
- [x] `npm run typecheck` 通过
- [x] `npm run test:run` 629 个测试全部通过（含新增用例）
- [x] `npm run build` + bundle-size 检查通过
- [x] 三个 workflow YAML 语法校验通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * Release 资产现在会根据文件类型显示对应的平台图标，包括 macOS、Windows 和 Linux。
  * 无法识别平台的资产将显示通用下载图标。
  * Release 页面与仓库 Release 侧栏的资产图标保持一致。
* **改进**
  * 优化源码资产图标展示，提升文件类型识别的直观性。
* **维护**
  * 更新 Docker 构建与发布流程所使用的相关工具版本。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->