### PR TITLE
feat(settings): add routeMode for local GitHub egress preference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "github-stars-manager",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^3.0.37",
         "@fontsource-variable/dm-sans": "^5.3.0",

--- a/src/components/ReadmeModal.test.tsx
+++ b/src/components/ReadmeModal.test.tsx
@@ -5,7 +5,7 @@ import { ReadmeModal } from './ReadmeModal';
 import { backend } from '../services/backendAdapter';
 import { GitHubApiService } from '../services/githubApi';
 import { useAppStore } from '../store/useAppStore';
-import type { Repository } from '../types';
+import type { Repository, RouteMode } from '../types';
 
 vi.mock('./BilingualMarkdownRenderer', async () => {
   const React = await import('react');
@@ -30,7 +30,7 @@ vi.mock('../services/githubApi', () => ({
   GitHubApiService: vi.fn(),
 }));
 
-let mockStoreState: { language: 'zh' | 'en'; githubToken: string | null; routeMode: 'auto' | 'backend' | 'browser'; setReadmeModalOpen: () => void } = {
+let mockStoreState: { language: 'zh' | 'en'; githubToken: string | null; routeMode: RouteMode; setReadmeModalOpen: () => void } = {
   language: 'zh',
   githubToken: null,
   routeMode: 'auto',
@@ -51,7 +51,7 @@ const setMockStore = (githubToken: string | null = null) => {
   mockStoreState = {
     language: 'zh',
     githubToken,
-    routeMode: 'auto',
+    routeMode: 'auto' as RouteMode,
     setReadmeModalOpen: vi.fn(),
   };
   (useAppStore as unknown as ReturnType<typeof vi.fn>).mockImplementation((selector?: (state: unknown) => unknown) => selector ? selector(mockStoreState) : mockStoreState);

--- a/src/components/ReadmeModal.test.tsx
+++ b/src/components/ReadmeModal.test.tsx
@@ -30,8 +30,15 @@ vi.mock('../services/githubApi', () => ({
   GitHubApiService: vi.fn(),
 }));
 
+let mockStoreState: { language: 'zh' | 'en'; githubToken: string | null; routeMode: 'auto' | 'backend' | 'browser'; setReadmeModalOpen: () => void } = {
+  language: 'zh',
+  githubToken: null,
+  routeMode: 'auto',
+  setReadmeModalOpen: vi.fn(),
+};
+
 vi.mock('../store/useAppStore', () => ({
-  useAppStore: vi.fn(),
+  useAppStore: Object.assign(vi.fn(), { getState: () => mockStoreState }),
 }));
 
 const mockGitHubApi = {
@@ -41,14 +48,13 @@ const mockGitHubApi = {
 };
 
 const setMockStore = (githubToken: string | null = null) => {
-  (useAppStore as unknown as ReturnType<typeof vi.fn>).mockImplementation((selector?: (state: unknown) => unknown) => {
-    const state = {
-      language: 'zh',
-      githubToken,
-      setReadmeModalOpen: vi.fn(),
-    };
-    return selector ? selector(state) : state;
-  });
+  mockStoreState = {
+    language: 'zh',
+    githubToken,
+    routeMode: 'auto',
+    setReadmeModalOpen: vi.fn(),
+  };
+  (useAppStore as unknown as ReturnType<typeof vi.fn>).mockImplementation((selector?: (state: unknown) => unknown) => selector ? selector(mockStoreState) : mockStoreState);
 };
 
 const mockedGitHubApiService = GitHubApiService as unknown as ReturnType<typeof vi.fn>;

--- a/src/components/ReadmeModal.tsx
+++ b/src/components/ReadmeModal.tsx
@@ -7,6 +7,7 @@ import { stripMarkdownFormatting } from '../utils/markdownUtils';
 import { Repository } from '../types';
 import { GitHubApiService } from '../services/githubApi';
 import { backend } from '../services/backendAdapter';
+import { shouldBypassBackend } from '../services/routeMode';
 import { useAppStore } from '../store/useAppStore';
 import { useShallow } from 'zustand/react/shallow';
 import { buildReadmeVariants, DEFAULT_README_VARIANT, type GitHubReadmeCandidateItem, type ReadmeVariant } from '../utils/readmeVariants';
@@ -344,7 +345,7 @@ export const ReadmeModal: React.FC<ReadmeModalProps> = ({
         : githubApi.getRepositoryReadmeByPath(owner, name, variant.path, signal);
     };
 
-    if (!backend.isAvailable) {
+    if (shouldBypassBackend() || !backend.isAvailable) {
       return fetchFromGitHubApi();
     }
 
@@ -374,7 +375,7 @@ export const ReadmeModal: React.FC<ReadmeModalProps> = ({
       return githubApi.listRepositoryReadmeCandidates(owner, name, defaultBranch, signal);
     };
 
-    if (!backend.isAvailable) {
+    if (shouldBypassBackend() || !backend.isAvailable) {
       return fetchFromGitHubApi();
     }
 

--- a/src/components/settings/BackendPanel.tsx
+++ b/src/components/settings/BackendPanel.tsx
@@ -1,9 +1,12 @@
 import { Input } from '../ui/input';
 import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
+import { RadioGroup, RadioGroupItem } from '../ui/radio-group';
 import React from 'react';
-import { Server, TestTube, RefreshCw, Upload, Download, CheckCircle, AlertCircle } from 'lucide-react';
+import { Server, TestTube, RefreshCw, Upload, Download, CheckCircle, AlertCircle, Route } from 'lucide-react';
 import { useBackendSettingsActions } from '../../features/settings/hooks/useBackendSettingsActions';
+import { useAppStore } from '../../store/useAppStore';
+import type { RouteMode } from '../../types';
 
 interface BackendPanelProps {
   t: (zh: string, en: string) => string;
@@ -22,6 +25,26 @@ export const BackendPanel: React.FC<BackendPanelProps> = ({ t }) => {
     syncToBackend: handleSyncToBackend,
     syncFromBackend: handleSyncFromBackend,
   } = useBackendSettingsActions({ t });
+  const routeMode = useAppStore((state) => state.routeMode);
+  const setRouteMode = useAppStore((state) => state.setRouteMode);
+
+  const routeOptions: Array<{ value: RouteMode; label: string; hint: string }> = [
+    {
+      value: 'auto',
+      label: t('智能', 'Auto'),
+      hint: t('有后端走后端，无后端走本机网络', 'Use backend when available, otherwise this device'),
+    },
+    {
+      value: 'backend',
+      label: t('优先走后端', 'Prefer backend'),
+      hint: t('支持后端代理的请求族优先经后端服务器出站', 'Backend-proxied request families prefer the backend egress'),
+    },
+    {
+      value: 'browser',
+      label: t('浏览器直连', 'Browser direct'),
+      hint: t('跳过后端代理，走当前设备网络', 'Skip backend proxying and use this device network'),
+    },
+  ];
 
   const getStatusIcon = () => {
     switch (status) {
@@ -76,6 +99,54 @@ export const BackendPanel: React.FC<BackendPanelProps> = ({ t }) => {
           </p>
         </div>
       )}
+
+      <div className="p-4 bg-background dark:bg-muted/40 rounded-lg border border-border dark:border-border">
+        <div className="flex items-center space-x-2 mb-1">
+          <Route className="w-4 h-4 text-muted-foreground dark:text-muted-foreground" />
+          <h4 className="text-sm font-medium text-foreground dark:text-foreground">
+            {t('网络请求路由', 'Network Request Routing')}
+          </h4>
+        </div>
+        <p className="text-xs text-muted-foreground dark:text-muted-foreground mb-3">
+          {t(
+            '选择支持后端代理的 GitHub/Release 请求从哪里发出。此项仅影响本设备，不参与后端与自动同步。',
+            'Choose where backend-proxied GitHub/Release requests originate. This only affects this device and is never synced.'
+          )}
+        </p>
+        <RadioGroup
+          value={routeMode}
+          onValueChange={(value) => setRouteMode(value as RouteMode)}
+          className="gap-3"
+        >
+          {routeOptions.map((option) => (
+            <label
+              key={option.value}
+              htmlFor={`route-mode-${option.value}`}
+              className="flex items-start space-x-3 rounded-lg p-2 hover:bg-muted/50 dark:hover:bg-muted/30 cursor-pointer"
+            >
+              <RadioGroupItem value={option.value} id={`route-mode-${option.value}`} className="mt-0.5" />
+              <div className="min-w-0">
+                <div className="text-sm font-medium text-foreground dark:text-foreground">{option.label}</div>
+                <div className="text-xs text-muted-foreground dark:text-muted-foreground">{option.hint}</div>
+              </div>
+            </label>
+          ))}
+        </RadioGroup>
+        {!backendAvailable && (
+          <p className="text-xs text-warning mt-3">
+            {t(
+              '当前后端不可达，「智能 / 优先走后端」与「浏览器直连」实际效果一致（都从本设备网络发出），切换不会改变现状。',
+              'The backend is unreachable right now, so "Auto / Prefer backend" and "Browser direct" behave identically (both use this device). Switching will not change current behavior.'
+            )}
+          </p>
+        )}
+        <p className="text-xs text-muted-foreground dark:text-muted-foreground mt-3">
+          {t(
+            '提示：服务器（如境内 VPS）访问不了 GitHub 时选「浏览器直连」。aria2 的下载流量由 aria2 进程所在机器发出，与本设置无关。浏览器直连下载有鉴权的大体积资产会占用标签页内存。',
+            'Tip: pick "Browser direct" when the server (e.g. a mainland-China VPS) cannot reach GitHub. aria2 download traffic leaves from wherever aria2 runs and is unaffected. Authenticated large assets downloaded via browser direct consume tab memory.'
+          )}
+        </p>
+      </div>
 
       <div className="p-4 bg-background dark:bg-muted/40 rounded-lg border border-border dark:border-border">
         <label htmlFor="backend-api-secret" className="block text-sm font-medium text-foreground dark:text-muted-foreground mb-2">

--- a/src/components/settings/NetworkPanel.tsx
+++ b/src/components/settings/NetworkPanel.tsx
@@ -302,6 +302,12 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
                 'Requires aria2 with RPC enabled (aria2c --enable-rpc --rpc-listen-port=6800)'
               )}
             </p>
+            <p className="text-xs text-muted-foreground dark:text-muted-foreground">
+              {t(
+                'RPC 下载与 GitHub 请求出口可在「设置 → 后端同步 → 网络请求路由」调整。aria2 的下载流量由 aria2 进程所在机器发出，与本设置无关。',
+                'RPC download and GitHub request egress can be adjusted under "Settings → Backend Sync → Network Request Routing". aria2 download traffic leaves from wherever aria2 runs and is unaffected.'
+              )}
+            </p>
 
             {/* Actions */}
             <div className="flex items-center space-x-3 pt-2">

--- a/src/components/settings/NetworkPanel.tsx
+++ b/src/components/settings/NetworkPanel.tsx
@@ -304,8 +304,8 @@ export const NetworkPanel: React.FC<NetworkPanelProps> = ({ t }) => {
             </p>
             <p className="text-xs text-muted-foreground dark:text-muted-foreground">
               {t(
-                'RPC 下载与 GitHub 请求出口可在「设置 → 后端同步 → 网络请求路由」调整。aria2 的下载流量由 aria2 进程所在机器发出，与本设置无关。',
-                'RPC download and GitHub request egress can be adjusted under "Settings → Backend Sync → Network Request Routing". aria2 download traffic leaves from wherever aria2 runs and is unaffected.'
+                'GitHub/Release 请求出口可在「设置 → 后端同步 → 网络请求路由」调整。RPC 下载仍由 aria2 配置决定，下载流量由 aria2 进程所在机器发出，与本设置无关。',
+                'Adjust GitHub/Release request egress under "Settings → Backend Sync → Network Request Routing". RPC downloads remain controlled by aria2 configuration, and traffic leaves from wherever aria2 runs; this setting does not change it.'
               )}
             </p>
 

--- a/src/features/repositories/hooks/useRepositoryReleaseSheet.test.tsx
+++ b/src/features/repositories/hooks/useRepositoryReleaseSheet.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Repository } from '../../../types';
+import type { Repository, RouteMode } from '../../../types';
 import { useRepositoryReleaseSheet } from './useRepositoryReleaseSheet';
 
 const mocks = vi.hoisted(() => ({
@@ -18,7 +18,7 @@ const mocks = vi.hoisted(() => ({
     backendApiSecret: null as string | null,
     aiConfigs: [],
     activeAIConfig: null as string | null,
-    routeMode: 'auto' as const,
+    routeMode: 'auto' as RouteMode,
   },
 }));
 
@@ -71,6 +71,7 @@ describe('useRepositoryReleaseSheet', () => {
     vi.clearAllMocks();
     mocks.backend.isAvailable = false;
     mocks.store.githubToken = 'token';
+    mocks.store.routeMode = 'auto';
   });
 
   it('uses the live backend GitHub proxy when available and maps repository identity locally', async () => {
@@ -181,5 +182,47 @@ describe('useRepositoryReleaseSheet', () => {
 
     expect(mocks.backend.downloadGitHubResource).toHaveBeenCalledWith('/repos/owner/repo/releases/assets/2');
     expect(clickSpy).toHaveBeenCalledOnce();
+  });
+
+  it('skips the backend proxy and fetches releases directly in browser route mode', async () => {
+    mocks.store.routeMode = 'browser';
+    mocks.backend.isAvailable = true;
+    mocks.githubGetRepositoryReleasesPage.mockResolvedValue({
+      releases: [{ ...rawRelease, repository: { id: 0, name: 'repo', full_name: 'owner/repo' } }],
+      hasMore: false,
+    });
+    const { result } = renderHook(() => useRepositoryReleaseSheet(repository));
+
+    await act(async () => {
+      await result.current.loadReleases();
+    });
+
+    expect(mocks.backend.getRepositoryReleases).not.toHaveBeenCalled();
+    expect(mocks.githubGetRepositoryReleasesPage).toHaveBeenCalledWith('owner', 'repo', 1, 100, expect.any(AbortSignal));
+    expect(result.current.error).toBeNull();
+  });
+
+  it('opens a new window instead of the backend proxy for tokenless downloads in browser route mode', async () => {
+    mocks.store.routeMode = 'browser';
+    mocks.store.githubToken = null;
+    mocks.backend.isAvailable = true;
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const { result } = renderHook(() => useRepositoryReleaseSheet(repository));
+
+    await act(async () => {
+      await result.current.downloadAsset({
+        id: 'asset-3',
+        name: 'browser-fallback.zip',
+        url: 'https://github.com/owner/repo/releases/download/v1/browser-fallback.zip',
+        authenticatedPath: '/repos/owner/repo/releases/assets/3',
+        size: 10,
+        isSourceCode: false,
+        assetId: 3,
+      });
+    });
+
+    expect(mocks.backend.downloadGitHubResource).not.toHaveBeenCalled();
+    expect(openSpy).toHaveBeenCalledWith('https://github.com/owner/repo/releases/download/v1/browser-fallback.zip', '_blank', 'noopener,noreferrer');
+    openSpy.mockRestore();
   });
 });

--- a/src/features/repositories/hooks/useRepositoryReleaseSheet.test.tsx
+++ b/src/features/repositories/hooks/useRepositoryReleaseSheet.test.tsx
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
     backendApiSecret: null as string | null,
     aiConfigs: [],
     activeAIConfig: null as string | null,
+    routeMode: 'auto' as const,
   },
 }));
 
@@ -31,7 +32,10 @@ vi.mock('../../../hooks/useDialog', () => ({
   useDialog: () => ({ toast: mocks.toast, confirm: vi.fn() }),
 }));
 vi.mock('../../../store/useAppStore', () => ({
-  useAppStore: (selector: (state: typeof mocks.store) => unknown) => selector(mocks.store),
+  useAppStore: Object.assign(
+    (selector: (state: typeof mocks.store) => unknown) => selector(mocks.store),
+    { getState: () => mocks.store },
+  ),
 }));
 
 const repository: Repository = {

--- a/src/features/repositories/hooks/useRepositoryReleaseSheet.ts
+++ b/src/features/repositories/hooks/useRepositoryReleaseSheet.ts
@@ -5,6 +5,7 @@ import { backend } from '../../../services/backendAdapter';
 import { GitHubApiService } from '../../../services/githubApi';
 import { sendToRpcDownload } from '../../../services/rpcDownloadService';
 import { AIService } from '../../../services/aiService';
+import { shouldBypassBackend } from '../../../services/routeMode';
 import { useAppStore } from '../../../store/useAppStore';
 import { useDialog } from '../../../hooks/useDialog';
 import type { ReleaseDownloadLink } from '../../../utils/releaseDownloadLinks';
@@ -185,7 +186,7 @@ export const useRepositoryReleaseSheet = (repository: Repository) => {
       let liveReleases: Release[] | null = null;
       let backendError: unknown;
 
-      if (backend.isAvailable) {
+      if (!shouldBypassBackend() && backend.isAvailable) {
         try {
           liveReleases = await fetchAllPages(async (page, signal) => {
             const records = await backend.getRepositoryReleases(owner, name, page, REMOTE_RELEASE_PAGE_SIZE, signal);
@@ -269,7 +270,7 @@ export const useRepositoryReleaseSheet = (repository: Repository) => {
           throw new Error(`${t('下载失败', 'Download failed')} (${response.status})`);
         }
         blob = await response.blob();
-      } else if (backend.isAvailable && link.authenticatedPath) {
+      } else if (!shouldBypassBackend() && backend.isAvailable && link.authenticatedPath) {
         blob = await backend.downloadGitHubResource(link.authenticatedPath);
       } else {
         window.open(link.url, '_blank', 'noopener,noreferrer');

--- a/src/features/settings/hooks/useBackupActions.ts
+++ b/src/features/settings/hooks/useBackupActions.ts
@@ -32,6 +32,7 @@ export const useBackupActions = ({ t }: UseBackupActionsOptions): BackupActions 
     activeWebDAVConfig: store.activeWebDAVConfig,
     proxyConfig: store.proxyConfig,
     rpcDownloadConfig: store.rpcDownloadConfig,
+    routeMode: store.routeMode,
     backendApiSecret: store.backendApiSecret,
     includeKeysInBackup: store.includeKeysInBackup,
     setLastBackup: store.setLastBackup,
@@ -49,6 +50,7 @@ export const useBackupActions = ({ t }: UseBackupActionsOptions): BackupActions 
     deleteWebDAVConfig: store.deleteWebDAVConfig,
     setProxyConfig: store.setProxyConfig,
     setRpcDownloadConfig: store.setRpcDownloadConfig,
+    setRouteMode: store.setRouteMode,
     setBackendApiSecret: store.setBackendApiSecret,
     setReleaseSourceSettings: store.setReleaseSourceSettings,
   })));
@@ -88,13 +90,14 @@ export const useBackupActions = ({ t }: UseBackupActionsOptions): BackupActions 
           ...state.rpcDownloadConfig,
           secret: state.includeKeysInBackup ? state.rpcDownloadConfig.secret : (state.rpcDownloadConfig.secret ? '***' : ''),
         },
+        routeMode: state.routeMode,
         backendApiSecret: state.includeKeysInBackup ? state.backendApiSecret : (state.backendApiSecret ? '***' : null),
         releaseSubscriptions: Array.from(useAppStore.getState().releaseSubscriptions),
         releaseSourceSettings: useAppStore.getState().releaseSourceSettings,
         readReleases: Array.from(useAppStore.getState().readReleases),
         includeKeysInBackup: state.includeKeysInBackup,
         exportedAt: new Date().toISOString(),
-        version: '1.1',
+        version: '1.2',
       };
       const filename = `github-stars-backup-${new Date().toISOString().split('T')[0]}.json`;
       const success = await new WebDAVService(activeConfig).uploadFile(filename, JSON.stringify(backupData, null, 2));
@@ -244,6 +247,18 @@ export const useBackupActions = ({ t }: UseBackupActionsOptions): BackupActions 
         }
       } catch (error) {
         console.warn('恢复远程下载配置时发生问题：', error);
+      }
+      // routeMode 是本地偏好：仅接受合法枚举，缺失/非法回退 auto（随 1.2 备份导出）
+      try {
+        const restored = backupData.routeMode;
+        const next: 'auto' | 'backend' | 'browser' = restored === 'backend' || restored === 'browser' || restored === 'auto'
+          ? restored
+          : 'auto';
+        if (useAppStore.getState().routeMode !== next) {
+          useAppStore.getState().setRouteMode(next);
+        }
+      } catch (error) {
+        console.warn('恢复网络路由偏好时发生问题：', error);
       }
       try {
         if (backupIncludedKeys && backupData.backendApiSecret !== undefined && backupData.backendApiSecret !== '***') {

--- a/src/services/aiAnalysisHelper.ts
+++ b/src/services/aiAnalysisHelper.ts
@@ -2,6 +2,7 @@ import { Repository, AIConfig, Category, DiscoveryRepo } from '../types';
 import { GitHubApiService } from './githubApi';
 import { AIService } from './aiService';
 import { backend } from './backendAdapter';
+import { shouldBypassBackend } from './routeMode';
 import { resolveCategoryAssignment, buildCategoryHints } from '../utils/categoryUtils';
 
 export interface AIAnalysisResult {
@@ -38,9 +39,9 @@ export const analyzeRepository = async (options: AnalyzeRepositoryOptions): Prom
   onProgress?.('Fetching README...');
   let readmeContent = '';
   try {
-    readmeContent = backend.isAvailable
-      ? await backend.getRepositoryReadme(owner, name, signal)
-      : await githubApi.getRepositoryReadme(owner, name, signal);
+    readmeContent = (shouldBypassBackend() || !backend.isAvailable)
+      ? await githubApi.getRepositoryReadme(owner, name, signal)
+      : await backend.getRepositoryReadme(owner, name, signal);
   } catch (error) {
     if (signal?.aborted || (error as { name?: string })?.name === 'AbortError') {
       throw error;

--- a/src/services/aiAnalysisOptimizer.test.ts
+++ b/src/services/aiAnalysisOptimizer.test.ts
@@ -5,6 +5,10 @@ import type { GitHubApiService } from './githubApi';
 import { AIRequestError } from './aiService';
 import type { Repository } from '../types';
 
+vi.mock('../store/useAppStore', () => ({
+  useAppStore: { getState: () => ({ routeMode: 'auto' }) },
+}));
+
 function makeRepo(id: number): Repository {
   return {
     id,

--- a/src/services/aiAnalysisOptimizer.ts
+++ b/src/services/aiAnalysisOptimizer.ts
@@ -2,6 +2,7 @@ import { Repository } from '../types';
 import { AIService } from './aiService';
 import { GitHubApiService } from './githubApi';
 import { backend } from './backendAdapter';
+import { shouldBypassBackend } from './routeMode';
 import { AIRateLimiter, AIRateLimitConfig } from './aiRequestLimiter';
 import { isRateLimitedError, getRetryAfterMsFromError } from './aiService';
 
@@ -179,7 +180,7 @@ export class AIAnalysisOptimizer {
     if (this.aborted || signal?.aborted) return '';
 
     try {
-      if (backend.isAvailable) {
+      if (!shouldBypassBackend() && backend.isAvailable) {
         const [owner, name] = repo.full_name.split('/');
         return await backend.getRepositoryReadme(owner, name, signal);
       }

--- a/src/services/githubApiFactory.test.ts
+++ b/src/services/githubApiFactory.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  setBackendUrl: vi.fn(),
+  setBackendAuthToken: vi.fn(),
+  backendUrlGet: vi.fn<() => string | null>(() => null),
+  isAvailableGet: vi.fn<() => boolean>(() => false),
+  routeMode: 'auto' as 'auto' | 'backend' | 'browser',
+}));
+
+vi.mock('./githubApi', () => ({
+  GitHubApiService: class {
+    setBackendUrl = mocks.setBackendUrl;
+    setBackendAuthToken = mocks.setBackendAuthToken;
+  },
+}));
+
+vi.mock('./githubListsApi', () => ({
+  GitHubListsApiService: class {
+    setBackendUrl = mocks.setBackendUrl;
+    setBackendAuthToken = mocks.setBackendAuthToken;
+  },
+}));
+
+vi.mock('./backendAdapter', () => ({
+  backend: {
+    get backendUrl() { return mocks.backendUrlGet(); },
+    get isAvailable() { return mocks.isAvailableGet(); },
+  },
+}));
+
+vi.mock('../store/useAppStore', () => ({
+  useAppStore: {
+    getState: () => ({ routeMode: mocks.routeMode, backendApiSecret: 'secret-value' }),
+  },
+}));
+
+import { createGitHubApiService, createGitHubListsApiService } from './githubApiFactory';
+
+describe('githubApiFactory routeMode', () => {
+  beforeEach(() => {
+    mocks.setBackendUrl.mockClear();
+    mocks.setBackendAuthToken.mockClear();
+    mocks.routeMode = 'auto';
+    mocks.backendUrlGet.mockReturnValue(null);
+    mocks.isAvailableGet.mockReturnValue(false);
+  });
+
+  it('does not set backend URL when backend is absent (auto)', () => {
+    mocks.backendUrlGet.mockReturnValue(null);
+    createGitHubApiService('token');
+    expect(mocks.setBackendUrl).not.toHaveBeenCalled();
+  });
+
+  it('sets backend URL when backend exists in auto mode', () => {
+    mocks.backendUrlGet.mockReturnValue('http://backend/api');
+    createGitHubApiService('token');
+    expect(mocks.setBackendUrl).toHaveBeenCalledWith('http://backend/api');
+    expect(mocks.setBackendAuthToken).toHaveBeenCalledWith('secret-value');
+  });
+
+  it('skips backend URL when routeMode is browser', () => {
+    mocks.routeMode = 'browser';
+    mocks.backendUrlGet.mockReturnValue('http://backend/api');
+    createGitHubApiService('token');
+    expect(mocks.setBackendUrl).not.toHaveBeenCalled();
+    expect(mocks.setBackendAuthToken).not.toHaveBeenCalled();
+  });
+
+  it('keeps backend routing for the lists factory in auto mode', () => {
+    mocks.backendUrlGet.mockReturnValue('http://backend/api');
+    createGitHubListsApiService('token');
+    expect(mocks.setBackendUrl).toHaveBeenCalledWith('http://backend/api');
+  });
+
+  it('skips backend URL for the lists factory in browser mode', () => {
+    mocks.routeMode = 'browser';
+    mocks.backendUrlGet.mockReturnValue('http://backend/api');
+    createGitHubListsApiService('token');
+    expect(mocks.setBackendUrl).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/githubApiFactory.test.ts
+++ b/src/services/githubApiFactory.test.ts
@@ -1,11 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RouteMode } from '../types';
 
 const mocks = vi.hoisted(() => ({
   setBackendUrl: vi.fn(),
   setBackendAuthToken: vi.fn(),
   backendUrlGet: vi.fn<() => string | null>(() => null),
   isAvailableGet: vi.fn<() => boolean>(() => false),
-  routeMode: 'auto' as 'auto' | 'backend' | 'browser',
+  routeMode: 'auto' as RouteMode,
 }));
 
 vi.mock('./githubApi', () => ({

--- a/src/services/githubApiFactory.ts
+++ b/src/services/githubApiFactory.ts
@@ -2,11 +2,22 @@ import { useAppStore } from '../store/useAppStore';
 import { backend } from './backendAdapter';
 import { GitHubApiService } from './githubApi';
 import { GitHubListsApiService } from './githubListsApi';
+import { shouldBypassBackend } from './routeMode';
+
+/**
+ * 决定新建的 service 是否应附加后端代理。
+ * 仅在后端可用、且当前 routeMode 不为 'browser' 时返回 true。
+ * 构造时读取一次 routeMode；切换 routeMode 后已存在的 service 不会热重路由，
+ * 新建的 service 才会按当前偏好决定。
+ */
+function shouldAttachBackend(): boolean {
+  return backend.backendUrl != null && !shouldBypassBackend();
+}
 
 export function createGitHubApiService(token: string): GitHubApiService {
   const api = new GitHubApiService(token);
 
-  if (backend.backendUrl) {
+  if (shouldAttachBackend()) {
     api.setBackendUrl(backend.backendUrl);
     api.setBackendAuthToken(useAppStore.getState().backendApiSecret || null);
   }
@@ -17,7 +28,7 @@ export function createGitHubApiService(token: string): GitHubApiService {
 export function createGitHubListsApiService(token: string): GitHubListsApiService {
   const api = new GitHubListsApiService(token);
 
-  if (backend.backendUrl) {
+  if (shouldAttachBackend()) {
     api.setBackendUrl(backend.backendUrl);
     api.setBackendAuthToken(useAppStore.getState().backendApiSecret || null);
   }

--- a/src/services/routeMode.ts
+++ b/src/services/routeMode.ts
@@ -1,0 +1,26 @@
+import type { RouteMode } from '../types';
+import { useAppStore } from '../store/useAppStore';
+
+/**
+ * 本地路由偏好辅助函数。
+ * routeMode 决定 GitHub / Release 数据面请求的出站方向：
+ * - 'auto'    ：保持现有行为（有后端用后端，无后端直连）
+ * - 'backend' ：仅在有后端时走后端（保留现有默认顺序，不重排）
+ * - 'browser' ：跳过后端代理，直接走当前设备网络
+ *
+ * 读取通过 `useAppStore.getState()`，每次调用都拉取最新值；
+ * 路径上**不**订阅响应式变化，避免在已构造的 service / 已发起的请求
+ * 中途切换路由策略。routeMode 变更只对新发起的请求生效。
+ */
+
+/**
+ * 解析当前 routeMode，缺失或非合法枚举时一律视为 'auto'。
+ * 防止初始化/测试环境拿到 undefined 时误判为 browser 绕过默认行为。
+ */
+function resolveRouteMode(): RouteMode {
+  const raw = useAppStore.getState().routeMode;
+  return raw === 'backend' || raw === 'browser' ? raw : 'auto';
+}
+
+/** 是否应走当前设备网络（绕开后端代理）。 */
+export const shouldBypassBackend = (): boolean => resolveRouteMode() === 'browser';

--- a/src/store/initialState.ts
+++ b/src/store/initialState.ts
@@ -72,6 +72,7 @@ export const createInitialState = (): AppState => ({
       backendApiSecret: readSessionBackendSecret(),
       proxyConfig: { enabled: false, type: 'http', host: '', port: 7890 },
       rpcDownloadConfig: { enabled: false, host: '', port: 6800 },
+      routeMode: 'auto',
       isSidebarCollapsed: false,
       readmeModalOpen: false,
       repositoryViewMode: 'grid',

--- a/src/store/normalizers/persistedState.ts
+++ b/src/store/normalizers/persistedState.ts
@@ -289,6 +289,10 @@ export const normalizePersistedState = (
       }
       return { enabled: false, host: '', port: 6800 };
     })(),
+    routeMode: (() => {
+      const m = (safePersisted as Record<string, unknown>).routeMode;
+      return m === 'backend' || m === 'browser' ? m : 'auto';
+    })(),
     headerMenuConfig: (() => {
       const persisted = (safePersisted as Record<string, unknown>).headerMenuConfig;
       if (!Array.isArray(persisted)) return defaultHeaderMenuConfig;

--- a/src/store/persistence/options.ts
+++ b/src/store/persistence/options.ts
@@ -20,7 +20,7 @@ import { debouncedPersistStorage } from './storage';
 
 export const appPersistenceOptions: PersistOptions<AppStoreState, PersistedAppState> = {
   name: 'github-stars-manager',
-  version: 12,
+  version: 13,
   storage: debouncedPersistStorage as PersistStorage<PersistedAppState>,
 partialize: (state) => ({
   // 持久化用户信息和认证状态
@@ -162,6 +162,7 @@ rpcDownloadConfig: {
   port: state.rpcDownloadConfig.port,
   secret: state.rpcDownloadConfig.secret,
 },
+routeMode: state.routeMode,
 }),
 migrate: (persistedState) => {
   // 版本升级适配处理
@@ -314,6 +315,14 @@ state.discoverySortOrder = 'Descending';
   // 初始化 rpcDownloadConfig
   if (state && !(state as Record<string, unknown>).rpcDownloadConfig) {
 (state as Record<string, unknown>).rpcDownloadConfig = { enabled: false, host: '', port: 6800 };
+  }
+
+  // v12→v13: 初始化 routeMode（纯本地偏好，缺失或非法时回退 auto，不参与后端/autoSync 同步）
+  if (state) {
+    const stateRecord = state as Record<string, unknown>;
+    if (stateRecord.routeMode !== 'backend' && stateRecord.routeMode !== 'browser') {
+      stateRecord.routeMode = 'auto';
+    }
   }
 
   // v8→v9: 初始化 headerMenuConfig

--- a/src/store/schema.ts
+++ b/src/store/schema.ts
@@ -111,6 +111,7 @@ export type PersistedAppState = Partial<
     | 'discoverySelectedTopic'
     | 'proxyConfig'
     | 'rpcDownloadConfig'
+    | 'routeMode'
     | 'subscriptionRepos'
     | 'subscriptionLastRefresh'
     | 'subscriptionIsLoading'

--- a/src/store/slices/preferenceSlice.ts
+++ b/src/store/slices/preferenceSlice.ts
@@ -17,6 +17,7 @@ export const createPreferenceSlice: AppStoreSlice<Pick<import('../types').AppAct
   | 'dismissUpdateNotification'
   | 'setAnalysisProgress'
   | 'setProxyConfig'
+  | 'setRouteMode'
   | 'setRpcDownloadConfig'
   | 'setRepositoryViewMode'
   | 'setReleaseViewMode'
@@ -57,6 +58,7 @@ export const createPreferenceSlice: AppStoreSlice<Pick<import('../types').AppAct
       setProxyConfig: (updates) => set((state) => ({
         proxyConfig: { ...state.proxyConfig, ...updates }
       })),
+      setRouteMode: (routeMode) => set({ routeMode }),
       setRpcDownloadConfig: (updates) => set((state) => ({
         rpcDownloadConfig: { ...state.rpcDownloadConfig, ...updates }
       })),

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -191,6 +191,7 @@ export interface AppActions {
 
   // Proxy actions
   setProxyConfig: (updates: Partial<ProxyConfig>) => void;
+  setRouteMode: (mode: import('../types').RouteMode) => void;
 
   // RPC Download actions
   setRpcDownloadConfig: (updates: Partial<RpcDownloadConfig>) => void;

--- a/src/store/useAppStore.modularization.test.ts
+++ b/src/store/useAppStore.modularization.test.ts
@@ -114,6 +114,7 @@ const currentPersistedKeys = [
   'discoverySelectedTopic',
   'proxyConfig',
   'rpcDownloadConfig',
+  'routeMode',
 ] as const;
 
 const historicalSnapshots = (): PersistedSnapshot[] => [
@@ -166,7 +167,7 @@ describe('PR-07 Store modularization compatibility', () => {
       rpcDownloadConfig: { enabled: true, host: 'rpc.example.com', port: 6800, secret: 'rpc-secret' },
     });
 
-    expect(options.version).toBe(12);
+    expect(options.version).toBe(13);
     expect(Object.keys(persisted)).toEqual(currentPersistedKeys);
     expect(persisted.analyzingGistIds).toEqual(['gist-1']);
     expect(persisted.proxyConfig).toMatchObject({ password: 'proxy-password' });

--- a/src/store/useAppStore.test.ts
+++ b/src/store/useAppStore.test.ts
@@ -965,6 +965,7 @@ describe('useAppStore persistence contracts', () => {
       discoveryRepos: buildTransientDiscoverySnapshot().discoveryRepos as ReturnType<typeof useAppStore.getState>['discoveryRepos'],
       proxyConfig: { enabled: true, type: 'http', host: 'proxy.example.com', port: 7890, username: 'user', password: 'proxy-password' },
       rpcDownloadConfig: { enabled: true, host: 'rpc.example.com', port: 6800, secret: 'rpc-secret' },
+      routeMode: 'browser',
     });
 
     expect(persisted).not.toHaveProperty('discoveryRepos');
@@ -982,6 +983,21 @@ describe('useAppStore persistence contracts', () => {
       port: 6800,
       secret: 'rpc-secret',
     });
+    expect(persisted.routeMode).toBe('browser');
+  });
+
+  it('falls back to auto for missing or invalid routeMode during hydration', () => {
+    const normalized = normalizePersistedState(
+      buildPersistedSnapshot({ routeMode: 'not-a-mode' as unknown as never }),
+      useAppStore.getInitialState(),
+    );
+    expect(normalized.routeMode).toBe('auto');
+
+    const legacy = normalizePersistedState(
+      buildPersistedSnapshot() as unknown as Record<string, unknown>,
+      useAppStore.getInitialState(),
+    );
+    expect(legacy.routeMode).toBe('auto');
   });
 
   it('restores the full proxy credential set after hydration', () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -330,6 +330,9 @@ export interface WebDAVConfig {
 
 export type ProxyType = 'http' | 'socks5';
 
+/** GitHub/Release 数据面请求出口偏好；仅影响本设备，不参与后端/autoSync 同步。 */
+export type RouteMode = 'auto' | 'backend' | 'browser';
+
 export interface ProxyConfig {
   enabled: boolean;
   type: ProxyType;
@@ -494,6 +497,8 @@ export interface AppState {
   // Network Proxy
   proxyConfig: ProxyConfig;
   rpcDownloadConfig: RpcDownloadConfig;
+  /** 本地路由偏好；不参与后端/autoSync 同步 */
+  routeMode: RouteMode;
 
   // Fork Timeline View
   forks: ForkRepo[];


### PR DESCRIPTION
Closes #316, Closes #321

## 背景

自托管在境内 VPS 时，后端容器网络往往无法访问 GitHub，但用户的本机 / 浏览器可以翻墙。

当前只有 `factory` 那批通过 `setBackendUrl()` 走代理的请求受影响（gists / lists / repositoryChat / agentToolLoop）；这些一旦探测到后端就被锁死到后端出站，连接失败。本特性新增 `routeMode`（`auto` / `backend` / `browser`），让用户能把"走后端出站"的数据面与部分下载切到"当前设备网络"。

**重要前提（来自评审 §5）**

- `routeMode` 只决定 GitHub/Release 数据面请求从哪里发出；
- **下载出口永远由下载守护进程所在机器决定**：
  - `window.open`/浏览器直连 = 发起 fetch 那一侧下载，browser 档直连有意义；
  - `aria2` = aria2 守护进程所在机器下载，browser 档切到浏览器直连只在 aria2 不在服务器时才有意义；
- 因此 **aria2 保持 auto（后端可达走后端）为默认安全策略**，不因 `routeMode=browser` 盲目切直连。

## 范围（故意收窄）

- `GitHubApiService` / `GitHubListsApiService` factory：routeMode=browser 时不 `setBackendUrl`。
- 后端优先的读路径（ReadmeModal 内容 + 变体列表、AI 分析 helper/optimizer、`useRepositoryReleaseSheet.loadReleases`）在 browser 档下也跳过后端，避免白等超时。
- Release 资产下载：保留现有 auto/backend 顺序，仅在 browser 档下加一条 fallback：用户无 token 时不再调后端，直接新窗口。
- 登录 / forks / discovery / release 时间线 / 搜索 / 订阅 / WebDAV / AI SSE 等本就走浏览器直连的请求**不动**。
- `aria2` 路由逻辑**不动**；aria2 的下载流量由 aria2 进程所在机器发出。
- server 端**不动**；`PUT /api/settings` 本就不白名单。

## 存储与兼容

- `routeMode` 加入持久化键集（`PersistedAppState` Pick），版本从 `12` 升到 `13`。
- migrate 缺失或非法值一律回退 `'auto'`；老用户无感知。
- **不**进入 autoSync、**不**进入后端 `/api/settings` 同步 payload，避免 5s 多设备互相覆盖。
- WebDAV 备份格式 `1.1` → `1.2`；恢复时仅接受合法枚举，否则回退 `'auto'`。

## UI

- `BackendPanel` 新增"网络请求路由"卡片（始终可见，后端不可用时额外提示"两档实际行为一致"）。
- `NetworkPanel` 增加交叉指引一行，提示该选项的位置与 aria2 出口不受影响。
- 文案严格说明：仅影响"支持后端代理的请求族"，不把 routeMode 解释为全局网络开关。

## 测试

- 新增 `githubApiFactory.test.ts`（5 用例）：auto/backend/browser 三种 mode 下的 `setBackendUrl` 行为。
- `useAppStore.test.ts`：补 routeMode persist 与 hydrate 缺/非法 → auto 用例。
- `useAppStore.modularization.test.ts`：持久化键集与 version 12→13 同步。
- 已存在的 ReadmeModal / useRepositoryReleaseSheet / aiAnalysisOptimizer 测试更新 mock store 形态（补 `routeMode` 与 `getState`）。

## CI 验证

```
npm run lint               ✅ 干净
npm run typecheck          ✅ 干净
npm run test:run           ✅ 68 文件 / 635 用例 全过
npm run check:boundaries   ✅ no frontend layering violations
npm run build              ✅ build + bundle-size 绿
```

## 评审 → 修复

- 删除 `persistence/options.ts` 中重复的 v12→v13 migrate 块（保留单点迁移）。
- `useRepositoryReleaseSheet.ts` 移除与实现不符的旧注释。
- `routeMode.ts` 删除 dead export `getRouteMode`，注释改为"每次调用都拉取最新值"真实语义。
- `useBackupActions.ts` 恢复 routeMode 改走 `setRouteMode` action，与 `setProxyConfig` / `setRpcDownloadConfig` 风格一致。
- `githubApiFactory.ts` 命名 `shouldRouteToBackend` → `shouldAttachBackend`，注释说清"切换 routeMode 只对新建 service 生效"。
- `BackendPanel` 后端不可用时补充 warning，避免用户误以为切换有用。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增“网络请求路由”设置，支持自动、后端代理和浏览器直连三种模式。
  - README、发布信息及 GitHub 请求将按所选模式选择网络出口。
  - 备份与恢复现会保留网络请求路由偏好。
- **改进**
  - 后端不可用或选择直连模式时，可直接访问 GitHub 获取内容及下载资源。
  - 网络设置中补充远程下载流量来源和路由配置说明。
- **兼容性**
  - 缺失或无效的路由配置会自动恢复为“自动”模式。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->