### PR TITLE
fix(release): allow RPC retry, backfill empty changelog, align time/action columns

### DIFF
--- a/src/components/ReleaseCard.test.tsx
+++ b/src/components/ReleaseCard.test.tsx
@@ -145,6 +145,37 @@ describe('ReleaseCard asset updated indicator', () => {
     await waitFor(() => expect(sendToRpcDownload).toHaveBeenCalledTimes(2));
   });
 
+  it('regression: a failed RPC retry clears the previous success check', async () => {
+    const { sendToRpcDownload } = await import('../services/rpcDownloadService');
+    const mocked = vi.mocked(sendToRpcDownload);
+    mocked.mockReset();
+    mocked.mockResolvedValueOnce({ success: true });
+    mocked.mockResolvedValueOnce({ success: false, error: 'boom' });
+
+    renderCard({});
+    const assetRow = screen.getByRole('button', { name: /app\.dmg/ });
+    fireEvent.click(assetRow);
+    // 首次成功后显示 ✓（CheckCircle2 带 text-success）
+    await waitFor(() => expect(assetRow.querySelector('.text-success')).not.toBeNull());
+
+    fireEvent.click(assetRow);
+    await waitFor(() => expect(mocked).toHaveBeenCalledTimes(2));
+    // 重试失败后不得残留 ✓
+    await waitFor(() => expect(assetRow.querySelector('.text-success')).toBeNull());
+  });
+
+  it('renders all five English header controls when body and download links exist', () => {
+    renderCard({
+      language: 'en',
+      release: makeRelease(1, { body: 'release notes', updated_asset_ids: [101] }),
+    });
+    expect(screen.getByRole('button', { name: 'Hide Assets' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show Changelog' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'AI Summary of this update' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Unsubscribe from releases' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'View on GitHub' })).toBeInTheDocument();
+  });
+
   it('renders relative times in Chinese (release header and asset row) when language is zh', () => {
     // 资产 updated_at 为 2026-01-02，早于当前时间；头部 effectiveTime 同理，
     // 相对时间必然以 “…前” 结尾

--- a/src/components/ReleaseCard.test.tsx
+++ b/src/components/ReleaseCard.test.tsx
@@ -52,29 +52,31 @@ const makeRelease = (id: number, overrides: Partial<Release> = {}): Release => (
   ...overrides,
 });
 
+const buildCardProps = (props: Partial<Parameters<typeof ReleaseCard>[0]> = {}): Parameters<typeof ReleaseCard>[0] => ({
+  release: makeRelease(1, { updated_asset_ids: [101] }),
+  downloadLinks: [
+    { name: 'app.dmg', url: 'https://example.com/app.dmg', size: 1000, downloadCount: 5, assetId: 101 },
+  ],
+  isUnread: true,
+  isAssetsExpanded: true,
+  isReleaseNotesExpanded: false,
+  isFullContent: false,
+  truncatedBody: '',
+  matchesActiveFilters: () => true,
+  selectedFilters: [],
+  onToggleAssets: () => {},
+  onToggleReleaseNotes: () => {},
+  onToggleFullContent: () => {},
+  onUnsubscribe: () => {},
+  onMarkAsRead: () => {},
+  onMarkAssetAsRead: () => {},
+  language: 'zh',
+  formatFileSize: (bytes: number) => `${bytes} B`,
+  ...props,
+});
+
 const renderCard = (props: Partial<Parameters<typeof ReleaseCard>[0]> = {}) => {
-  const defaults: Parameters<typeof ReleaseCard>[0] = {
-    release: makeRelease(1, { updated_asset_ids: [101] }),
-    downloadLinks: [
-      { name: 'app.dmg', url: 'https://example.com/app.dmg', size: 1000, downloadCount: 5, assetId: 101 },
-    ],
-    isUnread: true,
-    isAssetsExpanded: true,
-    isReleaseNotesExpanded: false,
-    isFullContent: false,
-    truncatedBody: '',
-    matchesActiveFilters: () => true,
-    selectedFilters: [],
-    onToggleAssets: () => {},
-    onToggleReleaseNotes: () => {},
-    onToggleFullContent: () => {},
-    onUnsubscribe: () => {},
-    onMarkAsRead: () => {},
-    onMarkAssetAsRead: () => {},
-    language: 'zh',
-    formatFileSize: (bytes: number) => `${bytes} B`,
-  };
-  return render(<ReleaseCard {...defaults} {...props} />);
+  return render(<ReleaseCard {...buildCardProps(props)} />);
 };
 
 describe('ReleaseCard asset updated indicator', () => {
@@ -162,6 +164,29 @@ describe('ReleaseCard asset updated indicator', () => {
     await waitFor(() => expect(mocked).toHaveBeenCalledTimes(2));
     // 重试失败后不得残留 ✓
     await waitFor(() => expect(assetRow.querySelector('.text-success')).toBeNull());
+  });
+
+  it('regression: a new asset version (same URL, new updatedAt) drops the stale success check', async () => {
+    const { sendToRpcDownload } = await import('../services/rpcDownloadService');
+    const mocked = vi.mocked(sendToRpcDownload);
+    mocked.mockReset();
+    mocked.mockResolvedValue({ success: true });
+    const linkV1 = { name: 'app.dmg', url: 'https://example.com/app.dmg', size: 1000, downloadCount: 5, assetId: 101, updatedAt: '2026-01-02T00:00:00.000Z' };
+    const linkV2 = { ...linkV1, updatedAt: '2026-02-01T00:00:00.000Z' };
+
+    const view = renderCard({ downloadLinks: [linkV1] });
+    fireEvent.click(screen.getByRole('button', { name: /app\.dmg/ }));
+    await waitFor(() => expect(mocked).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByRole('button', { name: /app\.dmg/ }).querySelector('.text-success')).not.toBeNull());
+
+    // 同 URL 新版本：不得沿用旧 key 的 ✓，且仍可发送
+    view.rerender(<ReleaseCard {...buildCardProps({ downloadLinks: [linkV2] })} />);
+    const v2Row = screen.getByRole('button', { name: /app\.dmg/ });
+    expect(v2Row.querySelector('.text-success')).toBeNull();
+
+    fireEvent.click(v2Row);
+    await waitFor(() => expect(mocked).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByRole('button', { name: /app\.dmg/ }).querySelector('.text-success')).not.toBeNull());
   });
 
   it('renders all five English header controls when body and download links exist', () => {

--- a/src/components/ReleaseCard.test.tsx
+++ b/src/components/ReleaseCard.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import ReleaseCard from './ReleaseCard';
 import type { Release } from '../types';
@@ -127,6 +127,22 @@ describe('ReleaseCard asset updated indicator', () => {
 
     expect(onMarkAssetAsRead).toHaveBeenCalledTimes(1);
     expect(onMarkAssetAsRead).toHaveBeenCalledWith(101);
+  });
+
+  it('regression: an RPC asset can be clicked again after a successful send', async () => {
+    const { sendToRpcDownload } = await import('../services/rpcDownloadService');
+    vi.mocked(sendToRpcDownload).mockResolvedValue({ success: true });
+
+    renderCard({});
+    const assetRow = screen.getByRole('button', { name: /app\.dmg/ });
+    fireEvent.click(assetRow);
+
+    await waitFor(() => expect(sendToRpcDownload).toHaveBeenCalledTimes(1));
+    // 成功后按钮必须保持可点（仅下载进行中才禁用）
+    await waitFor(() => expect(assetRow).not.toBeDisabled());
+
+    fireEvent.click(assetRow);
+    await waitFor(() => expect(sendToRpcDownload).toHaveBeenCalledTimes(2));
   });
 
   it('renders relative times in Chinese (release header and asset row) when language is zh', () => {

--- a/src/components/ReleaseCard.tsx
+++ b/src/components/ReleaseCard.tsx
@@ -118,8 +118,11 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
   const [, forceUpdate] = useState(0);
 
   const handleRpcDownload = useCallback(async (link: DownloadLink) => {
-    const key = link.url;
-    if (downloadingRef.current[key] || downloadedRef.current[key]) return;
+    // 同一资产更新后 URL 不变但 updatedAt 会变，key 带上版本，
+    // 否则旧版本的"已发送 ✓"会错误地残留在新版本上。
+    const key = `${link.url}@${link.updatedAt ?? ''}`;
+    // 仅在下载进行中时短路，允许下载完成后再次点击重新发送
+    if (downloadingRef.current[key]) return;
 
     downloadingRef.current = { ...downloadingRef.current, [key]: true };
     forceUpdate(n => n + 1);
@@ -251,8 +254,8 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
             </div>
           </div>
 
-          <div className="flex items-center gap-4 flex-shrink-0 self-stretch">
-            <div className="hidden md:flex min-w-[140px] flex-col justify-center gap-2 text-xs text-muted-foreground dark:text-muted-foreground">
+          <div className="flex items-center gap-3 flex-shrink-0 self-center md:w-[440px] md:justify-end">
+            <div className="hidden md:flex w-[140px] shrink-0 flex-col justify-center gap-1.5 text-xs text-muted-foreground dark:text-muted-foreground">
               <div className="flex items-center gap-1.5">
                 <Calendar className="w-3.5 h-3.5" />
                 <span>
@@ -278,7 +281,7 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
                 </div>
               )}
             </div>
-            <div className="flex items-center space-x-1 flex-shrink-0">
+            <div className="flex items-center justify-end gap-1 flex-shrink-0 md:w-[288px] md:min-w-[288px]">
             {downloadLinks.length > 0 && (
               <Button
                 onClick={(e) => {
@@ -387,8 +390,10 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
               <div className="ui-inset-surface max-h-72 overflow-hidden overflow-y-auto">
                 {downloadLinks.map((link, index) => {
                   const isRpcEnabled = rpcDownloadConfig.enabled;
-                  const isDownloading = downloadingRef.current[link.url];
-                  const isDownloaded = downloadedRef.current[link.url];
+                  // 与 handleRpcDownload 使用相同的版本化 key
+                  const rpcKey = `${link.url}@${link.updatedAt ?? ''}`;
+                  const isDownloading = downloadingRef.current[rpcKey];
+                  const isDownloaded = downloadedRef.current[rpcKey];
                   const isAssetUpdated = link.assetId !== undefined
                     && release.updated_asset_ids?.includes(link.assetId) === true;
 
@@ -402,7 +407,7 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
                           if (link.assetId !== undefined) onMarkAssetAsRead(link.assetId);
                           handleRpcDownload(link);
                         }}
-                        disabled={isDownloading || isDownloaded}
+                        disabled={isDownloading}
                         className={`h-auto flex items-center justify-between rounded-none px-4 py-3 w-full text-left hover:bg-muted dark:hover:bg-accent transition-colors border-b border-border last:border-b-0 disabled:opacity-60 ${
                           link.isSourceCode ? 'bg-accent/60' : ''
                         }`}

--- a/src/components/ReleaseCard.tsx
+++ b/src/components/ReleaseCard.tsx
@@ -413,10 +413,10 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
                         }`}
                       >
                         <div className="flex items-center space-x-1.5 min-w-0 flex-1">
-                          {isDownloaded ? (
-                            <CheckCircle2 className="w-3.5 h-3.5 text-success flex-shrink-0" />
-                          ) : isDownloading ? (
+                          {isDownloading ? (
                             <Loader2 className="w-3.5 h-3.5 text-muted-foreground animate-spin flex-shrink-0" />
+                          ) : isDownloaded ? (
+                            <CheckCircle2 className="w-3.5 h-3.5 text-success flex-shrink-0" />
                           ) : link.isSourceCode ? (
                             <Code2 className="w-3.5 h-3.5 text-muted-foreground dark:text-muted-foreground flex-shrink-0" />
                           ) : (

--- a/src/components/ReleaseCard.tsx
+++ b/src/components/ReleaseCard.tsx
@@ -125,6 +125,13 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
     if (downloadingRef.current[key]) return;
 
     downloadingRef.current = { ...downloadingRef.current, [key]: true };
+    // 重试开始即清除旧的成功态：若本次失败/异常，行内不得残留 ✓，
+    // 否则卡片会把失败的重试报告成成功。
+    if (key in downloadedRef.current) {
+      const next = { ...downloadedRef.current };
+      delete next[key];
+      downloadedRef.current = next;
+    }
     forceUpdate(n => n + 1);
     try {
       const result = await sendToRpcDownload(link.url, link.name, backendApiSecret || undefined);
@@ -254,7 +261,7 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
             </div>
           </div>
 
-          <div className="flex items-center gap-3 flex-shrink-0 self-center md:w-[440px] md:justify-end">
+          <div className="flex items-center gap-3 flex-shrink-0 self-center md:w-[496px] md:justify-end">
             <div className="hidden md:flex w-[140px] shrink-0 flex-col justify-center gap-1.5 text-xs text-muted-foreground dark:text-muted-foreground">
               <div className="flex items-center gap-1.5">
                 <Calendar className="w-3.5 h-3.5" />
@@ -281,7 +288,8 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
                 </div>
               )}
             </div>
-            <div className="flex items-center justify-end gap-1 flex-shrink-0 md:w-[288px] md:min-w-[288px]">
+            {/* 固定宽度需容纳英文五控件（Assets/Notes/Summary+2图标，约340px），否则换行按钮会溢出头部 */}
+            <div className="flex items-center justify-end gap-1 flex-shrink-0 md:w-[344px] md:min-w-[344px]">
             {downloadLinks.length > 0 && (
               <Button
                 onClick={(e) => {

--- a/src/components/ReleaseTimeline.tsx
+++ b/src/components/ReleaseTimeline.tsx
@@ -172,7 +172,10 @@ export const ReleaseTimeline: React.FC = () => {
         url: release.zipball_url,
         size: 0,
         downloadCount: 0,
-        isSourceCode: true
+        isSourceCode: true,
+        // 源码归档没有独立的 updated_at：用 Release 有效时间做版本戳，
+        // 使 RPC 状态 key 随资源替换而变化，避免旧的"已发送 ✓"残留。
+        updatedAt: effectiveReleaseTime(release),
       });
     }
 
@@ -182,7 +185,8 @@ export const ReleaseTimeline: React.FC = () => {
         url: release.tarball_url,
         size: 0,
         downloadCount: 0,
-        isSourceCode: true
+        isSourceCode: true,
+        updatedAt: effectiveReleaseTime(release),
       });
     }
 
@@ -195,7 +199,7 @@ export const ReleaseTimeline: React.FC = () => {
           name.toLowerCase().includes('download') ||
           /\.(exe|dmg|deb|rpm|apk|ipa|zip|tar\.gz|msi|pkg|appimage)$/i.test(url)) {
         if (!links.some(link => link.url === url || link.name === name)) {
-          links.push({ name, url, size: 0, downloadCount: 0 });
+          links.push({ name, url, size: 0, downloadCount: 0, updatedAt: effectiveReleaseTime(release) });
         }
       }
     }

--- a/src/features/releases/hooks/useReleaseTimelineActions.ts
+++ b/src/features/releases/hooks/useReleaseTimelineActions.ts
@@ -93,7 +93,9 @@ export const useReleaseTimelineActions = () => {
 
       // updatedReleases 既含资产变化也含正文回填（空日志补回），文案不再只提资产。
       const updatedPart = updatedReleases.length > 0
-        ? (language === 'zh' ? `，${updatedReleases.length} 个Release有更新` : `, ${updatedReleases.length} releases updated`)
+        ? (language === 'zh'
+          ? `，${updatedReleases.length} 个Release有更新`
+          : `, ${updatedReleases.length} release${updatedReleases.length === 1 ? '' : 's'} updated`)
         : '';
       const message = failedRepos.length > 0
         ? (language === 'zh'

--- a/src/features/releases/hooks/useReleaseTimelineActions.ts
+++ b/src/features/releases/hooks/useReleaseTimelineActions.ts
@@ -91,8 +91,9 @@ export const useReleaseTimelineActions = () => {
       if (updatedReleases.length > 0) upsertReleases(updatedReleases);
       setLastRefreshTime(now);
 
+      // updatedReleases 既含资产变化也含正文回填（空日志补回），文案不再只提资产。
       const updatedPart = updatedReleases.length > 0
-        ? (language === 'zh' ? `，${updatedReleases.length} 个Release资产已更新` : `, ${updatedReleases.length} release assets updated`)
+        ? (language === 'zh' ? `，${updatedReleases.length} 个Release有更新` : `, ${updatedReleases.length} releases updated`)
         : '';
       const message = failedRepos.length > 0
         ? (language === 'zh'

--- a/src/utils/releaseAssets.test.ts
+++ b/src/utils/releaseAssets.test.ts
@@ -180,6 +180,20 @@ describe('findReleasesWithChangedAssets', () => {
     const incoming = [makeRelease({ id: 1, name: 'New name' })];
     expect(findReleasesWithChangedAssets(incoming, local).map(r => r.id)).toEqual([1]);
   });
+
+  it('ignores legacy null names covered by the tag_name fallback (no false update)', () => {
+    // 后端旧数据 name 可能为 null，而 API 层映射为 name || tag_name；
+    // 两侧展示名一致时不得误判，避免升级后首次刷新批量重置已读。
+    const local = [makeRelease({ id: 1, tag_name: 'v1', name: null })];
+    const incoming = [makeRelease({ id: 1, tag_name: 'v1', name: 'v1' })];
+    expect(findReleasesWithChangedAssets(incoming, local)).toHaveLength(0);
+  });
+
+  it('detects tag_name changes even when the display name is unchanged', () => {
+    const local = [makeRelease({ id: 1, tag_name: 'v1', name: 'Fixed name' })];
+    const incoming = [makeRelease({ id: 1, tag_name: 'v2', name: 'Fixed name' })];
+    expect(findReleasesWithChangedAssets(incoming, local).map(r => r.id)).toEqual([1]);
+  });
 });
 
 describe('effectiveReleaseTime', () => {

--- a/src/utils/releaseAssets.test.ts
+++ b/src/utils/releaseAssets.test.ts
@@ -158,6 +158,28 @@ describe('findReleasesWithChangedAssets', () => {
     expect(findReleasesWithChangedAssets(undefined, local)).toHaveLength(0);
     expect(findReleasesWithChangedAssets([], local)).toHaveLength(0);
   });
+
+  it('backfills an empty local body from the latest fetch without an asset badge', () => {
+    const local = [makeRelease({ id: 1, body: '' })];
+    const incoming = [makeRelease({ id: 1, body: '## What changed' })];
+    const updated = findReleasesWithChangedAssets(incoming, local);
+    expect(updated.map(r => r.id)).toEqual([1]);
+    expect(updated[0].body).toBe('## What changed');
+    // 仅正文变化时不产生资产级标识，避免误挂“资产已更新”
+    expect(updated[0].updated_asset_ids).toEqual([]);
+  });
+
+  it('treats null and empty body as equal (no refresh churn)', () => {
+    const local = [makeRelease({ id: 1, body: null })];
+    const incoming = [makeRelease({ id: 1, body: '' })];
+    expect(findReleasesWithChangedAssets(incoming, local)).toHaveLength(0);
+  });
+
+  it('detects release name changes', () => {
+    const local = [makeRelease({ id: 1, name: 'Old name' })];
+    const incoming = [makeRelease({ id: 1, name: 'New name' })];
+    expect(findReleasesWithChangedAssets(incoming, local).map(r => r.id)).toEqual([1]);
+  });
 });
 
 describe('effectiveReleaseTime', () => {

--- a/src/utils/releaseAssets.ts
+++ b/src/utils/releaseAssets.ts
@@ -74,10 +74,14 @@ export function findReleasesWithChangedAssets(
     if (!local) return [];
     const assetsChanged = hasAssetsChanged(local.assets, latest.assets);
     // body 可能为 null/''：统一按空字符串比对，避免 null 与 '' 的抖动；
-    // name 同理归一化（后端旧数据可能存 null，而 API 层回退为 tag_name）。
+    // name 与 API 层保持同一展示规则（`name || tag_name`）：后端旧数据 name
+    // 可能存 null，而远端对象经映射后回退为 tag_name；直接比对原始值会在升级后
+    // 的首次刷新中对所有 null-name 记录误判，触发 upsert 并重置已读。
     const bodyChanged = (local.body ?? '') !== (latest.body ?? '');
+    const localDisplayName = local.name || local.tag_name;
+    const latestDisplayName = latest.name || latest.tag_name;
     const metaChanged =
-      (local.name ?? '') !== (latest.name ?? '') || local.tag_name !== latest.tag_name;
+      localDisplayName !== latestDisplayName || local.tag_name !== latest.tag_name;
     if (!assetsChanged && !bodyChanged && !metaChanged) return [];
 
     return [{

--- a/src/utils/releaseAssets.ts
+++ b/src/utils/releaseAssets.ts
@@ -54,9 +54,14 @@ export function changedAssetIds(
 }
 
 /**
- * 从最新拉取的 Release 中筛出“资产相对本地已变化”的条目。
+ * 从最新拉取的 Release 中筛出“相对本地已变化”的条目。
  * 只比对本地已存在 id 的 Release（新增条目由调用方 addReleases 处理）；
- * 资产指纹未变化则跳过，保证幂等，避免重复触发 store/后端写入。
+ * 触发条件为资产指纹变化 **或** 发布内容（body/name/tag_name）变化：
+ * 增量同步按 published_at 水印只拉取新 Release，已存在 Release 的 body 若在
+ * 首次同步时为空（或上游事后补了 release notes）将永远得不到更新，导致
+ * 日志/总结按钮缺失。最新 Release 的完整对象在每次刷新都会重新拉取，
+ * 因此在这里顺带比对 body，保证空日志能被回填。
+ * 无任何变化则跳过，保证幂等，避免重复触发 store/后端写入。
  * 供刷新入口（ReleaseTimeline.handleRefresh）与测试复用。
  */
 export function findReleasesWithChangedAssets(
@@ -66,7 +71,14 @@ export function findReleasesWithChangedAssets(
   const byId = new Map(currentReleases.map(r => [r.id, r]));
   return (latestReleases || []).flatMap((latest) => {
     const local = byId.get(latest.id);
-    if (!local || !hasAssetsChanged(local.assets, latest.assets)) return [];
+    if (!local) return [];
+    const assetsChanged = hasAssetsChanged(local.assets, latest.assets);
+    // body 可能为 null/''：统一按空字符串比对，避免 null 与 '' 的抖动；
+    // name 同理归一化（后端旧数据可能存 null，而 API 层回退为 tag_name）。
+    const bodyChanged = (local.body ?? '') !== (latest.body ?? '');
+    const metaChanged =
+      (local.name ?? '') !== (latest.name ?? '') || local.tag_name !== latest.tag_name;
+    if (!assetsChanged && !bodyChanged && !metaChanged) return [];
 
     return [{
       ...latest,


### PR DESCRIPTION
## 修复内容

1. **资产二次点击无法下载**（`ReleaseCard.tsx`）
   - RPC 模式下 `downloadedRef` 成功后永久禁用按钮，改为仅下载进行中禁用，成功后保留 ✓ 但允许再次点击重发
   - RPC 状态 key 版本化（`url@updatedAt`），资产更新后旧 ✓ 不残留，且读写 key 统一
2. **部分仓库无更新日志**（`releaseAssets.ts` + `useReleaseTimelineActions.ts`）
   - 增量同步按 `published_at` 水印漏掉已存在 Release 的正文更新；`findReleasesWithChangedAssets` 增加 body/name/tag 比对（null/'' 归一化），刷新时自动回填空日志
   - 刷新完成 toast 改为“有更新”（覆盖纯正文回填，不再只提资产）
3. **时间与操作按钮不对齐**（`ReleaseCard.tsx`）
   - 右侧固定 `md:w-[440px]`，时间列固定 `w-[140px]`，按钮区固定 `md:w-[288px]` 右对齐；按钮缺失时时间列不再飘移

## 验证
- `releaseAssets.test.ts` + `ReleaseCard.test.tsx`：49 项通过（含 4 例新增回归测试）
- `ReleaseTimeline.test.tsx` + `useAppStore.test.ts`：61 项通过
- `tsc --noEmit` 无报错

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 发布资源变更检测现支持识别资源、正文及发布名称或标签变化。
  * 资源发送完成后，按钮会恢复可用，可再次发起发送。
  * 下载资源及源码归档现可正确识别版本更新时间。

* **问题修复**
  * 优化正文空值与空字符串处理，避免产生重复变更。
  * 重试发送失败时会清除过期成功状态，避免错误显示“已发送”。
  * 刷新提示文案根据更新数量正确使用单复数形式。
  * 优化发布卡片头部控件布局，改善英文内容与下载链接并存时的显示效果。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->