### PR TITLE
refactor(frontend-layering): ban update/translate services in View, migrate 3 allowlisted components

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,6 +24,8 @@ const BANNED_COMPONENT_SERVICES = [
   'backendAdapter',
   'rpcDownloadService',
   'githubApiFactory',
+  'updateService',
+  'translateService',
 ];
 
 // Static-import ban patterns for no-restricted-imports.
@@ -50,16 +52,13 @@ const BANNED_COMPONENT_SERVICE_DYNAMIC_SELECTORS = BANNED_COMPONENT_SERVICES.map
 const COMPONENT_BOUNDARY_ALLOWLIST = [
   'src/components/SearchBar.tsx',
   'src/components/ReadmeModal.tsx',
-  'src/components/LoginScreen.tsx',
   'src/components/GistCard.tsx',
   'src/components/GistDetailModal.tsx',
   'src/components/GistEditorModal.tsx',
   'src/components/ReleaseCard.tsx',
   'src/components/ReleaseSourceSettingsModal.tsx',
   'src/components/SubscriptionRepoCard.tsx',
-  'src/components/CategorySidebar.tsx',
   'src/components/RepositoryEditModal.tsx',
-  'src/components/DebugModeIndicator.tsx',
   'src/components/SettingsPanel.tsx',
 ];
 

--- a/scripts/check-boundaries.cjs
+++ b/scripts/check-boundaries.cjs
@@ -40,22 +40,21 @@ const BANNED_COMPONENT_SERVICES = [
   'backendAdapter',
   'rpcDownloadService',
   'githubApiFactory',
+  'updateService',
+  'translateService',
 ];
 
 // Mirror of COMPONENT_BOUNDARY_ALLOWLIST in eslint.config.js. Keep in sync.
 const COMPONENT_ALLOWLIST = new Set([
   'src/components/SearchBar.tsx',
   'src/components/ReadmeModal.tsx',
-  'src/components/LoginScreen.tsx',
   'src/components/GistCard.tsx',
   'src/components/GistDetailModal.tsx',
   'src/components/GistEditorModal.tsx',
   'src/components/ReleaseCard.tsx',
   'src/components/ReleaseSourceSettingsModal.tsx',
   'src/components/SubscriptionRepoCard.tsx',
-  'src/components/CategorySidebar.tsx',
   'src/components/RepositoryEditModal.tsx',
-  'src/components/DebugModeIndicator.tsx',
   'src/components/SettingsPanel.tsx',
 ]);
 

--- a/src/components/BilingualMarkdownRenderer.tsx
+++ b/src/components/BilingualMarkdownRenderer.tsx
@@ -9,7 +9,7 @@ import {
   wrapTextNodesWithAttr,
   unwrapSpans,
 } from '../utils/domTextScanner';
-import { translateBatch, TranslateResult } from '../services/translateService';
+import { useTranslationActions, type TranslateResult } from '../features/settings/hooks/useTranslationActions';
 import { detectLanguage, getTranslateDirection, cleanTranslatedText } from '../utils/markdownSplitter';
 import { FileText, Languages, Eye, Loader2 } from 'lucide-react';
 
@@ -84,6 +84,7 @@ const BilingualMarkdownRenderer = forwardRef<BilingualMarkdownRendererHandle, Bi
   onProgressRef.current = onProgress;
 
   const [internalDisplayMode, setInternalDisplayMode] = useState<DisplayMode>(defaultDisplayMode);
+  const { translateBatch } = useTranslationActions();
   const [status, setStatus] = useState<TranslationStatus>('idle');
   const [progress, setProgress] = useState({ current: 0, total: 0 });
   const [error, setError] = useState<string | null>(null);
@@ -290,7 +291,7 @@ const BilingualMarkdownRenderer = forwardRef<BilingualMarkdownRendererHandle, Bi
       setError(err instanceof Error ? err.message : 'Translation failed');
       updateStatus('error');
     }
-  }, [language, scan, updateStatus, removeTranslations]);
+  }, [language, scan, updateStatus, removeTranslations, translateBatch]);
 
   const revert = useCallback(() => {
     if (abortRef.current) {

--- a/src/components/CategorySidebar.tsx
+++ b/src/components/CategorySidebar.tsx
@@ -12,7 +12,7 @@ import { Category, Repository } from '../types';
 import { useAppStore, getAllCategories, sortCategoriesByOrder } from '../store/useAppStore';
 import { useShallow } from 'zustand/react/shallow';
 import { CategoryEditModal } from './CategoryEditModal';
-import { forceSyncToBackend } from '../services/autoSync';
+import { useCategorySyncActions } from '../features/repositories/hooks/useCategorySyncActions';
 import { getAICategory, getDefaultCategory, computeCustomCategory, matchesCategory } from '../utils/categoryUtils';
 import { useDialog } from '../hooks/useDialog';
 
@@ -58,6 +58,7 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
   })));
 
   const { toast, confirm } = useDialog();
+  const { forceSyncToBackend } = useCategorySyncActions();
 
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [editingCategory, setEditingCategory] = useState<Category | null>(null);

--- a/src/components/DebugModeIndicator.tsx
+++ b/src/components/DebugModeIndicator.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { logger } from '../services/logger';
-import { backend } from '../services/backendAdapter';
+import { useDebugActions } from '../features/settings/hooks/useDebugActions';
 import { useAppStore } from '../store/useAppStore';
 import { Button } from './ui/button';
 
@@ -13,6 +13,7 @@ export const DebugModeIndicator: React.FC = () => {
   const [frontendDebug, setFrontendDebug] = useState(() => sessionStorage.getItem('gsm:frontend-debug') === 'true');
   const [backendDebug, setBackendDebug] = useState(() => sessionStorage.getItem('gsm:backend-debug') === 'true');
   const setCurrentView = useAppStore(s => s.setCurrentView);
+  const { disableBackendDebug } = useDebugActions();
 
   // Sync with sessionStorage changes (e.g. from DiagnosticLogsPanel)
   useEffect(() => {
@@ -37,16 +38,7 @@ export const DebugModeIndicator: React.FC = () => {
     setFrontendDebug(false);
 
     // Disable backend debug
-    if (backend.isAvailable) {
-      try {
-        const secret = sessionStorage.getItem('github-stars-manager-backend-secret');
-        await fetch('/api/logs/debug', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${secret}` },
-          body: JSON.stringify({ enabled: false }),
-        });
-      } catch { /* Backend unreachable */ }
-    }
+    await disableBackendDebug();
     sessionStorage.setItem('gsm:backend-debug', 'false');
     setBackendDebug(false);
 
@@ -57,7 +49,7 @@ export const DebugModeIndicator: React.FC = () => {
     setCurrentView('settings');
     // Also dispatch event as a backup for same-instance navigation
     window.dispatchEvent(new CustomEvent('gsm:navigate-to-settings-tab', { detail: { tab: 'logs' } }));
-  }, [setCurrentView]);
+  }, [setCurrentView, disableBackendDebug]);
 
   if (!frontendDebug && !backendDebug) return null;
 

--- a/src/components/LoginScreen.tsx
+++ b/src/components/LoginScreen.tsx
@@ -2,8 +2,7 @@ import React, { useState } from 'react';
 import { AlertCircle, ArrowRight, Github, Key, Moon, Sun } from 'lucide-react';
 import { useAppStore } from '../store/useAppStore';
 import { useShallow } from 'zustand/react/shallow';
-import { GitHubApiService } from '../services/githubApi';
-import { backend } from '../services/backendAdapter';
+import { useLoginActions } from '../features/lifecycle/hooks/useLoginActions';
 import { safeReadText } from '../utils/clipboardUtils';
 import { Button } from './ui/button';
 import { Card } from './ui/card';
@@ -25,6 +24,7 @@ export const LoginScreen: React.FC = () => {
     theme: state.theme,
     setTheme: state.setTheme,
   })));
+  const { authenticateWithGitHub, syncTokenToBackend } = useLoginActions();
 
   const handleConnect = async () => {
     if (!token.trim()) {
@@ -36,20 +36,18 @@ export const LoginScreen: React.FC = () => {
     setError('');
 
     try {
-      const githubApi = new GitHubApiService(token);
-      const user = await githubApi.getCurrentUser();
+      const user = await authenticateWithGitHub(token);
       setGitHubToken(token);
       setUser(user);
 
-      if (backend.isAvailable) {
-        try {
-          await backend.syncSettings({ github_token: token });
-        } catch (backendError) {
-          console.warn('Failed to save GitHub token to backend:', backendError);
-          setError(language === 'zh'
-            ? '已登录，但 GitHub Token 未能保存到后端，README 等后端代理功能可能不可用。'
-            : 'Signed in, but failed to save GitHub token to backend. README and other backend proxy features may be unavailable.');
-        }
+      // syncTokenToBackend checks backend availability itself at call time and
+      // returns { ok: true } when the backend is unreachable-by-design; only a
+      // real failure surfaces the warning banner below.
+      const { ok } = await syncTokenToBackend(token);
+      if (!ok) {
+        setError(language === 'zh'
+          ? '已登录，但 GitHub Token 未能保存到后端，README 等后端代理功能可能不可用。'
+          : 'Signed in, but failed to save GitHub token to backend. README and other backend proxy features may be unavailable.');
       }
 
       console.log('Successfully authenticated user:', user);

--- a/src/components/RepositoryCard.lazyReadme.test.tsx
+++ b/src/components/RepositoryCard.lazyReadme.test.tsx
@@ -110,7 +110,9 @@ describe('RepositoryCard README lazy boundary', () => {
     }));
 
     const { RepositoryCard } = await import('./RepositoryCard');
-    const user = userEvent.setup();
+    // delay: null removes artificial keystroke/click delays so the test does not
+    // depend on wall-clock timing when the suite runs 60+ files in parallel.
+    const user = userEvent.setup({ delay: null });
 
     render(
       <TooltipProvider>
@@ -122,10 +124,12 @@ describe('RepositoryCard README lazy boundary', () => {
     trigger.focus();
     await user.keyboard('{Enter}');
 
-    await user.click(await screen.findByRole('button', { name: 'Close README' }));
+    // The README modal is React.lazy-loaded; under parallel load the chunk can
+    // take longer than findBy's default 1s timeout to resolve.
+    await user.click(await screen.findByRole('button', { name: 'Close README' }, { timeout: 10_000 }));
 
     expect(trigger).toHaveFocus();
-  });
+  }, 15_000);
 
   it('renders the existing error boundary when the README lazy chunk cannot load', async () => {
     vi.doMock('./ReadmeModal', () => {
@@ -133,7 +137,7 @@ describe('RepositoryCard README lazy boundary', () => {
     });
 
     const { RepositoryCard } = await import('./RepositoryCard');
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
 
     render(
       <TooltipProvider>
@@ -143,6 +147,6 @@ describe('RepositoryCard README lazy boundary', () => {
 
     await user.click(screen.getByRole('button', { name: /owner\/example-repository/i }));
 
-    expect(await screen.findByRole('heading', { name: 'Application Error' })).toBeInTheDocument();
-  });
+    expect(await screen.findByRole('heading', { name: 'Application Error' }, { timeout: 10_000 })).toBeInTheDocument();
+  }, 15_000);
 });

--- a/src/components/UpdateChecker.tsx
+++ b/src/components/UpdateChecker.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Calendar, Download, ExternalLink, Package, RefreshCw } from 'lucide-react';
-import { UpdateService, VersionInfo } from '../services/updateService';
+import { useUpdateActions, type VersionInfo } from '../features/settings/hooks/useUpdateActions';
 import { useAppStore } from '../store/useAppStore';
 import { useShallow } from 'zustand/react/shallow';
 import { useDialog } from '../hooks/useDialog';
@@ -17,6 +17,7 @@ export const UpdateChecker: React.FC<UpdateCheckerProps> = ({ onUpdateAvailable 
     setUpdateNotification: state.setUpdateNotification,
   })));
   const { toast } = useDialog();
+  const { checkForUpdates: checkForUpdatesRemote, openDownloadUrl } = useUpdateActions();
   const [isChecking, setIsChecking] = useState(false);
   const [updateInfo, setUpdateInfo] = useState<VersionInfo | null>(null);
   const [showUpdateDialog, setShowUpdateDialog] = useState(false);
@@ -28,7 +29,7 @@ export const UpdateChecker: React.FC<UpdateCheckerProps> = ({ onUpdateAvailable 
     setIsChecking(true);
     setError(null);
     try {
-      const result = await UpdateService.checkForUpdates();
+      const result = await checkForUpdatesRemote();
       if (result.hasUpdate && result.latestVersion) {
         setUpdateInfo(result.latestVersion);
         setShowUpdateDialog(true);
@@ -55,7 +56,7 @@ export const UpdateChecker: React.FC<UpdateCheckerProps> = ({ onUpdateAvailable 
 
   const handleDownload = () => {
     if (updateInfo?.downloadUrl) {
-      UpdateService.openDownloadUrl(updateInfo.downloadUrl);
+      openDownloadUrl(updateInfo.downloadUrl);
       setShowUpdateDialog(false);
     }
   };

--- a/src/components/UpdateNotificationBanner.tsx
+++ b/src/components/UpdateNotificationBanner.tsx
@@ -1,7 +1,7 @@
 import { Calendar, Download, Package, X } from 'lucide-react';
 import { useAppStore } from '../store/useAppStore';
 import { useShallow } from 'zustand/react/shallow';
-import { UpdateService } from '../services/updateService';
+import { useUpdateActions } from '../features/settings/hooks/useUpdateActions';
 import { Button } from './ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 
@@ -12,11 +12,12 @@ export const UpdateNotificationBanner: React.FC = () => {
     language: state.language,
   })));
   const t = (zh: string, en: string) => language === 'zh' ? zh : en;
+  const { openDownloadUrl } = useUpdateActions();
 
   if (!updateNotification || updateNotification.dismissed) return null;
 
   const handleDownload = () => {
-    UpdateService.openDownloadUrl(updateNotification.downloadUrl);
+    openDownloadUrl(updateNotification.downloadUrl);
     dismissUpdateNotification();
   };
 

--- a/src/features/lifecycle/hooks/useLoginActions.ts
+++ b/src/features/lifecycle/hooks/useLoginActions.ts
@@ -1,0 +1,27 @@
+import { useCallback } from 'react';
+import { GitHubApiService } from '../../../services/githubApi';
+import { backend } from '../../../services/backendAdapter';
+import type { GitHubUser } from '../../../types';
+
+export interface LoginActions {
+  authenticateWithGitHub: (token: string) => Promise<GitHubUser>;
+  syncTokenToBackend: (token: string) => Promise<{ ok: boolean }>;
+}
+
+export const useLoginActions = (): LoginActions => {
+  const authenticateWithGitHub = useCallback(async (token: string) => {
+    const api = new GitHubApiService(token);
+    return api.getCurrentUser();
+  }, []);
+  const syncTokenToBackend = useCallback(async (token: string) => {
+    if (!backend.isAvailable) return { ok: true };
+    try {
+      await backend.syncSettings({ github_token: token });
+      return { ok: true };
+    } catch (e) {
+      console.warn('Failed to save GitHub token to backend:', e);
+      return { ok: false };
+    }
+  }, []);
+  return { authenticateWithGitHub, syncTokenToBackend };
+};

--- a/src/features/repositories/hooks/useCategorySyncActions.ts
+++ b/src/features/repositories/hooks/useCategorySyncActions.ts
@@ -1,0 +1,11 @@
+import { useCallback } from 'react';
+import { forceSyncToBackend } from '../../../services/autoSync';
+
+export interface CategorySyncActions {
+  forceSyncToBackend: () => Promise<void>;
+}
+
+export const useCategorySyncActions = (): CategorySyncActions => {
+  const sync = useCallback(() => forceSyncToBackend(), []);
+  return { forceSyncToBackend: sync };
+};

--- a/src/features/settings/hooks/useDebugActions.ts
+++ b/src/features/settings/hooks/useDebugActions.ts
@@ -1,0 +1,22 @@
+import { useCallback } from 'react';
+import { backend } from '../../../services/backendAdapter';
+
+export interface DebugActions {
+  disableBackendDebug: () => Promise<void>;
+}
+
+export const useDebugActions = (): DebugActions => {
+  const disableBackendDebug = useCallback(async () => {
+    if (backend.isAvailable) {
+      try {
+        const secret = sessionStorage.getItem('github-stars-manager-backend-secret');
+        await fetch('/api/logs/debug', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${secret}` },
+          body: JSON.stringify({ enabled: false }),
+        });
+      } catch { /* Backend unreachable — same silent behavior as the component */ }
+    }
+  }, []);
+  return { disableBackendDebug };
+};

--- a/src/features/settings/hooks/useTranslationActions.ts
+++ b/src/features/settings/hooks/useTranslationActions.ts
@@ -1,0 +1,19 @@
+import { useCallback } from 'react';
+import { translateBatch } from '../../../services/translateService';
+import type { TranslateResult } from '../../../services/translateService';
+
+export type { TranslateResult };
+
+export interface TranslationActions {
+  translateBatch: typeof translateBatch;
+}
+
+export const useTranslationActions = (): TranslationActions => {
+  // Pure passthrough for layering compliance; Parameters<> keeps the signature
+  // locked to the service so the two cannot drift apart.
+  const run = useCallback(
+    (...args: Parameters<typeof translateBatch>) => translateBatch(...args),
+    [],
+  );
+  return { translateBatch: run };
+};

--- a/src/features/settings/hooks/useUpdateActions.ts
+++ b/src/features/settings/hooks/useUpdateActions.ts
@@ -1,0 +1,16 @@
+import { useCallback } from 'react';
+import { UpdateService } from '../../../services/updateService';
+import type { UpdateCheckResult, VersionInfo } from '../../../services/updateService';
+
+export type { UpdateCheckResult, VersionInfo };
+
+export interface UpdateActions {
+  checkForUpdates: () => Promise<UpdateCheckResult>;
+  openDownloadUrl: (url: string) => void;
+}
+
+export const useUpdateActions = (): UpdateActions => {
+  const checkForUpdates = useCallback(() => UpdateService.checkForUpdates(), []);
+  const openDownloadUrl = useCallback((url: string) => UpdateService.openDownloadUrl(url), []);
+  return { checkForUpdates, openDownloadUrl };
+};


### PR DESCRIPTION
## Summary
- `updateService` / `translateService` 纳入 View 层封禁（`eslint.config.js` + `scripts/check-boundaries.cjs` 的 `BANNED_COMPONENT_SERVICES`），类型经 hook 重导出，组件零 `services/` 导入
- 新增 5 个 action hook：`useUpdateActions`、`useTranslationActions`、`useDebugActions`、`useLoginActions`（`lifecycle/hooks/`）、`useCategorySyncActions`
- 迁移 6 个组件：`UpdateNotificationBanner`、`UpdateChecker`（alias 避命名冲突）、`BilingualMarkdownRenderer`、`DebugModeIndicator`（裸 fetch 整块搬进 hook）、`LoginScreen`（warning 文案保留在组件）、`CategorySidebar`
- allowlist 移除 3 项（`LoginScreen`、`CategorySidebar`、`DebugModeIndicator`），剩余 10 项
- 修复审计问题：`LoginScreen` 后端可用性改为调用时 fresh 检查；删除无消费者 API；`translateBatch` 透传改 `Parameters<>` 锁定签名
- 稳定 `RepositoryCard.lazyReadme` focus 测试的并行负载 flake（`delay: null` + 放宽等待/超时）

## Test Plan
- [x] `node scripts/check-boundaries.cjs` — no violations
- [x] `npx eslint .` — clean
- [x] `npx tsc -b` — clean
- [x] `npm run test:run` — 68 files, 646/646 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化登录、翻译、分类同步、调试模式及应用更新相关操作的稳定性与一致性。
  - 登录后端令牌同步流程更加可靠，并在同步失败时提供明确提示。
  - 更新检查、下载和调试模式操作的处理方式得到统一。

- **测试**
  - 增强 README 延迟加载及应用错误场景的测试稳定性，减少偶发测试失败。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->