### PR TITLE
refactor(frontend-layering): 清零组件边界 allowlist，10 项组件动作全部收敛进 hook

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,8 +36,6 @@ layering violation fails the job before the slower steps.
 - [ ] No new `import` of React/JSX/the Store/any service into `src/features/*/application/**`
       (static or dynamic).
 - [ ] No inline `eslint-disable` to bypass the boundary rules — fix the layering instead.
-- [ ] If this PR migrates a component off the allowlist in `eslint.config.js` /
-      `scripts/check-boundaries.cjs`, that entry is removed in the same PR.
 
 ### Runtime / persistence / UI changes (if any)
 

--- a/docs/plans/allowlist-migration-plan.md
+++ b/docs/plans/allowlist-migration-plan.md
@@ -1,0 +1,448 @@
+# allowlist 清零迁移实施规格 v2（ADR 0001 · B 方案：搬运 + 顺手提纯 · 单 PR）
+
+- **Status**: 实施规格（Accepted on merge）
+- **仓库根**: 本仓库（GithubStarsManager）
+- **契约**: `docs/adr/0001-frontend-layering.md`（View → Hook → Application → Service → Store）
+- **目标**: `eslint.config.js` 的 `COMPONENT_BOUNDARY_ALLOWLIST`（52-63 行，恰 10 项）与 `scripts/check-boundaries.cjs` 的 `COMPONENT_ALLOWLIST`（48-59 行，镜像 10 项）**机制整体删除**（非置空）；10 个 View 组件的远程调用与 Store 写入全部收敛进 hook。
+- **行为基线**: 行为零变更。唯一例外 = `useRepositoryReleaseSheet` 委托共享 hook 的 **3 处已声明微差异**（§2.5，须在 PR 描述列明）；GistEditorModal 类型解套零行为影响。
+- **吸收的审计结论**: 第一轮 A1–A8 + 第二轮 B1–B8（附录二表，共 16 条已逐条修复进本文）。
+- **文案铁律**: 所有 toast/confirm/错误文案**以原文件现行为准逐字抄录**，禁止转写、概括或"顺手优化"。本文出现的文案仅为定位指引。
+
+---
+
+## 0. 背景与现状（10 项 allowlist 口径）
+
+PR 0–8 完成非破坏性迁移，PR 9 用 ESLint + `check-boundaries.cjs` 固化边界并留 10 项分阶段 allowlist。**两处 allowlist 常量为唯一真值**（ADR §Phased enforcement 的 13 项举例名单已过期：LoginScreen/CategorySidebar/DebugModeIndicator 早已无违规，勿追查）。
+
+ban list 12 项（`eslint.config.js:16-29` 与 `check-boundaries.cjs:32-45` 一致）：`githubApi / aiService / aiAnalysisHelper / aiAnalysisOptimizer / vectorSearchService / autoSync / webdavService / backendAdapter / rpcDownloadService / githubApiFactory / updateService / translateService`。注意 ADR 正文仍写 10 项（称 updateService/translateService 未禁）——**文档落后于实现，以 12 项为准**，ADR 勘误列 follow-up（§10），本 PR 不改 ADR。
+
+| # | 文件 | 业务服务直引 | 迁移落点 |
+|---|---|---|---|
+| 1 | `src/components/SearchBar.tsx` | aiService、vectorSearchService、githubApi、githubApiFactory、autoSync（5 服务，最重，1618 行） | `useSearchActions`（新建，repositories/hooks） |
+| 2 | `src/components/SubscriptionRepoCard.tsx` | aiAnalysisHelper、autoSync、githubApi | `useDiscoveryRepoActions`（新建，discovery/hooks） |
+| 3 | `src/components/GistCard.tsx` | githubApiFactory、aiService | `useGistActions`（扩展） |
+| 4 | `src/components/GistDetailModal.tsx` | githubApiFactory | `useGistActions.fetchGistFileRaw`（扩展） |
+| 5 | `src/components/GistEditorModal.tsx` | 仅 `import type`，零运行时（误伤） | 类型改从 `useGistActions` 重导出引（§5） |
+| 6 | `src/components/ReleaseCard.tsx` | rpcDownloadService、aiService | `useReleaseArtifactActions`（新建，src/hooks） |
+| 7 | `src/components/ReadmeModal.tsx` | githubApi、backendAdapter（另引 routeMode，非 banned） | `useReadmeFetch`（新建，src/hooks） |
+| 8 | `src/components/ReleaseSourceSettingsModal.tsx` | githubApi | `useReleaseTimelineActions.syncWatchedSources`（新增方法） |
+| 9 | `src/components/RepositoryEditModal.tsx` | autoSync（仅 1 处） | `useCategorySyncActions`（既有，直接复用） |
+| 10 | `src/components/SettingsPanel.tsx` | backendAdapter.backend.isAvailable 门控 | `useBackendAvailability`（新建，settings/hooks） |
+
+`src/components/ui/**` 零违规，保持不动。`updateService/translateService` 在 components 已零违规，执行时勿再追查（第一轮 A6）。
+
+---
+
+## 1. 总则
+
+### 1.1 原则
+
+1. **只搬运不改语义**。每个动作按 §1.2 保序表逐句搬运，含 toast/confirm 文案、console 诊断、错误分支与降级路径。
+2. **分析类动作不 forceSync**。只有 star/unstar/save/sync 类动作调用 `forceSyncToBackend()`，且 await 点与原文件一致（逐动作见 §1.2，硬约束）。
+3. **API 形态贴近既有惯例**：零参 hook 内部自建 `t`（`useGistActions`/`useReleaseTimelineActions` 先例）；需注入时用 `{ t }` 参数（`useStarSyncActions`/`useBackendSettingsActions` 先例）；confirm/toast 走 `useDialog`；Store 读取用 selector + `useShallow`；返回值 `useMemo` 稳定（`useRepositoryCardActions` 先例；在被扩展的既有文件内保持该文件原有风格，不回溯改造）。
+4. **原文件里 `useAppStore.getState()` 的非响应式读取保持 `getState()`**（如 SearchBar 的 vsConfig/storeRepos 读取），不改成响应式 selector。
+
+### 1.2 逐动作保序表（搬运时逐一对照；**粗体**为 forceSync 点）
+
+| # | 源动作（文件:行，基线行号） | 原调用顺序（→ 为顺序） | 归宿 |
+|---|---|---|---|
+| 1 | SearchBar.handleAISearch (370-559) | View-UI 状态留 View → isSearching/searchPhase → vectorScoreMapRef 清空 → [vsConfig 门控(enabled&&workerUrl&&activeEmbConfig) → 每次新建 EmbeddingClient/VectorSearchService → HyDE（仅 enableHyDE!==false&&hydeConfig；局部 AbortController + Promise.race 5s 超时降级回原 query）→ embed → query(topK??30, threshold??0.35) → 本地 keyword 加分 → AI rerank（仅 enableReranking!==false，无 signal，失败仅 console.warn 回退向量序）→ setSearchResults + setSearchFilters + skipNextTextSearchRef=true + vectorScoreMapRef 写入 + return] 或落关键词分支 [activeConfig? → searchRepositoriesWithReranking（失败回退 performBasicTextSearch）: performBasicTextSearch] → applyFilters(结果) → setSearchResults → setSearchFilters | useSearchActions.aiSearch / keywordSearch |
+| 2 | SearchBar.handleStarSync (714-926) | token 校验 toast → setSyncingStars(true) → new GitHubApiService → getAllStarredRepositories → 与 getState().repositories 逐字段合并（license `?? null` 回填）→ [stars-and-lists 时: createGitHubListsApiService → getUserLists(login)（无 login 抛错）→ 建缺失自定义分类(addCustomCategory，id=`custom-sync-${Date.now()}-${idx}`) → preExistingLocked 集 → 打标签/设分类/加锁循环 → appliedTagsCount toast（两种文案）→ list 失败 toast 后**不中断**星标结果] → setRepositories(final) → **await forceSyncToBackend()** → setLastSync → 新仓库数 toast（success/info 两分支）→ catch：message 含 'token' 专属文案 / 通用文案 → finally setSyncingStars(false) | useSearchActions.syncStars |
+| 3 | SearchBar.handleStarAndListSync (941-958) | confirm(warning，原文案) → handleStarSync('stars-and-lists') | **View 保留 confirm 包装**（§2.1；'auto'/'stars-only' 入口原无确认，勿加） |
+| 4 | SubscriptionRepoCard.executeUnstar (91-125) | 无 token 静默 return → setIsStarring → 乐观 setOptimisticStarred(false) → new GitHubApiService → unstarRepository(owner,name) → deleteRepository(按 full_name 查 id) → **await forceSyncToBackend()** → 乐观清 null；catch：回滚乐观 + toast（原文案）；finally setIsStarring(false)。**成功无 toast**。确认走自定义 Modal（留 View，B8） | useDiscoveryRepoActions.executeUnstar |
+| 5 | SubscriptionRepoCard.handleStar (128-183) | isStarring 短路 → 乐观(true) → starRepository(owner,name) → 构造 repositoryToAdd（rank/channel/platform 置 undefined + starred_at）→ addRepository → onStar(repo) → **await forceSyncToBackend()** → 乐观清 null → toast 成功；catch 回滚 + toast | useDiscoveryRepoActions.star |
+| 6 | SubscriptionRepoCard.handleAnalyze (193-274) | 三段校验 toast（token→无配置→apiKeyStatus→baseUrl/apiKey/model，**文案取本文件原文**，与 useRepositoryCardActions 措辞不同）→ isAnalyzing 短路 → abort 上一请求（abortControllerRef，unmount abort）→ analyzeRepository({repository: repo, githubToken, aiConfig, language, categories, signal})（aiAnalysisHelper）→ aborted 则 return → 成功 patch（ai_summary/ai_tags/ai_platforms/analyzed_at/analysis_failed/analysis_error:undefined，**无 custom_category/category_locked**）→ updateDiscoveryRepo → onAnalyze(updatedRepo)。**无 forceSync、成功无 toast、无重分析 confirm**（勿照 RepositoryCard "补齐"）；catch（非 abort）：createFailedAnalysisResult → 失败 patch → updateDiscoveryRepo → toast | useDiscoveryRepoActions.analyze |
+| 7 | GistCard.handleAnalyze (68-120) | 三段校验（gist 版原文案）→ 已分析则 confirm 覆盖（原文案）→ setAnalyzingGist(id,true)（store）+ 本地 flag → createGitHubApiService → getGistForAnalysis(id, gist) → new AIService → analyzeGist(detail, api.getGistContentPreview(detail))（**无 Abort**）→ updateGist(成功 patch) → toast；catch → updateGist(失败 patch) → toast；finally 双 flag 复位。**无 forceSync** | useGistActions.analyzeOne |
+| 8 | GistCard.handleUnstar (122-143) | 无 token 静默 return → confirm(warning+confirmText 原文案) → api.unstarGist(id) → onUnstarred(gist.id) → updateGist({starred:false}) → toast；catch toast。**无 forceSync** | useGistActions.unstarGist |
+| 9 | GistCard.handleDelete (145-174) | 无 token/isMine 静默 return → confirm(danger+confirmText 原文案) → api.deleteGist(id) → store.deleteGist → onDeleted(gist.id) → toast；catch：403/404/forbidden/scope/permission → 权限提示 toast（原文案）。**无 forceSync** | useGistActions.deleteGist |
+| 10 | GistDetailModal.HighlightedCode effect (45-80) | needsRawFetch=(truncated\|\|!content)&&raw_url → 局部 AbortController（cleanup abort）→ 无 token：setRawError(原文案) → createGitHubApiService().getGistFileRaw(raw_url, signal) → setRawContent + onContentLoaded 回写（本地缓存 + store updateGist，key `${gist.id}:${filename}:${rawUrl}`）；catch：abort 先 return，'Aborted' → 取消文案；retry 按钮 retryTick。**Abort/retry/局部缓存留 View** | useGistActions.fetchGistFileRaw |
+| 11 | ReleaseCard.handleRpcDownload (120-155) | key=`${url}@${updatedAt??''}` → sending 短路 → 重试先清 sent → forceUpdate → sendToRpcDownload(url, name, backendApiSecret\|\|undefined)（**三参**）→ success：mark sent + toast；failure：'RPC service not running' 专属分支 / result.error / 通用失败 → toast(error)；catch：RPC 未运行文案 → toast；finally sending=false + forceUpdate | useReleaseArtifactActions.sendRpcDownload |
+| 12 | ReleaseCard.runSummaryAnalysis (160-206) | 无 activeConfig → toast（原文案）→ abort 上一（summaryAbortRef，unmount abort）→ new AIService → analyzeReleaseSummary(release.body\|\|'', {repoName, tagName, releaseName}, signal) → done(content)+展开；catch AbortError 静默 return / 否则 error(message)+展开+toast。无 store 写、**无 forceSync**。summary 状态机 idle/loading/done/error 为本地态不持久化 | useReleaseArtifactActions.generateSummary |
+| 13 | ReadmeModal 两 fetcher (332-392) | shouldBypassBackend()\|\|!backend.isAvailable → 直连 GitHubApiService（content 路径无 token 抛原文案 / candidates 路径无 token 返回 []）；否则 backend.*，失败且非 abort、有 token → console.warn(原文案) + fallback 直连。两个 controller，fetch 前 abort 上一，unmount/关闭 abort+置 null | useReadmeFetch |
+| 14 | ReleaseSourceSettingsModal → WatchCustomReleaseSyncPanel.handleSync (221-249) | 无 token/isSyncing **静默** return（无 toast）→ new GitHubApiService → getAllWatchedRepositories()（仅 /user/subscriptions）→ repositoryToCustomReleaseRepository(repo, WATCH_CUSTOM_RELEASE_SOURCE_ID) 映射 + 保留既有 release_hidden → setReleaseSourceRepositories(sourceId, repos)（store）→ toast(success)；catch toast(error)；finally isSyncing 复位。**无 forceSync、无 confirm、无 Abort** | useReleaseTimelineActions.syncWatchedSources |
+| 15 | RepositoryEditModal.handleSave 尾部 (402-404) | updateRepository(updatedRepo) → **await forceSyncToBackend()** → onClose() | 复用 useCategorySyncActions |
+
+### 1.3 禁止事项（红线）
+
+- **禁止跨 feature 引 hook**（ADR 脚注²）：`useDiscoveryRepoActions` 不得 import `useRepositoryCardActions`（抄模式，不 import）；hook 只能调本 feature hook 或 `src/hooks/**` 共享 hook。
+- **禁止新建 application 目录**：仅允许在既有 `src/features/repositories/application/` 内新增一个文件（§3.1）；search/gists/releases 的提纯全部放各 hook 文件内导出。新 application 目录列 follow-up。
+- **禁止动 Store**：不改任何 slice 的 state/action 形状，不碰 `partialize/migrate/merge/version`；`src/store/useAppStore.modularization.test` 零改动。
+- **禁止改 12 项 BANNED_COMPONENT_SERVICES**（两处门禁各 12 项，不增不减）。
+- **禁止 `allowTypeImports: true`**：`check-boundaries.cjs` 的 `IMPORT_RE`（74-75 行）同样匹配 `import type`，只改 eslint 会导致 CI 红（A2）。
+- **禁止在 View 残留任何 banned service import**（静态/`import type`/动态 `import()`/`export from` 四形式）；`isElectron`/`logger`/`routeMode` 等非 ban 项 import 不动。
+- **禁止引入方案外新功能；禁止改任何 confirm/toast 文案。**
+
+### 1.4 infra 白名单口径（B7）
+
+机制是**黑名单制**：12 项 banned 以外皆可从组件 import。事实上的 infra 工具（未 banned、可继续在组件用）：`logger`、`electronProxy`/`isElectron`、`indexedDbStorage`、`mcpElectronBridge`、`aiRequestLimiter`、`discoveryAnalysisStorage`；另有 `routeMode`（`shouldBypassBackend`）——未 banned 未文档化的事实 infra，**本次不迁不动**（其决策逻辑随 fetch 进 hook，§2.4）。
+
+### 1.5 application 纯度门禁口径（B6）
+
+application 层门禁（`eslint.config.js:125-180`、`check-boundaries.cjs:143-183`）**只拦** `react/react-dom` import 与 `**/store/**`、`**/services/**` 路径。DOM/JSX 禁令**没有规则落地**，仅 ADR 脚注³约定——新增纯函数文件不要写 DOM/JSX，但验收无需断言。机制化列 follow-up（§10）。
+
+---
+
+## 2. Hook API 设计
+
+### 2.1 `useSearchActions`（新建 `src/features/repositories/hooks/useSearchActions.ts`）— 最重
+
+**归属**：SearchBar 是全局搜星标仓，归 repositories 域。零参，内部自建 `t`（参照 useGistActions）。
+
+```ts
+export interface SearchActions {
+  isSearching: boolean;
+  searchPhase: string | null;
+  // 渲染相关 ref：View 的过滤 effect（SearchBar.tsx:239-277）仍要读写，故以 RefObject 暴露
+  vectorScoreMapRef: MutableRefObject<{ query: string; scores: Map<string, number> } | null>;
+  skipNextTextSearchRef: MutableRefObject<boolean>;
+  aiSearch: (query: string, applyFilters: (repos: Repository[]) => Repository[]) => Promise<void>;
+  keywordSearch: (query: string, applyFilters: (repos: Repository[]) => Repository[]) => Promise<void>;
+  syncStars: (mode?: 'auto' | 'stars-only' | 'stars-and-lists') => Promise<void>;
+}
+```
+
+- **ref 归属决策**：两 ref 的写点在 handleAISearch（→hook），读点在 View 过滤 effect（242/249/252/254/264/266 行，依赖 View 本地 applyFilters 闭包与 17 个 filter 依赖）。该 effect 整体搬入 hook 会扩大改动面、引入漂移风险，故 **ref 实体挂 hook、以 RefObject 暴露给 View 原样读写**——"只搬运不改语义"约束下风险最低的切法。hook 文件内注释写明该契约。
+- **`applyFilters` 参数**：原 handleAISearch 在 490/546 行调用 View 本地闭包；hook 以参数接收（调用时传入，避免 stale closure），在**完全相同的两处**调用。
+- `aiSearch`：逐句搬运 370-559 中非 View-UI 部分。View-UI 部分（setIsRealTimeSearch(false)/setShowSearchHistory(false)/setShowSuggestions(false)/搜索历史 localStorage 块）**留在 View**，View 的 handleAISearch 变薄包装（§4.1）。hook 从 setIsSearching(true)+setSearchPhase(null)+清 vectorScoreMapRef 起。向量门控读 `useAppStore.getState().vectorSearchConfig/embeddingConfigs`（保持原时机）。向量命中：setSearchResults→setSearchFilters→skipNextTextSearchRef=true→return；未命中/异常：`await keywordSearch(query, applyFilters)`（原为 fall-through，顺序调用等价）。HyDE 局部 controller+5s race、rerank 无 signal、console 诊断全保留。
+- `keywordSearch`：搬运 517-552。`repositories` 用 hook selector 值；activeConfig 分支 → searchRepositoriesWithReranking（catch 回退 `performBasicTextSearch`，utils 导入非服务）；无配置 → performBasicTextSearch；尾部 applyFilters(filtered)→setSearchResults→setSearchFilters。独立暴露为可测性。
+- `syncStars(mode='auto')`：逐句搬运 714-926（保序表 #2）。storeRepos 用 `useAppStore.getState().repositories`；allCategories 在回调内以与 View useMemo 同源同值的方式计算（getAllCategories(customCategories, language, hiddenDefaultCategoryIds, defaultCategoryOverrides)）；lists 元素类型从 `getUserLists` 返回推导（`src/services/githubListsApi.ts:502`）。
+- **confirm 归属（B8）**：`syncStars` **不内置 confirm**——原代码仅 stars-and-lists 下拉入口确认；View 保留 handleStarAndListSync 薄包装：confirm（原文案）→ `syncStars('stars-and-lists')`。
+- **toast 归属**：全部随动作入 hook。**Abort**：仅 HyDE 局部 controller（随代码入 hook，无 ref 持久化）。
+- **selector**（一个 useShallow 块）：`repositories, aiConfigs, activeAIConfig, language, setSearchFilters, setSearchResults, githubToken, setRepositories, setLastSync, setSyncingStars, syncMode, user, addCustomCategory, customCategories, hiddenDefaultCategoryIds, defaultCategoryOverrides`。`isSyncingStars` 等纯展示字段留 View 自己的 selector。
+- 返回 `useMemo` 稳定（refs 天然稳定）。
+
+### 2.2 `useGistActions` 扩展（`src/features/gists/hooks/useGistActions.ts`）
+
+现状：零参、`useShallow(selectGistViewState)`（**已含** updateGist/deleteGist/setAnalyzingGist，selectors.ts:97-116，无需改 selector）、useDialog、内部 t。新增：
+
+```ts
+analyzeOne: (gist: Gist) => Promise<void>;
+unstarGist: (gist: Gist, onUnstarred?: (gistId: string) => void) => Promise<void>;
+deleteGist: (gist: Gist, onDeleted?: (gistId: string) => void) => Promise<void>;
+fetchGistFileRaw: (rawUrl: string, signal?: AbortSignal) => Promise<string>;
+isAnalyzingGist: (gistId: string) => boolean;
+isMutating: boolean;
+```
+
+- `analyzeOne`：搬运保序表 #7，View 保留 `event.stopPropagation()` 前置。confirm（覆盖确认）**入 hook**。本地 isAnalyzingLocal 与 setAnalyzingGist 同置同清、渲染值恒等于 store 集合值——hook 只操作 store 的 analyzingGistIds，暴露 `isAnalyzingGist(id)`，**代码注释写明该等价性**防后人"修复"。无 Abort（原样）、无 forceSync。
+- `unstarGist/deleteGist`：View 回调（onUnstarred/onDeleted）以**参数**传入，在原顺序点被调用。confirm **入 hook**（原文案）。`isMutating` 留 hook（每卡片实例化，等效原卡片本地态）。
+- `fetchGistFileRaw(rawUrl, signal)`：薄封装——无 token 时 throw，err.message = GistDetailModal 原无 token 错误文案**逐字抄录**（View catch 写 rawError，渲染结果与原 setRawError 直写逐字一致）；有 token 则 `createGitHubApiService(token).getGistFileRaw(rawUrl, signal)`。**Abort 归 View**（HighlightedCode 局部 controller + retry 不动）。
+- 返回对象追加以上成员，保持该文件"直接展开 state + 字段"风格，不追加 useMemo。
+
+### 2.3 `useDiscoveryRepoActions`（新建 `src/features/discovery/hooks/useDiscoveryRepoActions.ts`）
+
+注意：`discovery/hooks/` 已有 `useDiscoveryActions.ts`（频道加载/批量分析）——新 hook 与其并存、零重叠（卡片级动作），命名已核验无撞名。**禁止 import useRepositoryCardActions**（跨 feature 红线）；校验模板**参照** useRepositoryCardActions.analyze（B3），但文案用 SubscriptionRepoCard 原文。
+
+```ts
+export interface UseDiscoveryRepoActionsOptions { repo: DiscoveryRepo; }
+export interface DiscoveryRepoActions {
+  analyze: (onAnalyzed?: (repo: DiscoveryRepo) => void) => Promise<void>;
+  star: (onStar?: (repo: DiscoveryRepo) => void) => Promise<void>;
+  executeUnstar: () => Promise<void>;
+  isAnalyzing: boolean;
+  isStarring: boolean;
+  isStarred: boolean;          // optimisticStarred ?? isStarredComputed（原 View 公式）
+  optimisticStarred: boolean | null;
+}
+```
+
+- **selector**（useShallow）：`githubToken, aiConfigs, activeAIConfig, language, customCategories, repositories, updateDiscoveryRepo, addRepository, deleteRepository`；`isStarredComputed = repositories.some(r => r.full_name === repo.full_name)` 用 useMemo。
+- `analyze(onAnalyzed?)`：保序表 #6 逐句。AbortController ref 挂 hook，unmount effect 只 abort。成功/失败 patch 用 §3.1 纯函数。getAllCategories 调用点保持。
+- `star(onStar?)`：保序表 #5；乐观态 `optimisticStarred` **从 View 移入 hook**；repositoryToAdd 构造用 §3.2 纯函数。
+- `executeUnstar()`：保序表 #4。**无 confirm**——unstar 确认是自定义 Modal，**确认 UI 留 View**（B8）。原 finally 的 `setPendingUnstarAction(null)` 是 View 态，hook 不可触——View 确认按钮改为 `setUnstarConfirmOpen(false); setPendingUnstarAction(null); void executeUnstar();`（可见行为等价）。
+- `isStarring` 本地态入 hook（star/unstar 共用）。
+
+### 2.4 `useReadmeFetch`（新建 `src/hooks/useReadmeFetch.ts`，共享层）
+
+放共享层理由：ReadmeModal 是通用 owner/name props 组件（RepositoryCard/SubscriptionRepoCard 等亦用），无归属 feature；`src/hooks/` 有 useAutoUpdateCheck 直调 service 先例，ADR 脚注² 允许 feature hook/View 调 `src/hooks/**`。
+
+```ts
+export interface UseReadmeFetchOptions { owner: string; name: string; }
+export interface ReadmeFetchActions {
+  fetchReadmeContent: (variant: ReadmeVariant) => Promise<string>;              // 332-364 路径
+  fetchReadmeCandidates: (defaultBranch: string | undefined) => Promise<GitHubReadmeCandidateItem[]>; // 366-392 路径
+  cancel: () => void;  // abort 两路 controller 并置 null；View 关闭 modal 时调；hook unmount 亦自动
+}
+export const pickReadmeCandidate = (
+  variants: ReadmeVariant[], selectedKey: string | undefined, defaultVariant: ReadmeVariant,
+): ReadmeVariant;  // ReadmeModal.tsx:468 的 find(...)||default 提纯
+```
+
+- **Abort 归 hook**：hook 持两个 controller（content/candidates），每次 fetch 前 abort 上一个；`useEffect(() => cancel, [])` 兜底 unmount。View 删除自己的两 ref 与卸载/关闭 abort 块，关闭时改调 `cancel()`。
+- **shouldBypassBackend 决策随 fetch 入 hook**（routeMode import 从 View 移入 hook）。
+- selector：`githubToken, language`（useShallow）。backend 优先→GitHub fallback 两级逻辑与 console.warn 文案逐字搬运（含 candidates 分支"无 token 返回 []"而非抛错）。无 toast/confirm、无 store 写。
+- View 的 `readmeCache`、变体 tab 状态、`buildReadmeVariants(candidates, language)`（utils，已存在）留 View；仅 468 行变体选择改用 `pickReadmeCandidate`。
+
+### 2.5 `useReleaseArtifactActions`（新建 `src/hooks/useReleaseArtifactActions.ts`）+ `useRepositoryReleaseSheet` 委托
+
+**规范语义 = ReleaseCard 版本**（迁移对象语义神圣）；`useRepositoryReleaseSheet`（repositories/hooks:119，已实现相同 RPC+AI 逻辑，禁止第三份拷贝——A1）改委托。
+
+```ts
+export type ReleaseArtifactSummaryState =
+  { status: 'idle' | 'loading' | 'done' | 'error'; content?: string; error?: string };
+export interface ReleaseArtifactActions {
+  summaries: Record<number, ReleaseArtifactSummaryState>;
+  rpcDownloadStates: Record<string, 'idle' | 'sending' | 'sent'>;  // key = computeRpcDownloadKey(link)
+  sendRpcDownload: (link: { url: string; name: string; updatedAt?: string }) => Promise<void>;
+  generateSummary: (release: Release) => Promise<void>;
+  cancelSummaryRequests: () => void;
+  reset: () => void;  // 实施补充：清空 summaries/RPC 状态并取消进行中请求（sheet loadReleases 需要，规格遗漏）
+}
+export const computeRpcDownloadKey = (link: { url: string; updatedAt?: string }): string; // `${url}@${updatedAt ?? ''}`
+```
+
+- 零参自建 t；selector（useShallow）：`language, backendApiSecret, aiConfigs, activeAIConfig`。
+- `sendRpcDownload(link)`：保序表 #11 逐句。key 由 `computeRpcDownloadKey` 计算；downloading/downloaded 用 `useState` Record 替换原 refs+forceUpdate（渲染等价的实现替换，注释说明）；三参 `sendToRpcDownload(link.url, link.name, backendApiSecret || undefined)`；'RPC service not running' 专属分支保留（原文案）。
+- `generateSummary(release)`：保序表 #12 + sheet 兼容前置守卫（existing?.status==='loading' 或 ('done'&&content) 时 return——对 ReleaseCard 是无害 no-op：其展开短路在 View toggle handler）。`summaryAbortRefs: Record<number, AbortController>` 挂 hook；unmount effect abort 全部。无 activeConfig → toast（原文案）不写状态；AbortError 静默。
+- **useRepositoryReleaseSheet 委托改造点**（同 commit 完成，避免中间态第三份拷贝）：
+  1. 删 sendToRpcDownload/AIService import、summaryAbortRefs、generateSummary(288-329) 与 sendAssetToRpc(231-249) 内联实现；
+  2. 内部实例化 `useReleaseArtifactActions()`；generateSummary 直接转发；sendAssetToRpc 变为 `if (!rpcDownloadConfig.enabled) return; await actions.sendRpcDownload(link);`（enabled 守卫留 sheet——ReleaseCard 侧由按钮显隐承担）；
+  3. 对外返回的 summaries/downloadStates 改由 hook 供给 + computeRpcDownloadKey 换算（RepositoryReleaseSheet UI 及其测试同步换 key）；
+  4. cancelPendingRequests 保留 fetch abort 部分，summary 部分转发 cancelSummaryRequests；
+  5. **3 处已接受微差异（写入 PR 描述，行为零变更的唯一例外）**：① dedup key 由 url-only 变 `url@updatedAt`（与卡片一致，修同病灶）；② AI 配置缺失由"静默置 error 态"变"toast 不置态"；③ RPC 失败文案统一为 ReleaseCard 版。若存量测试断言旧文案/旧 key，按新语义更新断言并在 PR 说明（§6.2）。
+
+### 2.6 `useReleaseTimelineActions` 新增 `syncWatchedSources`（B1：方法不存在，为新增）
+
+`src/features/releases/hooks/useReleaseTimelineActions.ts` 现有仅 handleRefresh/handleMarkAllRead/handleUnsubscribeRelease。
+
+```ts
+syncWatchedSources: () => Promise<void>;
+isSyncingWatchedSources: boolean;
+```
+
+逐句搬运保序表 #14。repos 来源：原面板 props `repos = releaseSourceSettings.watchCustomReleaseRepos`（ReleaseSourceSettingsModal.tsx:389）——hook 直接从 `selectReleaseTimelineState` 已含的 `state.releaseSourceSettings.watchCustomReleaseRepos` 读取（**不改共享 selector**）；`setReleaseSourceRepositories` 用独立单值 selector（useCallback 包裹）获取。`repositoryToCustomReleaseRepository`/`WATCH_CUSTOM_RELEASE_SOURCE_ID` 从 utils/releaseSources import（utils 非 banned）。无 token/isSyncing 静默 return（原样，无 toast）；无 confirm、无 forceSync、无 Abort（原样）。
+
+### 2.7 `useBackendAvailability`（新建 `src/features/settings/hooks/useBackendAvailability.ts`）
+
+```ts
+export const useBackendAvailability = (): boolean;
+// 读取并返回 backend.isAvailable（一次性同步属性，无订阅——与 SettingsPanel 现状逐字等价，勿引入订阅/状态）
+```
+
+SettingsPanel 两处 `(isElectron() || backend.isAvailable)`（369/380 行）改 `(isElectron() || backendAvailable)`；删 24 行 import。`isElectron` 属 infra 不动。
+
+### 2.8 `RepositoryEditModal` → 复用 `useCategorySyncActions`
+
+`src/features/repositories/hooks/useCategorySyncActions.ts` 已存在（零参，返回 `{ forceSyncToBackend }`，先例 CategorySidebar.tsx:61）。View 删 12 行 import，加 `const { forceSyncToBackend } = useCategorySyncActions();`，402-404 调用点原样（保序表 #15）。
+
+---
+
+## 3. 纯函数提纯清单
+
+### 3.1 `src/features/repositories/application/discoveryRepoPatches.ts`（唯一新 application 文件）
+
+```ts
+import type { DiscoveryRepo } from '../../../types';
+export interface DiscoveryAnalysisSuccessInput {
+  summary: string | undefined; tags: string[] | undefined; platforms: string[] | undefined;
+  analyzedAt: string; analysisFailed: boolean | undefined;
+}
+export interface DiscoveryAnalysisFailureInput {
+  analyzedAt: string; analysisFailed: boolean | undefined; analysisError: string | undefined;
+}
+export const applyDiscoveryAnalysisSuccess = (repo: DiscoveryRepo, input: DiscoveryAnalysisSuccessInput): DiscoveryRepo;
+export const applyDiscoveryAnalysisFailure = (repo: DiscoveryRepo, input: DiscoveryAnalysisFailureInput): DiscoveryRepo;
+```
+
+**字段集逐字取自 SubscriptionRepoCard 239-247/260-265**（含 `analysis_failed: result.analysis_failed`、`analysis_error: undefined`），**不含** custom_category/category_locked——与 `repositoryPatches.applyAnalysisSuccess` **不是同一形状，勿复用/勿"对齐"**。输入输出均 DiscoveryRepo（保留 rank/channel/platform）。受 application 纯度门禁约束（§1.5），types 导入合法。同目录 `__tests__/` 加单测（先例 repositoryPatches.test.ts）。
+
+### 3.2 各 hook 文件内导出纯函数（同文件单测覆盖；不下沉新目录——红线）
+
+| 文件 | 纯函数 | 来源（逐字提纯块） |
+|---|---|---|
+| useSearchActions.ts | `buildSearchPatch(query, vectorResults): Map<string, number>` | SearchBar 446-459：name +0.05 / desc +0.03 / tags +0.02 加分 + scoreMap 构造 |
+| useSearchActions.ts | `mergeStarredRepositories(newRepos, storeRepos): Repository[]` | SearchBar 725-750 字段合并（license `?? null` 回填） |
+| useSearchActions.ts | `planListCategories(lists, localCategoryNames, makeCategoryId): { toCreate: Category[]; categoryByLowerName: Map<string,string> }` | SearchBar 774-799；`makeCategoryId: (idx) => \`custom-sync-${Date.now()}-${idx}\`` 由 hook 注入保持可测性；过滤 isReservedCategoryName |
+| useSearchActions.ts | `applyListsToRepositories(repositories, lists, categoryByLowerName): { repositories: Repository[]; appliedTagsCount: Record<string, number> }` | SearchBar 807-868：preExistingLocked 集 + 打标签/设分类/加锁循环 + last_edited |
+| useDiscoveryRepoActions.ts | `discoveryRepoToRepository(repo: DiscoveryRepo, starredAt: string): Repository` | SubscriptionRepoCard 152-160（rank/channel/platform 置 undefined） |
+| useGistActions.ts | `applyGistAnalysisSuccess(detail: Gist, summary: string, now: string): Gist` / `applyGistAnalysisFailure(gist: Gist, error: string, now: string): Gist` | GistCard 100-106 / 109-114 patch 字面量 |
+| useReleaseArtifactActions.ts | `computeRpcDownloadKey(link)`（§2.5） | ReleaseCard 123 |
+| useReadmeFetch.ts | `pickReadmeCandidate(variants, selectedKey, defaultVariant)`（§2.4） | ReadmeModal 468 |
+
+`Category`/`Repository` 等类型从 `types` 导入；lists 元素类型从 `GitHubListsApiService['getUserLists']` 返回推导。
+
+---
+
+## 4. 逐 View 改动清单（行号为当前基线，执行时以符号为准）
+
+### 4.1 `src/components/SearchBar.tsx`（最重，最后一个换）
+
+- **删 import**：L7 AIService、L8 EmbeddingClient/VectorSearchService、L9 GitHubApiService、L10 createGitHubListsApiService、L11 forceSyncToBackend。
+- **加**：`import { useSearchActions } from '../features/repositories/hooks/useSearchActions';`
+- **删 state/refs**：isSearching/searchPhase 两个 useState（改从 hook 解构）；L189-190 两 ref 声明（改用 hook 暴露）。
+- **删 body**：handleAISearch 370-559 → 薄包装（View-UI 三行 + 历史块 + `await aiSearch(searchQuery, applyFilters)`）；handleStarSync 714-926 整删；handleStarAndListSync 941-958 保留 confirm 原文、改调 `syncStars('stars-and-lists')`。
+- **留 View**：applyFilters 闭包（~300-368）、过滤 effect 239-277（继续读写 hook 的两 ref，代码不变）、实时搜索/历史/建议/IME、formatLastSync、selector 中纯展示字段（isSyncingStars/releaseSubscriptions/lastSync 等）、1080/1209/1233/1240 调用点对接改名。
+- store selector 收缩：删仅被搬走逻辑使用的字段（setRepositories/setLastSync/setSyncingStars/syncMode/user/addCustomCategory 等）。
+
+### 4.2 `src/components/GistCard.tsx`
+
+- **删 import**：L4 createGitHubApiService、L5 AIService。**加**：`import { useGistActions } from '../features/gists/hooks/useGistActions';`（每卡片实例化）。
+- 三个 handler → `analyzeOne(gist)` / `unstarGist(gist, onUnstarred)` / `deleteGist(gist, onDeleted)`（View 保留 stopPropagation 前置与 props 回调透传）。`isAnalyzing` 改 `isAnalyzingGist(gist.id)`，`isMutating` 从 hook 取。删本地 isAnalyzingLocal/isMutating state 及 store 直读中不再使用字段（updateGist/deleteGist/setAnalyzingGist/aiConfigs/activeAIConfig 若无他处使用）。
+
+### 4.3 `src/components/GistDetailModal.tsx`
+
+- **删 import**：L9 createGitHubApiService。
+- 父组件调 `useGistActions()` 取 fetchGistFileRaw，以 prop `fetchRaw: (rawUrl: string, signal: AbortSignal) => Promise<string>` 传入内部 HighlightedCode；HighlightedCode 删自身 service 调用与 githubToken 读取（L28 若仅服务该 fetch 则删），effect 内改 `await fetchRaw(file.raw_url!, controller.signal)`（无 token 分支交给 hook 抛错，catch 落 rawError 文案不变）。**Abort/retry/局部缓存留 View 不动**；父组件 loadedContents 缓存 + updateGist 回写（View→Store 合法）不动。
+
+### 4.4 `src/components/SubscriptionRepoCard.tsx`
+
+- **删 import**：L6 analyzeRepository/createFailedAnalysisResult、L7 forceSyncToBackend、L8 GitHubApiService。**加**：`import { useDiscoveryRepoActions } from '../features/discovery/hooks/useDiscoveryRepoActions';`
+- 取 `{ analyze, star, executeUnstar, isAnalyzing, isStarring, isStarred, optimisticStarred }`。删本地 isStarring/isAnalyzing/optimisticStarred state、abortControllerRef+unmount effect、store 直读中不再使用项（githubToken/aiConfigs/activeAIConfig/updateDiscoveryRepo/addRepository/deleteRepository；repositories 若仅 isStarredComputed 用也删）。
+- **留 View**：unstarConfirmOpen/pendingUnstarAction state、自定义 Modal JSX（499-544，文案原样）、确认按钮三行改动（§2.3）、onStar/onAnalyze 透传、stopPropagation 前置。
+
+### 4.5 `src/components/ReleaseCard.tsx`
+
+- **删 import**：L11 sendToRpcDownload、L12 AIService。**加**：`import { useReleaseArtifactActions, computeRpcDownloadKey } from '../hooks/useReleaseArtifactActions';`
+- 取 `{ summaries, rpcDownloadStates, sendRpcDownload, generateSummary, cancelSummaryRequests }`。删：SummaryState 类型与 summary state、summaryAbortRef+unmount effect（109-115）、downloadingRef/downloadedRef/forceUpdate（116-118）、handleRpcDownload（120-155）、runSummaryAnalysis（160-206）、selector 中 backendApiSecret/aiConfigs/activeAIConfig（96-101 收缩为 rpcDownloadConfig 若仍需）。
+- handleToggleSummary 改读 `summaries[release.id] ?? { status: 'idle' }`，done 短路/收起展开原样；卸载取消由 hook 承担（卡片卸载即 hook 卸载）。
+
+### 4.6 `src/components/ReadmeModal.tsx`
+
+- **删 import**：L8 GitHubApiService、L9 backend、L10 shouldBypassBackend。**加**：`import { useReadmeFetch, pickReadmeCandidate } from '../hooks/useReadmeFetch';`
+- 删两个 fetcher useCallback（332-364/366-392）、两个 abortControllerRef 及 abort/cleanup 块。fetchReadmeContent/fetchReadmeVariants（394-466）保留编排（缓存读写、空内容/失败文案、variantsLoading），内部改调 hook 方法；468 行 find||default 改 pickReadmeCandidate(...)。modal 关闭路径原 abort 调用点改 cancel()。readmeCache/TOC/翻译全不动。
+
+### 4.7 `src/components/ReleaseSourceSettingsModal.tsx`
+
+- **删 import**：L9 GitHubApiService。**加**：`import { useReleaseTimelineActions } from '../features/releases/hooks/useReleaseTimelineActions';`
+- WatchCustomReleaseSyncPanel.handleSync（221-249）删除，按钮改调 `syncWatchedSources`；isSyncing 改 `isSyncingWatchedSources`。panel 的 repos prop 若回显仍用可留；setReleaseSourceRepositories 直读若仅 sync 用则删。`updateReleaseSourceRepository`（284 行隐藏开关）是 View→Store，**留 View 不动**。
+
+### 4.8 `src/components/RepositoryEditModal.tsx`
+
+删 L12 import；加 useCategorySyncActions（§2.8）。402-404 调用点不变。
+
+### 4.9 `src/components/SettingsPanel.tsx`
+
+删 L24 import；加 `const backendAvailable = useBackendAvailability();`，369/380 两处条件替换（§2.7）。其余不动。
+
+### 4.10 `src/components/GistEditorModal.tsx`
+
+见 §5。
+
+---
+
+## 5. 类型解套：GistEditorModal（第一个 commit，独立可回滚）
+
+L9 `import type { GistCreateInput, GistUpdateInput } from '../services/githubApi';` → 改 `from '../features/gists/hooks/useGistActions'`（该文件 L12 已有 `export type { GistCreateInput, GistUpdateInput }` 重导出）。**规则文件零改动**；eslint 与 check-boundaries 双放行（import type 均匹配 IMPORT_RE，A2 已核验）。
+
+---
+
+## 6. 测试计划
+
+### 6.1 新增测试（同目录 `.test.tsx`，vitest globals+jsdom；mock 骨架统一 `vi.hoisted` → `vi.mock store` → `vi.mock useDialog` → 逐 service；GitHubApiService/EmbeddingClient/VectorSearchService/AIService 用 class 形态，范本 `useRepositoryCardActions.test.tsx:7-55`）
+
+| 文件（新增） | mock 要点 | 关键断言 |
+|---|---|---|
+| `src/features/repositories/application/__tests__/discoveryRepoPatches.test.ts` | 纯函数无 mock | 成功/失败 patch 字段集（无 custom_category/category_locked）、DiscoveryRepo 字段保留 |
+| `src/features/repositories/hooks/useSearchActions.test.tsx` | store mock **必须同时提供 getState**：`useAppStore: Object.assign(vi.fn(sel => sel(state)), { getState: () => state })`；mock vectorSearchService/aiService/githubApi/githubApiFactory/autoSync | ① 向量命中：topK/threshold 默认 30/0.35、加分映射、rerank 失败仅回退不 toast、skipNextTextSearchRef=true；② HyDE 5s race 降级回原 query；③ 向量无结果→keywordSearch AI 失败回退 performBasicTextSearch；④ syncStars('stars-and-lists')：**setRepositories 先于 forceSyncToBackend、再 setLastSync**（保序断言）；list 失败不中断星标结果；token 过期文案分支；⑤ 4 个纯函数 |
+| `src/features/gists/hooks/useGistActions.test.tsx`（**全新增**，B4：无存量） | store state 覆盖 selectGistViewState 全字段；githubApiFactory mock 出 getGistForAnalysis/getGistContentPreview/unstarGist/deleteGist/getGistFileRaw；AIService.analyzeGist | analyzeOne：已分析触发 confirm、成功 patch 字段、**不调用 forceSync**；unstarGist/deleteGist：confirm false 中止、onUnstarred/onDeleted 各自原点位；fetchGistFileRaw：无 token 抛原文案、有 token 透传 signal |
+| `src/features/discovery/hooks/useDiscoveryRepoActions.test.tsx` | aiAnalysisHelper/autoSync/githubApi/store | analyze 三段校验文案与顺序、abort 短路、成功 patch 无 custom_category、**无 forceSync**；star 乐观→远端→addRepository→onStar→**forceSync**→乐观清→toast 保序；executeUnstar 乐观/回滚、deleteRepository by full_name、**forceSync**、成功无 toast |
+| `src/hooks/useReadmeFetch.test.tsx` | backendAdapter/githubApi/routeMode | bypass 或 !isAvailable→直连；backend 成功不走 GitHub；backend 失败非 abort 有 token→fallback+warn；无 token：content 抛/candidates 返回 []；cancel 后再 fetch abort 上一个；pickReadmeCandidate |
+| `src/hooks/useReleaseArtifactActions.test.tsx`（B4 更名：非 useReleaseCardActions.test） | rpcDownloadService/AIService/useDialog/store | sendRpcDownload：key=url@updatedAt、sending 短路、重试清 sent、'RPC service not running' 分支、catch 文案；generateSummary：无配置 toast、loading/done 短路、error 态+toast、AbortError 静默、unmount abort；computeRpcDownloadKey |
+| `src/features/releases/hooks/useReleaseTimelineActions.test.tsx`（新增，聚焦 syncWatchedSources） | githubApi/store（含 releaseSourceSettings.watchCustomReleaseRepos、setReleaseSourceRepositories） | 无 token/isSyncing 静默；release_hidden 保留合并；setReleaseSourceRepositories 入参；成功/失败 toast；**不调用 forceSync** |
+| `src/features/settings/hooks/useBackendAvailability.test.tsx`（小） | backendAdapter | 返回 backend.isAvailable 两态 |
+
+### 6.2 存量回归（`npm run test:run` 必绿）
+
+`src/components/SearchBar.test.tsx`（未 mock service，不触达迁移路径）、`RepositoryEditModal.test.tsx`（已模块级 mock `../services/autoSync`，命中 useCategorySyncActions 内同名 import）、`ReadmeModal.test.tsx`（backendAdapter/githubApi 模块级 mock 命中 useReadmeFetch 内 import；若 hook 读取的 store 字段超出 mock 形状，补 fixture 字段而非改断言）、`ReleaseCard.test.tsx`（rpcDownloadService/aiService mock 命中共享 hook；注意其 mock 走动态 import 形式）、`RepositoryReleaseSheet.test.tsx` + `src/features/repositories/hooks/useRepositoryReleaseSheet.test.tsx`（委托重构后仅当断言 §2.5 三处微差异时按新语义更新断言并 PR 说明）、`useRepositoryCardActions.test.tsx`（不动）、`ReleaseTimeline.test.tsx`、`ForkTimeline.test.tsx`、`settings/BackendPanel.test.tsx`、`src/store/useAppStore.modularization.test.ts`（**必须零改动通过**——Store 未动的证明）。
+
+**vi.mock 原则（B4）**：组件不再 import service 后，既有测试的 `vi.mock('.../services/x')` 经解析路径仍拦截 hook 内同名 import——**不预防性重写任何测试文件，跑通为准**；仅断言与既定微差异冲突时最小修改。
+
+---
+
+## 7. 执行顺序与 commit 切分（单 PR，~17 commits，每 commit 门禁可过）
+
+allowlist 在最后一个 commit 前始终豁免这 10 文件，故中间态两道门禁全绿。
+
+1. `refactor(gists): GistEditorModal 改从 useGistActions 重导出引类型`（§5，一文件）
+2. `feat(gists): useGistActions 扩展 analyzeOne/unstarGist/deleteGist/fetchGistFileRaw + gist patch 纯函数 + 单测`
+3. `feat(discovery): 新建 useDiscoveryRepoActions + discoveryRepoPatches + 单测`
+4. `feat(readme): 新建 src/hooks/useReadmeFetch + pickReadmeCandidate + 单测`
+5. `feat(release): 新建 src/hooks/useReleaseArtifactActions + 单测；useRepositoryReleaseSheet 改委托`（同一 commit 完成委托，避免中间态第三份拷贝）
+6. `feat(releases): useReleaseTimelineActions 新增 syncWatchedSources + 单测`
+7. `feat(settings): 新建 useBackendAvailability`
+8. `feat(repositories): 新建 useSearchActions + 纯函数 + 单测`
+9. View 切换（每文件一 commit，小→大）：9a GistCard；9b GistDetailModal；9c SettingsPanel；9d RepositoryEditModal；9e ReleaseSourceSettingsModal；9f SubscriptionRepoCard；9g ReleaseCard；9h ReadmeModal；9i SearchBar
+10. `chore(boundaries): 删除组件边界 allowlist 机制`（**最后一步**）：
+    - `eslint.config.js`：删 COMPONENT_BOUNDARY_ALLOWLIST 常量（52-63 行）+ 43-51 行 JSDoc 中 "Phased allowlist..." 段落；97-101 行 ignores 删 `...COMPONENT_BOUNDARY_ALLOWLIST` 展开（**保留** `'src/components/**/*.test.{ts,tsx}'`）；同步修剪 87-96 行规则块注释中提及 allowlist 的句子。
+    - `scripts/check-boundaries.cjs`：删 COMPONENT_ALLOWLIST Set（48-59 行）+ 47 行 `// Mirror of ... Keep in sync.` 注释 + checkComponentFile 内早返（106 行）；同步修剪文件头注释（17-21 行）关于 phased allowlist 的描述。
+    - **不是置空数组**——留空数组/残留接线即 review 打回（A5）。
+
+---
+
+## 8. 验收
+
+三条门禁（按序执行，全绿为验收标准；命令均已核实存在于 package.json）：
+
+```sh
+npm run lint                        # eslint . —— 全仓，而非仅 src/components
+node scripts/check-boundaries.cjs   # 等价 npm run check:boundaries
+npm run test:run                    # vitest run（注意：npm test 是 watch 模式，勿用）
+```
+
+辅助（不作门禁但必须干净）：
+
+```sh
+npm run typecheck                   # tsc -b --noEmit（package.json:14）
+# zsh 下务必单引号防 glob 展开：
+rg -n 'services/(githubApi|aiService|aiAnalysisHelper|aiAnalysisOptimizer|vectorSearchService|autoSync|webdavService|backendAdapter|rpcDownloadService|githubApiFactory|updateService|translateService)' src/components --glob '*.ts' --glob '*.tsx' --glob '!*.test.*'
+# 期望空（rg 递归覆盖全部子目录含 settings/、ui/；*.test.* 豁免；非 ban 的 logger/isElectron/routeMode 等不计）
+rg -n 'import\s*\(' src/components --glob '*.ts' --glob '*.tsx' --glob '!*.test.*' | rg 'services/'
+# 期望空（动态 import 抽查；check-boundaries.cjs 的 DYNAMIC_IMPORT_RE 已机制化覆盖）
+rg -n 'COMPONENT_BOUNDARY_ALLOWLIST|COMPONENT_ALLOWLIST' eslint.config.js scripts/check-boundaries.cjs
+# 期望空（机制删净，无死接线）
+```
+
+行为自测清单（人工，10 文件）：AI 搜索（向量/关键词/无配置三路）、星标同步三入口（含 list 建分类与锁定语义）、发现页 star/unstar/单卡分析与取消、gist 单卡分析/取消收藏/删除/大文件懒加载重试、Release 卡 RPC 发送与重试、README 多变体切换与后端降级、Watch 仓库同步、仓库编辑保存、设置页 Network/MCP tab 显隐（SPA 隐藏/后端连接显示/Electron 显示）。
+
+---
+
+## 9. 风险与回滚
+
+| 风险 | 缓解 |
+|---|---|
+| 单 PR 体量大 | 每 commit 一文件/一主题（§7），可按 commit 粒度 revert；hook commit 与 View commit 相互独立 |
+| SearchBar 改动面最大 | ref 暴露策略（§2.1）使过滤 effect 零改动；applyFilters 参数传入消除 stale closure；置于最后一个 View commit |
+| DiscoveryRepo 类型摩擦 | patch 纯函数收发均 DiscoveryRepo（§3.1）；不改 Store shape；modularization 测试不动 |
+| useRepositoryReleaseSheet 委托的 3 处微差异 | §2.5 改造点显式列明 + PR 描述声明；断言同步更新；不满意可单独 revert commit 5（需恢复 sheet 内联实现） |
+| 存量测试 mock 失配 | vi.mock 按解析路径拦截（§6.2 原则）；只补 fixture、不预防性重写 |
+| 删 allowlist 后冒出新违规 | 最后 commit 前先跑三条门禁；allowlist 删除 commit 本身只动两个门禁文件 |
+
+---
+
+## 10. Follow-up（本 PR 不做）
+
+1. **ADR 勘误**：ban list 10→12 项；§Phased enforcement 尾部 13 项举例名单已过期；补记"allowlist 已清零、机制已删除"。
+2. **application DOM/JSX 禁令机制化**（B6：当前门禁只拦 react/react-dom/store/services import）。
+3. **新 application 目录评估**：search/gists/releases 提纯函数是否下沉各自 `application/`。
+4. `routeMode` 是否文档化为 infra（当前未 banned 未文档化）。
+5. `useVectorSearchActions` 补 token/配置校验与 toast（当前无校验；模板在 useRepositoryCardActions.analyze / useGistActions.analyzeVisibleGists——B3）。
+6. SearchBar applyFilters 闭包与过滤 effect 后续整体下沉评估。
+7. `useRepositoryReleaseSheet` 与 `useReleaseArtifactActions` 的 RPC 状态 key 彻底统一后的 UI 层清理。
+
+---
+
+## 附录一：第一轮审计记录（A1–A8，已修复）
+
+| # | 问题 | 等级 | 修复 |
+|---|---|---|---|
+| A1 | 原方案新建 useReleaseCardActions，无视已实现相同 RPC+AI 逻辑的 useRepositoryReleaseSheet，将制造第三份拷贝 | 高 | 改抽共享 `src/hooks/useReleaseArtifactActions.ts`，两处委托（§2.5） |
+| A2 | GistEditorModal 用 allowTypeImports:true 解套：check-boundaries 的 IMPORT_RE 同样匹配 import type，只改 eslint 则 CI 仍红 | 高 | 改从 useGistActions 重导出引 import type，规则零改动（§5） |
+| A3 | 新建顶层 features/search/ + 3 个新 application/ 目录：无 Store/selector 交代，与"7 feature hooks-only"现状冲突 | 高 | Hook 落既有位置（repositories/hooks、src/hooks）；提纯收敛到 repositories/application + hook 内纯函数（§2/§3） |
+| A4 | 验收 rg 仅 src/components/*.tsx 口径：漏子目录/动态 import()/export from | 中 | 以两道门禁为源，辅助 rg 改全仓口径（§8） |
+| A5 | 验收写"数组置空"：残留常量+ignores 接线+Set 早返留死机制 | 中 | 改整体删除（§7.10）；声明 allowlist 常量为唯一真值（ADR 举例名单已过期） |
+| A6 | 未声明 updateService/translateService 在 components 已零违规，执行人会误查旧文件 | 低 | §0 显式声明已迁完、勿追查 |
+| A7 | "复用 useRepositoryCardActions 模式"未澄清禁止跨 feature 直引 hook | 高 | 明确抄模式新建 useDiscoveryRepoActions，禁 import 跨 feature hooks（§1.3/§2.3） |
+| A8 | useStarSyncActions/useBackendSettingsActions 需 { t } 参数，方案"参照/并入"未提 | 低 | 本版涉及 hook 均为既有零参自建 t 风格或新建零参（§2），不触 { t } 系 |
+
+## 附录二：第二轮审计记录（B1–B8，本版修复）
+
+| # | 问题 | 等级 | 修复 |
+|---|---|---|---|
+| B1 | useReleaseTimelineActions.syncWatchedSources 不存在（全仓 0 匹配），原表述"并入"错误 | 高 | 改为新增方法并给出设计（§2.6） |
+| B2 | §4 数据流 "patch→updateX→forceSyncToBackend→toast" 一刀切错误：analyze 类成功后不 forceSync（useRepositoryCardActions.analyze 存量测试断言不调用） | 高 | 改逐动作保序表 15 条（§1.2），原则"只搬运不改语义" |
+| B3 | "校验复用 useVectorSearchActions 模式"错误——该 hook 无 token/AI 校验无 toast | 中 | 校验模板指向 useRepositoryCardActions.analyze 与 useGistActions.analyzeVisibleGists（§2.3；follow-up §10.5） |
+| B4 | 测试清单失实：useGistActions 无存量测试；useReleaseCardActions.test 名已失效 | 中 | 测试计划重写（§6）：8 个新增测试 + 存量回归清单 + vi.mock 拦截原则 |
+| B5 | 验收命令失实：vitest 是 watch 模式；eslint 只跑 components | 中 | §8 改 npm run lint（全仓）/ check-boundaries / test:run + typecheck + rg（单引号） |
+| B6 | "application 禁 DOM（lint+双拦）"失实——两道门禁均无 DOM/JSX 规则 | 低 | §1.5 表述修正；机制化列 follow-up（§10.2） |
+| B7 | infra 白名单表述失实——黑名单制，文档化 infra 6 项且无 routeMode | 低 | §1.4 修正；routeMode 定性事实 infra 本次不迁 |
+| B8 | SubscriptionRepoCard 的 unstar 确认是自定义 Modal 而非 useDialog.confirm | 中 | 每 hook 显式标注 confirm/toast/Abort 归属（§2）；确认 UI 留 View、hook 暴露动作（§2.3） |

--- a/docs/plans/allowlist-migration-plan.md
+++ b/docs/plans/allowlist-migration-plan.md
@@ -4,7 +4,7 @@
 - **仓库根**: 本仓库（GithubStarsManager）
 - **契约**: `docs/adr/0001-frontend-layering.md`（View → Hook → Application → Service → Store）
 - **目标**: `eslint.config.js` 的 `COMPONENT_BOUNDARY_ALLOWLIST`（52-63 行，恰 10 项）与 `scripts/check-boundaries.cjs` 的 `COMPONENT_ALLOWLIST`（48-59 行，镜像 10 项）**机制整体删除**（非置空）；10 个 View 组件的远程调用与 Store 写入全部收敛进 hook。
-- **行为基线**: 行为零变更。唯一例外 = `useRepositoryReleaseSheet` 委托共享 hook 的 **3 处已声明微差异**（§2.5，须在 PR 描述列明）；GistEditorModal 类型解套零行为影响。
+- **行为基线**: 行为零变更。例外 = PR 描述声明的 **8 处行为微差异/等价调整**（3 处规格预设见 §2.5 + 5 处实施补充，以 PR 描述清单为完整真值）；GistEditorModal 类型解套零行为影响。
 - **吸收的审计结论**: 第一轮 A1–A8 + 第二轮 B1–B8（附录二表，共 16 条已逐条修复进本文）。
 - **文案铁律**: 所有 toast/confirm/错误文案**以原文件现行为准逐字抄录**，禁止转写、概括或"顺手优化"。本文出现的文案仅为定位指引。
 
@@ -51,7 +51,7 @@ ban list 12 项（`eslint.config.js:16-29` 与 `check-boundaries.cjs:32-45` 一�
 | 3 | SearchBar.handleStarAndListSync (941-958) | confirm(warning，原文案) → handleStarSync('stars-and-lists') | **View 保留 confirm 包装**（§2.1；'auto'/'stars-only' 入口原无确认，勿加） |
 | 4 | SubscriptionRepoCard.executeUnstar (91-125) | 无 token 静默 return → setIsStarring → 乐观 setOptimisticStarred(false) → new GitHubApiService → unstarRepository(owner,name) → deleteRepository(按 full_name 查 id) → **await forceSyncToBackend()** → 乐观清 null；catch：回滚乐观 + toast（原文案）；finally setIsStarring(false)。**成功无 toast**。确认走自定义 Modal（留 View，B8） | useDiscoveryRepoActions.executeUnstar |
 | 5 | SubscriptionRepoCard.handleStar (128-183) | isStarring 短路 → 乐观(true) → starRepository(owner,name) → 构造 repositoryToAdd（rank/channel/platform 置 undefined + starred_at）→ addRepository → onStar(repo) → **await forceSyncToBackend()** → 乐观清 null → toast 成功；catch 回滚 + toast | useDiscoveryRepoActions.star |
-| 6 | SubscriptionRepoCard.handleAnalyze (193-274) | 三段校验 toast（token→无配置→apiKeyStatus→baseUrl/apiKey/model，**文案取本文件原文**，与 useRepositoryCardActions 措辞不同）→ isAnalyzing 短路 → abort 上一请求（abortControllerRef，unmount abort）→ analyzeRepository({repository: repo, githubToken, aiConfig, language, categories, signal})（aiAnalysisHelper）→ aborted 则 return → 成功 patch（ai_summary/ai_tags/ai_platforms/analyzed_at/analysis_failed/analysis_error:undefined，**无 custom_category/category_locked**）→ updateDiscoveryRepo → onAnalyze(updatedRepo)。**无 forceSync、成功无 toast、无重分析 confirm**（勿照 RepositoryCard "补齐"）；catch（非 abort）：createFailedAnalysisResult → 失败 patch → updateDiscoveryRepo → toast | useDiscoveryRepoActions.analyze |
+| 6 | SubscriptionRepoCard.handleAnalyze (193-274) | 四段校验 toast（token→无配置→apiKeyStatus→baseUrl/apiKey/model，**文案取本文件原文**，与 useRepositoryCardActions 措辞不同）→ isAnalyzing 短路 → abort 上一请求（abortControllerRef，unmount abort）→ analyzeRepository({repository: repo, githubToken, aiConfig, language, categories, signal})（aiAnalysisHelper）→ aborted 则 return → 成功 patch（ai_summary/ai_tags/ai_platforms/analyzed_at/analysis_failed/analysis_error:undefined，**无 custom_category/category_locked**）→ updateDiscoveryRepo → onAnalyze(updatedRepo)。**无 forceSync、成功无 toast、无重分析 confirm**（勿照 RepositoryCard "补齐"）；catch（非 abort）：createFailedAnalysisResult → 失败 patch → updateDiscoveryRepo → toast | useDiscoveryRepoActions.analyze |
 | 7 | GistCard.handleAnalyze (68-120) | 三段校验（gist 版原文案）→ 已分析则 confirm 覆盖（原文案）→ setAnalyzingGist(id,true)（store）+ 本地 flag → createGitHubApiService → getGistForAnalysis(id, gist) → new AIService → analyzeGist(detail, api.getGistContentPreview(detail))（**无 Abort**）→ updateGist(成功 patch) → toast；catch → updateGist(失败 patch) → toast；finally 双 flag 复位。**无 forceSync** | useGistActions.analyzeOne |
 | 8 | GistCard.handleUnstar (122-143) | 无 token 静默 return → confirm(warning+confirmText 原文案) → api.unstarGist(id) → onUnstarred(gist.id) → updateGist({starred:false}) → toast；catch toast。**无 forceSync** | useGistActions.unstarGist |
 | 9 | GistCard.handleDelete (145-174) | 无 token/isMine 静默 return → confirm(danger+confirmText 原文案) → api.deleteGist(id) → store.deleteGist → onDeleted(gist.id) → toast；catch：403/404/forbidden/scope/permission → 权限提示 toast（原文案）。**无 forceSync** | useGistActions.deleteGist |
@@ -199,7 +199,8 @@ export const computeRpcDownloadKey = (link: { url: string; updatedAt?: string })
   2. 内部实例化 `useReleaseArtifactActions()`；generateSummary 直接转发；sendAssetToRpc 变为 `if (!rpcDownloadConfig.enabled) return; await actions.sendRpcDownload(link);`（enabled 守卫留 sheet——ReleaseCard 侧由按钮显隐承担）；
   3. 对外返回的 summaries/downloadStates 改由 hook 供给 + computeRpcDownloadKey 换算（RepositoryReleaseSheet UI 及其测试同步换 key）；
   4. cancelPendingRequests 保留 fetch abort 部分，summary 部分转发 cancelSummaryRequests；
-  5. **3 处已接受微差异（写入 PR 描述，行为零变更的唯一例外）**：① dedup key 由 url-only 变 `url@updatedAt`（与卡片一致，修同病灶）；② AI 配置缺失由"静默置 error 态"变"toast 不置态"；③ RPC 失败文案统一为 ReleaseCard 版。若存量测试断言旧文案/旧 key，按新语义更新断言并在 PR 说明（§6.2）。
+  4b. loadReleases 原有的 `setSummaries({})`/`setDownloadStates({})` 置空行为由共享 hook 的 `reset()` 承担（规格遗漏，实施补充）：reset 先 `cancelSummaryRequests()` 取消进行中请求、再清空 summaries/rpcDownloadStates，防止迟到结果回写；generateSummary 另设 summaryAbortRefs 同步门卫（loading 守卫读渲染快照，挡不住同 tick 双调用）；
+  5. **3 处规格预设微差异（写入 PR 描述；实施期补充的 5 处等价调整一并在 PR 描述列明，该清单为完整真值）**：① dedup key 由 url-only 变 `url@updatedAt`（与卡片一致，修同病灶）；② AI 配置缺失由"静默置 error 态（含行内错误卡片）"变"仅 toast 不置态"；③ RPC 失败文案统一为 ReleaseCard 版。若存量测试断言旧文案/旧 key，按新语义更新断言并在 PR 说明（§6.2）。
 
 ### 2.6 `useReleaseTimelineActions` 新增 `syncWatchedSources`（B1：方法不存在，为新增）
 
@@ -335,15 +336,15 @@ L9 `import type { GistCreateInput, GistUpdateInput } from '../services/githubApi
 | `src/features/repositories/application/__tests__/discoveryRepoPatches.test.ts` | 纯函数无 mock | 成功/失败 patch 字段集（无 custom_category/category_locked）、DiscoveryRepo 字段保留 |
 | `src/features/repositories/hooks/useSearchActions.test.tsx` | store mock **必须同时提供 getState**：`useAppStore: Object.assign(vi.fn(sel => sel(state)), { getState: () => state })`；mock vectorSearchService/aiService/githubApi/githubApiFactory/autoSync | ① 向量命中：topK/threshold 默认 30/0.35、加分映射、rerank 失败仅回退不 toast、skipNextTextSearchRef=true；② HyDE 5s race 降级回原 query；③ 向量无结果→keywordSearch AI 失败回退 performBasicTextSearch；④ syncStars('stars-and-lists')：**setRepositories 先于 forceSyncToBackend、再 setLastSync**（保序断言）；list 失败不中断星标结果；token 过期文案分支；⑤ 4 个纯函数 |
 | `src/features/gists/hooks/useGistActions.test.tsx`（**全新增**，B4：无存量） | store state 覆盖 selectGistViewState 全字段；githubApiFactory mock 出 getGistForAnalysis/getGistContentPreview/unstarGist/deleteGist/getGistFileRaw；AIService.analyzeGist | analyzeOne：已分析触发 confirm、成功 patch 字段、**不调用 forceSync**；unstarGist/deleteGist：confirm false 中止、onUnstarred/onDeleted 各自原点位；fetchGistFileRaw：无 token 抛原文案、有 token 透传 signal |
-| `src/features/discovery/hooks/useDiscoveryRepoActions.test.tsx` | aiAnalysisHelper/autoSync/githubApi/store | analyze 三段校验文案与顺序、abort 短路、成功 patch 无 custom_category、**无 forceSync**；star 乐观→远端→addRepository→onStar→**forceSync**→乐观清→toast 保序；executeUnstar 乐观/回滚、deleteRepository by full_name、**forceSync**、成功无 toast |
+| `src/features/discovery/hooks/useDiscoveryRepoActions.test.tsx` | aiAnalysisHelper/autoSync/githubApi/store | analyze 四段校验文案与顺序、abort 短路、成功 patch 无 custom_category、**无 forceSync**；star 乐观→远端→addRepository→onStar→**forceSync**→乐观清→toast 保序；executeUnstar 乐观/回滚、deleteRepository by full_name、**forceSync**、成功无 toast |
 | `src/hooks/useReadmeFetch.test.tsx` | backendAdapter/githubApi/routeMode | bypass 或 !isAvailable→直连；backend 成功不走 GitHub；backend 失败非 abort 有 token→fallback+warn；无 token：content 抛/candidates 返回 []；cancel 后再 fetch abort 上一个；pickReadmeCandidate |
-| `src/hooks/useReleaseArtifactActions.test.tsx`（B4 更名：非 useReleaseCardActions.test） | rpcDownloadService/AIService/useDialog/store | sendRpcDownload：key=url@updatedAt、sending 短路、重试清 sent、'RPC service not running' 分支、catch 文案；generateSummary：无配置 toast、loading/done 短路、error 态+toast、AbortError 静默、unmount abort；computeRpcDownloadKey |
+| `src/hooks/useReleaseArtifactActions.test.tsx`（B4 更名：非 useReleaseCardActions.test） | rpcDownloadService/AIService/useDialog/store | sendRpcDownload：key=url@updatedAt、sending 短路、重试清 sent、'RPC service not running' 分支、catch 文案；generateSummary：无配置 toast、loading/done 短路、error 态+toast、AbortError 静默、unmount abort、同 tick 连续调用去重；reset：取消进行中请求、迟到结果不回写（abort 感知型与 resolve 型 mock 各一）、清空 summaries/rpcDownloadStates；computeRpcDownloadKey |
 | `src/features/releases/hooks/useReleaseTimelineActions.test.tsx`（新增，聚焦 syncWatchedSources） | githubApi/store（含 releaseSourceSettings.watchCustomReleaseRepos、setReleaseSourceRepositories） | 无 token/isSyncing 静默；release_hidden 保留合并；setReleaseSourceRepositories 入参；成功/失败 toast；**不调用 forceSync** |
 | `src/features/settings/hooks/useBackendAvailability.test.tsx`（小） | backendAdapter | 返回 backend.isAvailable 两态 |
 
 ### 6.2 存量回归（`npm run test:run` 必绿）
 
-`src/components/SearchBar.test.tsx`（未 mock service，不触达迁移路径）、`RepositoryEditModal.test.tsx`（已模块级 mock `../services/autoSync`，命中 useCategorySyncActions 内同名 import）、`ReadmeModal.test.tsx`（backendAdapter/githubApi 模块级 mock 命中 useReadmeFetch 内 import；若 hook 读取的 store 字段超出 mock 形状，补 fixture 字段而非改断言）、`ReleaseCard.test.tsx`（rpcDownloadService/aiService mock 命中共享 hook；注意其 mock 走动态 import 形式）、`RepositoryReleaseSheet.test.tsx` + `src/features/repositories/hooks/useRepositoryReleaseSheet.test.tsx`（委托重构后仅当断言 §2.5 三处微差异时按新语义更新断言并 PR 说明）、`useRepositoryCardActions.test.tsx`（不动）、`ReleaseTimeline.test.tsx`、`ForkTimeline.test.tsx`、`settings/BackendPanel.test.tsx`、`src/store/useAppStore.modularization.test.ts`（**必须零改动通过**——Store 未动的证明）。
+`src/components/SearchBar.test.tsx`（未 mock service，不触达迁移路径）、`RepositoryEditModal.test.tsx`（已模块级 mock `../services/autoSync`，命中 useCategorySyncActions 内同名 import）、`ReadmeModal.test.tsx`（backendAdapter/githubApi 模块级 mock 命中 useReadmeFetch 内 import；若 hook 读取的 store 字段超出 mock 形状，补 fixture 字段而非改断言）、`ReleaseCard.test.tsx`（rpcDownloadService/aiService mock 命中共享 hook；注意其 mock 走动态 import 形式）、`RepositoryReleaseSheet.test.tsx` + `src/features/repositories/hooks/useRepositoryReleaseSheet.test.tsx`（存量文件扩展：委托重构后仅当断言 §2.5 微差异时按新语义更新断言并 PR 说明；本 PR 为后者补 1 个同步门卫/状态回写回归用例）、`useRepositoryCardActions.test.tsx`（不动）、`ReleaseTimeline.test.tsx`、`ForkTimeline.test.tsx`、`settings/BackendPanel.test.tsx`、`src/store/useAppStore.modularization.test.ts`（**必须零改动通过**——Store 未动的证明）。
 
 **vi.mock 原则（B4）**：组件不再 import service 后，既有测试的 `vi.mock('.../services/x')` 经解析路径仍拦截 hook 内同名 import——**不预防性重写任何测试文件，跑通为准**；仅断言与既定微差异冲突时最小修改。
 
@@ -403,7 +404,7 @@ rg -n 'COMPONENT_BOUNDARY_ALLOWLIST|COMPONENT_ALLOWLIST' eslint.config.js script
 | 单 PR 体量大 | 每 commit 一文件/一主题（§7），可按 commit 粒度 revert；hook commit 与 View commit 相互独立 |
 | SearchBar 改动面最大 | ref 暴露策略（§2.1）使过滤 effect 零改动；applyFilters 参数传入消除 stale closure；置于最后一个 View commit |
 | DiscoveryRepo 类型摩擦 | patch 纯函数收发均 DiscoveryRepo（§3.1）；不改 Store shape；modularization 测试不动 |
-| useRepositoryReleaseSheet 委托的 3 处微差异 | §2.5 改造点显式列明 + PR 描述声明；断言同步更新；不满意可单独 revert commit 5（需恢复 sheet 内联实现） |
+| useRepositoryReleaseSheet 委托的行为微差异 | §2.5 列明规格预设 3 处 + PR 描述声明全部 8 条（含实施补充）；断言同步更新；不满意可单独 revert commit 5（需恢复 sheet 内联实现） |
 | 存量测试 mock 失配 | vi.mock 按解析路径拦截（§6.2 原则）；只补 fixture、不预防性重写 |
 | 删 allowlist 后冒出新违规 | 最后 commit 前先跑三条门禁；allowlist 删除 commit 本身只动两个门禁文件 |
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ import tseslint from 'typescript-eslint';
 /**
  * Business services a View component may never import directly. These modules own remote
  * calls or Store mutation; they belong behind a hook in src/features/.../hooks/**.
- * See docs/adr/0001-frontend-layering.md for the layering contract and the phasing rationale.
+ * See docs/adr/0001-frontend-layering.md for the layering contract.
  *
  * Infrastructure utilities (logger, isElectron/electronProxy, indexedDbStorage,
  * mcpElectronBridge, aiRequestLimiter, discoveryAnalysisStorage) are intentionally NOT

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,27 +40,6 @@ const BANNED_COMPONENT_SERVICE_IMPORTS = BANNED_COMPONENT_SERVICES.map(
 const BANNED_COMPONENT_SERVICE_DYNAMIC_SELECTORS = BANNED_COMPONENT_SERVICES.map(
   (name) => `ImportExpression > Literal[value=/\\/services\\/${name}$/]`,
 );
-/**
- * Phased allowlist: components whose operations have NOT yet been lifted into a hook.
- * The boundary rule is enforced everywhere in src/components/** EXCEPT these files.
- * Each entry is tech debt with an expiration date — a follow-up PR that migrates the
- * component removes it from this list. See ADR §"Phased enforcement".
- *
- * `src/components/ui/**` is never allowlisted: primitives must never touch a business
- * service, so any new violation there fails lint immediately.
- */
-const COMPONENT_BOUNDARY_ALLOWLIST = [
-  'src/components/SearchBar.tsx',
-  'src/components/ReadmeModal.tsx',
-  'src/components/GistCard.tsx',
-  'src/components/GistDetailModal.tsx',
-  'src/components/GistEditorModal.tsx',
-  'src/components/ReleaseCard.tsx',
-  'src/components/ReleaseSourceSettingsModal.tsx',
-  'src/components/SubscriptionRepoCard.tsx',
-  'src/components/RepositoryEditModal.tsx',
-  'src/components/SettingsPanel.tsx',
-];
 
 export default tseslint.config(
   { ignores: ['dist'] },
@@ -87,8 +66,7 @@ export default tseslint.config(
     /**
      * Boundary rule for View components: no direct imports of business services, neither
      * static nor dynamic. Tests are exempt so vi.mock('../services/...') in *.test.tsx
-     * stays legal. The phased allowlist exempts not-yet-migrated components; see ADR
-     * §"Phased enforcement".
+     * stays legal.
      *
      * `no-restricted-imports` covers static `import ... from` / `export ... from`.
      * `no-restricted-syntax` covers dynamic `import('...')` (ImportExpression), which
@@ -97,7 +75,6 @@ export default tseslint.config(
     files: ['src/components/**/*.{ts,tsx}'],
     ignores: [
       'src/components/**/*.test.{ts,tsx}',
-      ...COMPONENT_BOUNDARY_ALLOWLIST,
     ],
     rules: {
       'no-restricted-imports': [

--- a/scripts/check-boundaries.cjs
+++ b/scripts/check-boundaries.cjs
@@ -15,10 +15,6 @@
  *    source files as text and pattern-matches import statements.
  *  - Exempts test files (*.test.ts / *.test.tsx) so vi.mock('../services/...')
  *    stays legal.
- *  - Uses the same phased allowlist as eslint.config.js: components whose
- *    operations have not yet been lifted into a hook are skipped, with an
- *    expiration date (each follow-up PR that migrates one removes it here
- *    and in eslint.config.js together).
  *
  * Exit code: 0 = clean, 1 = violations found (or unreadable file).
  */
@@ -43,20 +39,6 @@ const BANNED_COMPONENT_SERVICES = [
   'updateService',
   'translateService',
 ];
-
-// Mirror of COMPONENT_BOUNDARY_ALLOWLIST in eslint.config.js. Keep in sync.
-const COMPONENT_ALLOWLIST = new Set([
-  'src/components/SearchBar.tsx',
-  'src/components/ReadmeModal.tsx',
-  'src/components/GistCard.tsx',
-  'src/components/GistDetailModal.tsx',
-  'src/components/GistEditorModal.tsx',
-  'src/components/ReleaseCard.tsx',
-  'src/components/ReleaseSourceSettingsModal.tsx',
-  'src/components/SubscriptionRepoCard.tsx',
-  'src/components/RepositoryEditModal.tsx',
-  'src/components/SettingsPanel.tsx',
-]);
 
 // application purity: banned module specifiers (exact) + banned path patterns.
 // Mirrors eslint.config.js: **/store/** (not just useAppStore) so store/selectors
@@ -103,7 +85,6 @@ let violations = 0;
 
 function checkComponentFile(full, relPath) {
   if (isTestFile(relPath)) return;
-  if (COMPONENT_ALLOWLIST.has(relPath)) return;
   let src;
   try {
     src = fs.readFileSync(full, 'utf8');

--- a/src/components/GistCard.tsx
+++ b/src/components/GistCard.tsx
@@ -13,7 +13,7 @@ interface GistCardProps {
   isMine: boolean;
   onOpen: (gist: Gist) => void;
   onEdit: (gist: Gist) => void;
-  onDeleted: (gistId: string) => void;
+  onDeleted?: (gistId: string) => void;
   onUnstarred: (gistId: string) => void;
 }
 

--- a/src/components/GistCard.tsx
+++ b/src/components/GistCard.tsx
@@ -1,10 +1,8 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { Bot, Clock, Copy, Edit3, ExternalLink, FileCode2, Loader2, StarOff, Trash2, User } from 'lucide-react';
 import type { Gist } from '../types';
-import { createGitHubApiService } from '../services/githubApiFactory';
-import { AIService } from '../services/aiService';
 import { useAppStore } from '../store/useAppStore';
-import { useShallow } from 'zustand/react/shallow';
+import { useGistActions } from '../features/gists/hooks/useGistActions';
 import { useDialog } from '../hooks/useDialog';
 import { safeWriteText } from '../utils/clipboardUtils';
 import { getGistFileCount, getGistPrimaryLanguage, getGistTitle } from '../utils/gistUtils';
@@ -27,32 +25,14 @@ export const GistCard: React.FC<GistCardProps> = ({
   onDeleted,
   onUnstarred,
 }) => {
-  const {
-    githubToken,
-    aiConfigs,
-    activeAIConfig,
-    language,
-    updateGist,
-    deleteGist,
-    setAnalyzingGist,
-  } = useAppStore(useShallow((state) => ({
-    githubToken: state.githubToken,
-    aiConfigs: state.aiConfigs,
-    activeAIConfig: state.activeAIConfig,
-    language: state.language,
-    updateGist: state.updateGist,
-    deleteGist: state.deleteGist,
-    setAnalyzingGist: state.setAnalyzingGist,
-  })));
-  const isStoreAnalyzing = useAppStore(state => state.analyzingGistIds.has(gist.id));
-  const { toast, confirm } = useDialog();
-  const [isAnalyzingLocal, setIsAnalyzingLocal] = useState(false);
-  const [isMutating, setIsMutating] = useState(false);
+  const language = useAppStore(state => state.language);
+  const { analyzeOne, unstarGist, deleteGist, isAnalyzingGist, isMutating } = useGistActions();
+  const { toast } = useDialog();
   const t = (zh: string, en: string) => language === 'zh' ? zh : en;
   const title = getGistTitle(gist);
   const primaryLanguage = getGistPrimaryLanguage(gist);
   const fileCount = getGistFileCount(gist);
-  const isAnalyzing = isStoreAnalyzing || isAnalyzingLocal;
+  const isAnalyzing = isAnalyzingGist(gist.id);
 
   const fileNames = useMemo(() =>
     Object.values(gist.files || {}).slice(0, 3).map(file => file.filename).join(', '),
@@ -65,112 +45,19 @@ export const GistCard: React.FC<GistCardProps> = ({
     toast(result.success ? t('链接已复制', 'Link copied') : (result.error || t('复制失败', 'Copy failed')), result.success ? 'success' : 'error');
   };
 
-  const handleAnalyze = async (event: React.MouseEvent) => {
+  const handleAnalyze = (event: React.MouseEvent) => {
     event.stopPropagation();
-    if (!githubToken) {
-      toast(t('GitHub token 未找到，请重新登录。', 'GitHub token not found. Please login again.'), 'error');
-      return;
-    }
-    const activeConfig = aiConfigs.find(config => config.id === activeAIConfig);
-    if (!activeConfig) {
-      toast(t('请先在设置中配置AI服务。', 'Please configure AI service in settings first.'), 'error');
-      return;
-    }
-    if (!activeConfig.baseUrl || !activeConfig.apiKey || !activeConfig.model || activeConfig.apiKeyStatus === 'decrypt_failed' || activeConfig.apiKeyStatus === 'empty') {
-      toast(t('AI服务配置不完整，请检查设置。', 'AI service configuration is incomplete. Please check settings.'), 'error');
-      return;
-    }
-
-    if (gist.analyzed_at) {
-      const shouldContinue = await confirm(
-        t('重新分析确认', 'Re-analyze Confirmation'),
-        t('此 gist 已经分析过，是否覆盖现有摘要？', 'This gist has already been analyzed. Overwrite the existing summary?'),
-        { type: 'warning' }
-      );
-      if (!shouldContinue) return;
-    }
-
-    setAnalyzingGist(gist.id, true);
-    setIsAnalyzingLocal(true);
-    try {
-      const githubApi = createGitHubApiService(githubToken);
-      const detail = await githubApi.getGistForAnalysis(gist.id, gist);
-      const aiService = new AIService(activeConfig, language);
-      const summary = await aiService.analyzeGist(detail, githubApi.getGistContentPreview(detail));
-      updateGist({
-        ...detail,
-        ai_summary: summary.trim(),
-        analyzed_at: new Date().toISOString(),
-        analysis_failed: false,
-        analysis_error: undefined,
-      });
-      toast(t('Gist AI分析完成', 'Gist AI analysis completed'), 'success');
-    } catch (error) {
-      updateGist({
-        ...gist,
-        analyzed_at: new Date().toISOString(),
-        analysis_failed: true,
-        analysis_error: error instanceof Error ? error.message : String(error),
-      });
-      toast(t('Gist AI分析失败', 'Gist AI analysis failed'), 'error');
-    } finally {
-      setIsAnalyzingLocal(false);
-      setAnalyzingGist(gist.id, false);
-    }
+    void analyzeOne(gist);
   };
 
-  const handleUnstar = async (event: React.MouseEvent) => {
+  const handleUnstar = (event: React.MouseEvent) => {
     event.stopPropagation();
-    if (!githubToken) return;
-    const confirmed = await confirm(
-      t('取消收藏 Gist', 'Unstar Gist'),
-      t('确定要取消收藏这个 gist 吗？', 'Are you sure you want to unstar this gist?'),
-      { type: 'warning', confirmText: t('取消收藏', 'Unstar') }
-    );
-    if (!confirmed) return;
-
-    setIsMutating(true);
-    try {
-      await createGitHubApiService(githubToken).unstarGist(gist.id);
-      onUnstarred(gist.id);
-      updateGist({ ...gist, starred: false });
-      toast(t('已取消收藏', 'Unstarred'), 'success');
-    } catch {
-      toast(t('取消收藏失败', 'Failed to unstar'), 'error');
-    } finally {
-      setIsMutating(false);
-    }
+    void unstarGist(gist, onUnstarred);
   };
 
-  const handleDelete = async (event: React.MouseEvent) => {
+  const handleDelete = (event: React.MouseEvent) => {
     event.stopPropagation();
-    if (!githubToken || !isMine) return;
-    const confirmed = await confirm(
-      t('删除 Gist', 'Delete Gist'),
-      t('确定要删除这个 gist 吗？此操作不可撤销。', 'Are you sure you want to delete this gist? This cannot be undone.'),
-      { type: 'danger', confirmText: t('删除', 'Delete') }
-    );
-    if (!confirmed) return;
-
-    setIsMutating(true);
-    try {
-      await createGitHubApiService(githubToken).deleteGist(gist.id);
-      deleteGist(gist.id);
-      onDeleted(gist.id);
-      toast(t('Gist 已删除', 'Gist deleted'), 'success');
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : '';
-      const isPermission = /403|404|forbidden|scope|permission/i.test(msg);
-      toast(
-        t(
-          `删除 Gist 失败${msg ? `：${msg}` : ''}${isPermission ? '（请确认 token 已勾选 gist 权限，并在设置中重新输入 token 登录）' : ''}`,
-          `Failed to delete gist${msg ? `: ${msg}` : ''}${isPermission ? ' (Make sure your token has the gist scope and re-login with the updated token)' : ''}`
-        ),
-        'error'
-      );
-    } finally {
-      setIsMutating(false);
-    }
+    void deleteGist(gist, onDeleted);
   };
 
   return (

--- a/src/components/GistDetailModal.tsx
+++ b/src/components/GistDetailModal.tsx
@@ -6,8 +6,8 @@ import { Modal } from './Modal';
 import type { Gist, GistFile } from '../types';
 import { getGistTitle, inferGistCodeLanguage } from '../utils/gistUtils';
 import { safeWriteText } from '../utils/clipboardUtils';
-import { createGitHubApiService } from '../services/githubApiFactory';
 import { useAppStore } from '../store/useAppStore';
+import { useGistActions } from '../features/gists/hooks/useGistActions';
 import { useDialog } from '../hooks/useDialog';
 import 'highlight.js/styles/github.min.css';
 
@@ -19,13 +19,13 @@ interface GistDetailModalProps {
 
 interface HighlightedCodeProps {
   file: GistFile;
+  fetchRaw: (rawUrl: string, signal: AbortSignal) => Promise<string>;
   onContentLoaded?: (filename: string, content: string, rawUrl?: string) => void;
 }
 
-const HighlightedCode: React.FC<HighlightedCodeProps> = ({ file, onContentLoaded }) => {
+const HighlightedCode: React.FC<HighlightedCodeProps> = ({ file, fetchRaw, onContentLoaded }) => {
   const codeRef = useRef<HTMLElement>(null);
   const language = inferGistCodeLanguage(file.filename, file.language);
-  const githubToken = useAppStore(state => state.githubToken);
   const language2 = useAppStore(state => state.language);
   const t = (zh: string, en: string) => language2 === 'zh' ? zh : en;
 
@@ -53,14 +53,9 @@ const HighlightedCode: React.FC<HighlightedCodeProps> = ({ file, onContentLoaded
     setIsLoadingRaw(true);
     setRawError(null);
     const doFetch = async () => {
-      if (!githubToken) {
-        setRawError(t('未配置 GitHub token，无法加载文件内容', 'GitHub token not configured, cannot load file content'));
-        setIsLoadingRaw(false);
-        return;
-      }
       try {
-        const api = createGitHubApiService(githubToken);
-        const text = await api.getGistFileRaw(file.raw_url!, controller.signal);
+        // 无 token 时由 hook 抛出原文案错误，catch 落 rawError 后与原直写渲染一致
+        const text = await fetchRaw(file.raw_url!, controller.signal);
         if (controller.signal.aborted) return;
         setRawContent(text);
         onContentLoadedRef.current?.(file.filename, text, file.raw_url);
@@ -77,7 +72,7 @@ const HighlightedCode: React.FC<HighlightedCodeProps> = ({ file, onContentLoaded
     return () => controller.abort();
     // retryTick 用于手动触发重试；file.raw_url/filename 变化时也会重新拉取。
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [needsRawFetch, file.raw_url, file.filename, retryTick, githubToken]);
+  }, [needsRawFetch, file.raw_url, file.filename, retryTick, fetchRaw]);
 
   useEffect(() => {
     if (!codeRef.current) return;
@@ -130,6 +125,7 @@ const HighlightedCode: React.FC<HighlightedCodeProps> = ({ file, onContentLoaded
 export const GistDetailModal: React.FC<GistDetailModalProps> = ({ gist, isOpen, onClose }) => {
   const language = useAppStore(state => state.language);
   const updateGist = useAppStore(state => state.updateGist);
+  const { fetchGistFileRaw } = useGistActions();
   const { toast } = useDialog();
   const [activeFilename, setActiveFilename] = useState<string>('');
   const [loadedContents, setLoadedContents] = useState<Record<string, string>>({});
@@ -278,6 +274,7 @@ export const GistDetailModal: React.FC<GistDetailModalProps> = ({ gist, isOpen, 
             <HighlightedCode
               key={`${gist.id}:${activeFile.filename}:${activeFile.raw_url ?? ''}`}
               file={effectiveActiveFile!}
+              fetchRaw={fetchGistFileRaw}
               onContentLoaded={handleContentLoaded}
             />
           </div>

--- a/src/components/GistEditorModal.tsx
+++ b/src/components/GistEditorModal.tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { Plus, Trash2 } from 'lucide-react';
 import { Modal } from './Modal';
 import type { Gist } from '../types';
-import type { GistCreateInput, GistUpdateInput } from '../services/githubApi';
+import type { GistCreateInput, GistUpdateInput } from '../features/gists/hooks/useGistActions';
 import { useAppStore } from '../store/useAppStore';
 
 interface EditableFile {

--- a/src/components/GistView.tsx
+++ b/src/components/GistView.tsx
@@ -46,9 +46,6 @@ export const GistView: React.FC = () => {
     fetchGistDetail,
     submitGist,
   } = useGistActions();
-  // useGistActions.deleteGist 是卡片级动作（接收 Gist 对象、内置确认）；这里的
-  // onDeleted 只需要原始 store action 按 id 移除记录，故直接订阅 store。
-  const deleteGistRecord = useAppStore(state => state.deleteGist);
   const t = (zh: string, en: string) => language === 'zh' ? zh : en;
   const [query, setQuery] = useState(gistSearchFilters.query);
   const [detailGist, setDetailGist] = useState<Gist | null>(null);
@@ -281,9 +278,6 @@ export const GistView: React.FC = () => {
                 onEdit={(target) => {
                   setEditingGist(target);
                   setIsEditorOpen(true);
-                }}
-                onDeleted={(gistId) => {
-                  deleteGistRecord(gistId);
                 }}
                 onUnstarred={(gistId) => {
                   const latestStarred = useAppStore.getState().starredGists;

--- a/src/components/GistView.tsx
+++ b/src/components/GistView.tsx
@@ -36,7 +36,6 @@ export const GistView: React.FC = () => {
     setGistSearchFilters,
     setGistSearchResults,
     setSelectedGistCategory,
-    deleteGist,
     setStarredGists,
     isRefreshing,
     isSearching,
@@ -47,6 +46,9 @@ export const GistView: React.FC = () => {
     fetchGistDetail,
     submitGist,
   } = useGistActions();
+  // useGistActions.deleteGist 是卡片级动作（接收 Gist 对象、内置确认）；这里的
+  // onDeleted 只需要原始 store action 按 id 移除记录，故直接订阅 store。
+  const deleteGistRecord = useAppStore(state => state.deleteGist);
   const t = (zh: string, en: string) => language === 'zh' ? zh : en;
   const [query, setQuery] = useState(gistSearchFilters.query);
   const [detailGist, setDetailGist] = useState<Gist | null>(null);
@@ -281,7 +283,7 @@ export const GistView: React.FC = () => {
                   setIsEditorOpen(true);
                 }}
                 onDeleted={(gistId) => {
-                  deleteGist(gistId);
+                  deleteGistRecord(gistId);
                 }}
                 onUnstarred={(gistId) => {
                   const latestStarred = useAppStore.getState().starredGists;

--- a/src/components/ReadmeModal.tsx
+++ b/src/components/ReadmeModal.tsx
@@ -5,12 +5,10 @@ import { X, Loader2, AlertCircle, FileText, ExternalLink, List, Type, ArrowUp, L
 import BilingualMarkdownRenderer, { DisplayMode, BilingualMarkdownRendererHandle, TranslationStatus } from './BilingualMarkdownRenderer';
 import { stripMarkdownFormatting } from '../utils/markdownUtils';
 import { Repository } from '../types';
-import { GitHubApiService } from '../services/githubApi';
-import { backend } from '../services/backendAdapter';
-import { shouldBypassBackend } from '../services/routeMode';
 import { useAppStore } from '../store/useAppStore';
 import { useShallow } from 'zustand/react/shallow';
-import { buildReadmeVariants, DEFAULT_README_VARIANT, type GitHubReadmeCandidateItem, type ReadmeVariant } from '../utils/readmeVariants';
+import { useReadmeFetch, pickReadmeCandidate } from '../hooks/useReadmeFetch';
+import { buildReadmeVariants, DEFAULT_README_VARIANT, type ReadmeVariant } from '../utils/readmeVariants';
 import { Dialog, DialogContent, DialogTitle } from './ui/dialog';
 
 interface TocItem {
@@ -49,8 +47,7 @@ export const ReadmeModal: React.FC<ReadmeModalProps> = ({
   onCloseAutoFocus,
   repository
 }) => {
-  const { githubToken, language, setReadmeModalOpen } = useAppStore(useShallow((state) => ({
-    githubToken: state.githubToken,
+  const { language, setReadmeModalOpen } = useAppStore(useShallow((state) => ({
     language: state.language,
     setReadmeModalOpen: state.setReadmeModalOpen,
   })));
@@ -76,11 +73,18 @@ export const ReadmeModal: React.FC<ReadmeModalProps> = ({
   const defaultReadmeVariant = useMemo(() => getDefaultReadmeVariant(language), [language]);
 
   const contentRef = useRef<HTMLDivElement>(null);
-  const abortControllerRef = useRef<AbortController | null>(null);
-  const variantsAbortControllerRef = useRef<AbortController | null>(null);
   const isResizingRef = useRef(false);
   const startXRef = useRef(0);
   const startWidthRef = useRef(0);
+
+  // README 抓取（backend 优先 → GitHub 兜底）由共享 hook 承担；
+  // abort 实体在 hook（每次 fetch 前中止上一个，unmount 自动取消），关闭 modal 时调 cancelFetches。
+  const [repoOwner = '', repoName = ''] = repository?.full_name.split('/') ?? [];
+  const {
+    fetchReadmeContent: fetchReadmeContentFromAvailableSource,
+    fetchReadmeCandidates: fetchReadmeCandidatesFromAvailableSource,
+    cancel: cancelFetches,
+  } = useReadmeFetch({ owner: repoOwner, name: repoName });
 
   const bilingualRef = useRef<BilingualMarkdownRendererHandle>(null);
   const [translateStatus, setTranslateStatus] = useState<TranslationStatus>('idle');
@@ -329,85 +333,14 @@ export const ReadmeModal: React.FC<ReadmeModalProps> = ({
     scrollToTop();
   }, [resetTranslationState, scrollToTop]);
 
-  const fetchReadmeContentFromAvailableSource = useCallback(async (
-    owner: string,
-    name: string,
-    variant: ReadmeVariant,
-    signal: AbortSignal
-  ): Promise<string> => {
-    const fetchFromGitHubApi = async () => {
-      if (!githubToken) {
-        throw new Error(language === 'zh' ? '未登录且后端不可用，无法加载 README' : 'Not logged in and backend unavailable, cannot load README');
-      }
-      const githubApi = new GitHubApiService(githubToken);
-      return variant.isDefault || !variant.path
-        ? githubApi.getRepositoryReadme(owner, name, signal)
-        : githubApi.getRepositoryReadmeByPath(owner, name, variant.path, signal);
-    };
-
-    if (shouldBypassBackend() || !backend.isAvailable) {
-      return fetchFromGitHubApi();
-    }
-
-    try {
-      return variant.isDefault || !variant.path
-        ? await backend.getRepositoryReadme(owner, name, signal)
-        : await backend.getRepositoryReadmeByPath(owner, name, variant.path, signal);
-    } catch (backendError) {
-      if (isAbortError(backendError, signal) || !githubToken) {
-        throw backendError;
-      }
-
-      console.warn('Falling back to direct GitHub README fetch after backend failure:', backendError);
-      return fetchFromGitHubApi();
-    }
-  }, [githubToken, language]);
-
-  const fetchReadmeCandidatesFromAvailableSource = useCallback(async (
-    owner: string,
-    name: string,
-    defaultBranch: string | undefined,
-    signal: AbortSignal
-  ): Promise<GitHubReadmeCandidateItem[]> => {
-    const fetchFromGitHubApi = async () => {
-      if (!githubToken) return [];
-      const githubApi = new GitHubApiService(githubToken);
-      return githubApi.listRepositoryReadmeCandidates(owner, name, defaultBranch, signal);
-    };
-
-    if (shouldBypassBackend() || !backend.isAvailable) {
-      return fetchFromGitHubApi();
-    }
-
-    try {
-      return await backend.listRepositoryReadmeCandidates(owner, name, defaultBranch, signal);
-    } catch (backendError) {
-      if (isAbortError(backendError, signal) || !githubToken) {
-        throw backendError;
-      }
-
-      console.warn('Falling back to direct GitHub README variant detection after backend failure:', backendError);
-      return fetchFromGitHubApi();
-    }
-  }, [githubToken]);
-
   const fetchReadmeContent = useCallback(async (variant: ReadmeVariant) => {
     if (!repository) return;
-
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-    }
-    const abortController = new AbortController();
-    abortControllerRef.current = abortController;
 
     setLoading(true);
     setError(null);
 
     try {
-      const [owner, name] = repository.full_name.split('/');
-      const content = await fetchReadmeContentFromAvailableSource(owner, name, variant, abortController.signal);
-
-      if (abortController.signal.aborted) return;
+      const content = await fetchReadmeContentFromAvailableSource(variant);
 
       setReadmeCache(prev => ({ ...prev, [variant.key]: content }));
 
@@ -420,54 +353,41 @@ export const ReadmeModal: React.FC<ReadmeModalProps> = ({
           ? (language === 'zh' ? '该仓库没有 README 文件' : 'This repository has no README file')
           : (language === 'zh' ? '该 README 文件为空' : 'This README file is empty'));
       }
+      setLoading(false);
     } catch (err) {
-      if (abortController.signal.aborted) return;
+      // 被 hook abort（被新请求取代 / cancel）时静默返回，不动 loading 态
+      if (isAbortError(err)) return;
       console.error('Failed to fetch README:', err);
       setReadmeContent('');
       const fallbackMessage = variant.isDefault
         ? (language === 'zh' ? '加载 README 失败，请检查网络连接或稍后重试' : 'Failed to load README. Please check your network connection and try again later')
         : (language === 'zh' ? '加载所选 README 失败，请稍后重试' : 'Failed to load selected README. Please try again later');
       setError(err instanceof Error && err.message ? err.message : fallbackMessage);
-    } finally {
-      if (!abortController.signal.aborted) {
-        setLoading(false);
-      }
+      setLoading(false);
     }
   }, [repository, fetchReadmeContentFromAvailableSource, language]);
 
   const fetchReadmeVariants = useCallback(async () => {
     if (!repository) return;
 
-    if (variantsAbortControllerRef.current) {
-      variantsAbortControllerRef.current.abort();
-    }
-    const abortController = new AbortController();
-    variantsAbortControllerRef.current = abortController;
-
     setVariantsLoading(true);
 
     try {
-      const [owner, name] = repository.full_name.split('/');
       const defaultBranch = (repository as Repository & { default_branch?: string }).default_branch;
-      const candidates = await fetchReadmeCandidatesFromAvailableSource(owner, name, defaultBranch, abortController.signal);
+      const candidates = await fetchReadmeCandidatesFromAvailableSource(defaultBranch);
 
-      if (abortController.signal.aborted) return;
       setReadmeVariants(buildReadmeVariants(candidates, language));
+      setVariantsLoading(false);
     } catch (err) {
-      if (!abortController.signal.aborted) {
-        console.warn('Failed to detect README variants:', err);
-        setReadmeVariants([defaultReadmeVariant]);
-      }
-    } finally {
-      if (!abortController.signal.aborted) {
-        setVariantsLoading(false);
-      }
+      if (isAbortError(err)) return;
+      console.warn('Failed to detect README variants:', err);
+      setReadmeVariants([defaultReadmeVariant]);
+      setVariantsLoading(false);
     }
   }, [repository, fetchReadmeCandidatesFromAvailableSource, language, defaultReadmeVariant]);
 
   const fetchReadme = useCallback(async () => {
-    const currentVariant = readmeVariants.find(variant => variant.key === selectedReadmeKey) || defaultReadmeVariant;
-    await fetchReadmeContent(currentVariant);
+    await fetchReadmeContent(pickReadmeCandidate(readmeVariants, selectedReadmeKey, defaultReadmeVariant));
   }, [readmeVariants, selectedReadmeKey, defaultReadmeVariant, fetchReadmeContent]);
 
   const handleReadmeVariantChange = useCallback((nextKey: string) => {
@@ -521,14 +441,7 @@ export const ReadmeModal: React.FC<ReadmeModalProps> = ({
 
   useEffect(() => {
     if (!isOpen) {
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-        abortControllerRef.current = null;
-      }
-      if (variantsAbortControllerRef.current) {
-        variantsAbortControllerRef.current.abort();
-        variantsAbortControllerRef.current = null;
-      }
+      cancelFetches();
       setReadmeContent('');
       setError(null);
       setLoading(false);
@@ -554,20 +467,7 @@ export const ReadmeModal: React.FC<ReadmeModalProps> = ({
     } else {
       setShowToc(true);
     }
-  }, [isOpen, language]);
-
-  useEffect(() => {
-    return () => {
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-        abortControllerRef.current = null;
-      }
-      if (variantsAbortControllerRef.current) {
-        variantsAbortControllerRef.current.abort();
-        variantsAbortControllerRef.current = null;
-      }
-    };
-  }, []);
+  }, [isOpen, language, cancelFetches]);
 
   if (!repository) return null;
 
@@ -592,7 +492,7 @@ export const ReadmeModal: React.FC<ReadmeModalProps> = ({
   const isTranslating = translateStatus === 'translating';
   const isTranslated = translateStatus === 'translated';
   const isTranslateError = translateStatus === 'error';
-  const currentReadmeVariant = readmeVariants.find(variant => variant.key === selectedReadmeKey) || defaultReadmeVariant;
+  const currentReadmeVariant = pickReadmeCandidate(readmeVariants, selectedReadmeKey, defaultReadmeVariant);
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>

--- a/src/components/ReleaseCard.tsx
+++ b/src/components/ReleaseCard.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useRef, useState, useEffect } from 'react';
+import React, { memo, useCallback, useState, useEffect } from 'react';
 import { ExternalLink, GitBranch, Calendar, Download, ChevronDown, ChevronUp, BookOpen, ArrowUpRight, FolderOpen, Folder, BellOff, FileArchive, Code2, Loader2, CheckCircle2, Sparkles } from 'lucide-react';
 import { Release } from '../types';
 import { formatDistanceToNow } from 'date-fns';
@@ -7,20 +7,12 @@ import MarkdownRenderer from './MarkdownRenderer';
 import AssetLeadingIcon from './AssetLeadingIcon';
 import { useAppStore } from '../store/useAppStore';
 import { useShallow } from 'zustand/react/shallow';
-import { useDialog } from '../hooks/useDialog';
-import { sendToRpcDownload } from '../services/rpcDownloadService';
-import { AIService } from '../services/aiService';
+import { computeRpcDownloadKey, useReleaseArtifactActions } from '../hooks/useReleaseArtifactActions';
 import {
   effectiveReleaseTime,
   shouldShowAssetsUpdatedIndicator,
 } from '../utils/releaseAssets';
 import { Button } from './ui/button';
-
-type SummaryState = {
-  status: 'idle' | 'loading' | 'done' | 'error';
-  content?: string;
-  error?: string;
-};
 
 interface DownloadLink {
   name: string;
@@ -92,118 +84,29 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
   const effectiveTime = effectiveReleaseTime(release);
   const showAssetsUpdatedIndicator = shouldShowAssetsUpdatedIndicator(release);
 
-  // RPC download support — use refs to avoid stale closure in async handler
-  const { rpcDownloadConfig, backendApiSecret, aiConfigs, activeAIConfig } = useAppStore(useShallow((state) => ({
+  // RPC 发送与 AI 总结动作由共享 hook 承担（useRepositoryReleaseSheet 同源委托）
+  const { rpcDownloadConfig } = useAppStore(useShallow((state) => ({
     rpcDownloadConfig: state.rpcDownloadConfig,
-    backendApiSecret: state.backendApiSecret,
-    aiConfigs: state.aiConfigs,
-    activeAIConfig: state.activeAIConfig,
   })));
-  const activeConfig = aiConfigs.find((config) => config.id === activeAIConfig);
-
-  // AI 总结的本地状态（展开态与结果均内聚在卡片内，不持久化）
+  const { summaries, rpcDownloadStates, sendRpcDownload, generateSummary } = useReleaseArtifactActions();
+  // AI 总结状态内聚在 hook（展开态留在卡片内，不持久化）；
+  // 卡片卸载时的请求取消由 hook 的 unmount 副作用承担（卡片卸载即 hook 卸载）。
   const [isSummaryExpanded, setIsSummaryExpanded] = useState(false);
-  const [summary, setSummary] = useState<SummaryState>({ status: 'idle' });
-  const { toast } = useDialog();
-  // 管理进行中的 AI 请求，组件卸载或重新发起时取消，避免内存泄漏与无效网络开销
-  const summaryAbortRef = useRef<AbortController | null>(null);
+  const summary = summaries[release.id] ?? { status: 'idle' as const };
 
+  // 完成或失败后自动展开（原 runSummaryAnalysis 成功/失败分支的 setIsSummaryExpanded(true)）
   useEffect(() => {
-    return () => {
-      summaryAbortRef.current?.abort();
-    };
-  }, []);
-  const downloadingRef = useRef<Record<string, boolean>>({});
-  const downloadedRef = useRef<Record<string, boolean>>({});
-  const [, forceUpdate] = useState(0);
-
-  const handleRpcDownload = useCallback(async (link: DownloadLink) => {
-    // 同一资产更新后 URL 不变但 updatedAt 会变，key 带上版本，
-    // 否则旧版本的"已发送 ✓"会错误地残留在新版本上。
-    const key = `${link.url}@${link.updatedAt ?? ''}`;
-    // 仅在下载进行中时短路，允许下载完成后再次点击重新发送
-    if (downloadingRef.current[key]) return;
-
-    downloadingRef.current = { ...downloadingRef.current, [key]: true };
-    // 重试开始即清除旧的成功态：若本次失败/异常，行内不得残留 ✓，
-    // 否则卡片会把失败的重试报告成成功。
-    if (key in downloadedRef.current) {
-      const next = { ...downloadedRef.current };
-      delete next[key];
-      downloadedRef.current = next;
+    if (summary.status === 'done' || summary.status === 'error') {
+      setIsSummaryExpanded(true);
     }
-    forceUpdate(n => n + 1);
-    try {
-      const result = await sendToRpcDownload(link.url, link.name, backendApiSecret || undefined);
-      if (result.success) {
-        downloadedRef.current = { ...downloadedRef.current, [key]: true };
-        toast(t('已发送到远程下载器', 'Sent to remote downloader'), 'success');
-      } else {
-        toast(
-          result.error === 'RPC service not running'
-            ? t('远程下载服务未运行，请检查配置', 'Remote download service not running, please check config')
-            : result.error || t('发送失败', 'Send failed'),
-          'error'
-        );
-      }
-    } catch {
-      toast(t('远程下载服务未运行，请检查配置', 'Remote download service not running, please check config'), 'error');
-    } finally {
-      downloadingRef.current = { ...downloadingRef.current, [key]: false };
-      forceUpdate(n => n + 1);
-    }
-  }, [backendApiSecret, toast, t]);
+  }, [summary.status]);
 
   // 判断是否有任何内容展开
   const isAnyExpanded = isAssetsExpanded || isReleaseNotesExpanded || isSummaryExpanded;
 
-  const runSummaryAnalysis = useCallback(async () => {
-    if (!activeConfig) {
-      toast(
-        language === 'zh' ? '请先在设置中配置 AI 服务。' : 'Please configure AI service in settings first.',
-        'error'
-      );
-      return;
-    }
-
-    // 取消上一次未完成的请求
-    summaryAbortRef.current?.abort();
-    const controller = new AbortController();
-    summaryAbortRef.current = controller;
-
-    const config = activeConfig;
-    setSummary({ status: 'loading' });
-    try {
-      const aiService = new AIService(config, language);
-      const content = await aiService.analyzeReleaseSummary(
-        release.body || '',
-        {
-          repoName: release.repository.full_name,
-          tagName: release.tag_name,
-          releaseName: release.name && release.name !== release.tag_name ? release.name : undefined,
-        },
-        controller.signal
-      );
-      setSummary({ status: 'done', content });
-      setIsSummaryExpanded(true);
-    } catch (error) {
-      // 主动取消（卸载/重新发起）时静默处理，不更新状态、不弹错误
-      if (error instanceof Error && error.name === 'AbortError') {
-        return;
-      }
-      const message = error instanceof Error ? error.message : String(error);
-      setSummary({ status: 'error', error: message });
-      setIsSummaryExpanded(true);
-      toast(
-        language === 'zh' ? `总结生成失败：${message}` : `Summary failed: ${message}`,
-        'error'
-      );
-    } finally {
-      if (summaryAbortRef.current === controller) {
-        summaryAbortRef.current = null;
-      }
-    }
-  }, [activeConfig, language, release, toast]);
+  const handleRpcDownload = useCallback(async (link: DownloadLink) => {
+    await sendRpcDownload(link);
+  }, [sendRpcDownload]);
 
   const handleToggleSummary = useCallback(async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -221,8 +124,8 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
     }
 
     // 未分析或上次失败 → 触发 AI 分析（按钮转圈，完成后自动展开）
-    await runSummaryAnalysis();
-  }, [isSummaryExpanded, summary, runSummaryAnalysis]);
+    await generateSummary(release);
+  }, [isSummaryExpanded, summary, generateSummary, release]);
 
   return (
     <div
@@ -398,10 +301,10 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
               <div className="ui-inset-surface max-h-72 overflow-hidden overflow-y-auto">
                 {downloadLinks.map((link, index) => {
                   const isRpcEnabled = rpcDownloadConfig.enabled;
-                  // 与 handleRpcDownload 使用相同的版本化 key
-                  const rpcKey = `${link.url}@${link.updatedAt ?? ''}`;
-                  const isDownloading = downloadingRef.current[rpcKey];
-                  const isDownloaded = downloadedRef.current[rpcKey];
+                  // 与 sendRpcDownload 使用相同的版本化 key
+                  const rpcKey = computeRpcDownloadKey(link);
+                  const isDownloading = rpcDownloadStates[rpcKey] === 'sending';
+                  const isDownloaded = rpcDownloadStates[rpcKey] === 'sent';
                   const isAssetUpdated = link.assetId !== undefined
                     && release.updated_asset_ids?.includes(link.assetId) === true;
 

--- a/src/components/ReleaseCard.tsx
+++ b/src/components/ReleaseCard.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback, useState, useEffect } from 'react';
+import React, { memo, useCallback, useMemo, useState, useEffect } from 'react';
 import { ExternalLink, GitBranch, Calendar, Download, ChevronDown, ChevronUp, BookOpen, ArrowUpRight, FolderOpen, Folder, BellOff, FileArchive, Code2, Loader2, CheckCircle2, Sparkles } from 'lucide-react';
 import { Release } from '../types';
 import { formatDistanceToNow } from 'date-fns';
@@ -92,7 +92,7 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
   // AI 总结状态内聚在 hook（展开态留在卡片内，不持久化）；
   // 卡片卸载时的请求取消由 hook 的 unmount 副作用承担（卡片卸载即 hook 卸载）。
   const [isSummaryExpanded, setIsSummaryExpanded] = useState(false);
-  const summary = summaries[release.id] ?? { status: 'idle' as const };
+  const summary = useMemo(() => summaries[release.id] ?? { status: 'idle' as const }, [summaries, release.id]);
 
   // 完成或失败后自动展开（原 runSummaryAnalysis 成功/失败分支的 setIsSummaryExpanded(true)）
   useEffect(() => {

--- a/src/components/ReleaseSourceSettingsModal.tsx
+++ b/src/components/ReleaseSourceSettingsModal.tsx
@@ -6,7 +6,7 @@ import type { CustomReleaseRepository, ReleaseSourceId } from '../types';
 import { useAppStore } from '../store/useAppStore';
 import { Modal } from './Modal';
 import { useDialog } from '../hooks/useDialog';
-import { GitHubApiService } from '../services/githubApi';
+import { useReleaseTimelineActions } from '../features/releases/hooks/useReleaseTimelineActions';
 import {
   CUSTOM_RELEASE_SOURCE_ID,
   RELEASE_SOURCE_LABELS,
@@ -14,7 +14,6 @@ import {
   WATCH_CUSTOM_RELEASE_SOURCE_ID,
   createCustomReleaseRepository,
   normalizeRepoKey,
-  repositoryToCustomReleaseRepository,
 } from '../utils/releaseSources';
 
 interface ReleaseSourceSettingsModalProps {
@@ -211,41 +210,14 @@ interface WatchCustomReleaseSyncPanelProps {
 
 const WatchCustomReleaseSyncPanel: React.FC<WatchCustomReleaseSyncPanelProps> = ({ repos, language }) => {
   const githubToken = useAppStore(state => state.githubToken);
-  const setReleaseSourceRepositories = useAppStore(state => state.setReleaseSourceRepositories);
   const updateReleaseSourceRepository = useAppStore(state => state.updateReleaseSourceRepository);
-  const { toast } = useDialog();
-  const [isSyncing, setIsSyncing] = useState(false);
+  const { syncWatchedSources, isSyncingWatchedSources } = useReleaseTimelineActions();
+  const isSyncing = isSyncingWatchedSources;
 
   const t = (zh: string, en: string) => language === 'zh' ? zh : en;
 
-  const handleSync = async () => {
-    if (!githubToken || isSyncing) return;
-
-    setIsSyncing(true);
-    try {
-      const githubApi = new GitHubApiService(githubToken);
-      // 只拉 /user/subscriptions（含私有仓）。/users/{login}/subscriptions 已被 GitHub 改为
-      // 恒定返回 204 空响应体，且其结果本就是前者的公开子集，并行合并只会拖垮整个同步。
-      const watchedRepos = await githubApi.getAllWatchedRepositories();
-      const hiddenByRepo = new Map(repos.map(repo => [normalizeRepoKey(repo.full_name), repo.release_hidden]));
-      const sourceRepos = watchedRepos.map(repo => ({
-        ...repositoryToCustomReleaseRepository(repo, WATCH_CUSTOM_RELEASE_SOURCE_ID),
-        release_hidden: hiddenByRepo.get(normalizeRepoKey(repo.full_name)) || undefined,
-      }));
-      setReleaseSourceRepositories(WATCH_CUSTOM_RELEASE_SOURCE_ID, sourceRepos);
-      toast(
-        t(
-          `已同步 ${sourceRepos.length} 个 Watch 仓库。`,
-          `Synced ${sourceRepos.length} Watch repositories.`
-        ),
-        'success'
-      );
-    } catch (error) {
-      console.error('Failed to sync watched repositories:', error);
-      toast(t('同步 Watch 仓库失败，请检查网络或 Token 权限。', 'Failed to sync Watch repositories. Check network or token permissions.'), 'error');
-    } finally {
-      setIsSyncing(false);
-    }
+  const handleSync = () => {
+    void syncWatchedSources();
   };
 
   return (

--- a/src/components/RepositoryEditModal.tsx
+++ b/src/components/RepositoryEditModal.tsx
@@ -9,7 +9,7 @@ import { Modal } from './Modal';
 import { Repository } from '../types';
 import { useAppStore, getAllCategories } from '../store/useAppStore';
 import { useShallow } from 'zustand/react/shallow';
-import { forceSyncToBackend } from '../services/autoSync';
+import { useCategorySyncActions } from '../features/repositories/hooks/useCategorySyncActions';
 import { computeCustomCategory, getAICategory, getDefaultCategory } from '../utils/categoryUtils';
 import { deferOutsideDismiss } from './modalDismiss';
 
@@ -70,6 +70,7 @@ export const RepositoryEditModal: React.FC<RepositoryEditModalProps> = ({
     hiddenDefaultCategoryIds: state.hiddenDefaultCategoryIds,
     defaultCategoryOverrides: state.defaultCategoryOverrides,
   })));
+  const { forceSyncToBackend } = useCategorySyncActions();
 
   const [formData, setFormData] = useState({
     description: '',

--- a/src/components/RepositoryReleaseSheet.tsx
+++ b/src/components/RepositoryReleaseSheet.tsx
@@ -7,6 +7,7 @@ import MarkdownRenderer from './MarkdownRenderer';
 import AssetLeadingIcon from './AssetLeadingIcon';
 import { useAppStore } from '../store/useAppStore';
 import { useRepositoryReleaseSheet } from '../features/repositories/hooks/useRepositoryReleaseSheet';
+import { computeRpcDownloadKey } from '../hooks/useReleaseArtifactActions';
 import { buildReleaseDownloadLinks, type ReleaseDownloadLink } from '../utils/releaseDownloadLinks';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from './ui/accordion';
 import { Button } from './ui/button';
@@ -105,7 +106,7 @@ const ReleaseAssetsTable: React.FC<{
         </TableHeader>
         <TableBody>
           {displayedLinks.map((link) => {
-            const downloadState = downloadStates[link.url] ?? 'idle';
+            const downloadState = downloadStates[computeRpcDownloadKey(link)] ?? 'idle';
             const isSending = downloadState === 'sending';
             const isSent = downloadState === 'sent';
             return (

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -4,15 +4,10 @@ import { Search, X, SlidersHorizontal, CheckCircle, Bell, BellOff, Bot, Edit3, L
 import { getPlatformDisplayName, getPlatformIcon } from './platformMeta';
 import { useAppStore, getAllCategories } from '../store/useAppStore';
 import { useShallow } from 'zustand/react/shallow';
-import { AIService } from '../services/aiService';
-import { EmbeddingClient, VectorSearchService } from '../services/vectorSearchService';
-import { GitHubApiService } from '../services/githubApi';
-import { createGitHubListsApiService } from '../services/githubApiFactory';
-import { forceSyncToBackend } from '../services/autoSync';
 import { useSearchShortcuts } from '../hooks/useSearchShortcuts';
+import { useSearchActions } from '../features/repositories/hooks/useSearchActions';
 import { useDialog } from '../hooks/useDialog';
 import { isRepoCustomized } from '../utils/repoUtils';
-import { isReservedCategoryName } from '../utils/categoryUtils';
 import { applyRepoFilters, performBasicTextSearch as basicTextSearch, sortRepositories } from '../utils/repoSearch';
 import { NO_LICENSE_SENTINEL, normalizeLicense } from '../utils/licenseFilter';
 import { NumberInput } from './ui/NumberInput';
@@ -26,7 +21,6 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from './ui/dropdown-menu';
-import type { Repository } from '../types';
 
 type SortBy = 'stars' | 'updated' | 'name' | 'starred';
 
@@ -76,7 +70,6 @@ export const SearchBar: React.FC = () => {
     searchFilters,
     repositories,
     releaseSubscriptions,
-    aiConfigs,
     activeAIConfig,
     language,
     setSearchFilters,
@@ -84,20 +77,12 @@ export const SearchBar: React.FC = () => {
     customCategories,
     hiddenDefaultCategoryIds,
     defaultCategoryOverrides,
-    githubToken,
     lastSync,
-    setRepositories,
-    setLastSync,
     isSyncingStars,
-    setSyncingStars,
-    syncMode,
-    user,
-    addCustomCategory,
   } = useAppStore(useShallow((state) => ({
     searchFilters: state.searchFilters,
     repositories: state.repositories,
     releaseSubscriptions: state.releaseSubscriptions,
-    aiConfigs: state.aiConfigs,
     activeAIConfig: state.activeAIConfig,
     language: state.language,
     setSearchFilters: state.setSearchFilters,
@@ -105,22 +90,24 @@ export const SearchBar: React.FC = () => {
     customCategories: state.customCategories,
     hiddenDefaultCategoryIds: state.hiddenDefaultCategoryIds,
     defaultCategoryOverrides: state.defaultCategoryOverrides,
-    githubToken: state.githubToken,
     lastSync: state.lastSync,
-    setRepositories: state.setRepositories,
-    setLastSync: state.setLastSync,
     isSyncingStars: state.isSyncingStars,
-    setSyncingStars: state.setSyncingStars,
-    syncMode: state.syncMode,
-    user: state.user,
-    addCustomCategory: state.addCustomCategory,
   })));
 
-  const { toast, confirm } = useDialog();
+  const { confirm } = useDialog();
+  // 搜索动作（向量/关键词/AI 搜索、星标同步）由 hook 承担；
+  // 两 ref 实体挂 hook、以 RefObject 暴露，View 的过滤 effect 原样读写。
+  const {
+    isSearching,
+    searchPhase,
+    vectorScoreMapRef,
+    skipNextTextSearchRef,
+    aiSearch,
+    syncStars,
+  } = useSearchActions();
   
   const [showFilters, setShowFilters] = useState(false);
   const [searchQuery, setSearchQuery] = useState(searchFilters.query);
-  const [isSearching, setIsSearching] = useState(false);
   const [availableLanguages, setAvailableLanguages] = useState<string[]>([]);
   const [availableTags, setAvailableTags] = useState<string[]>([]);
   const [availablePlatforms, setAvailablePlatforms] = useState<string[]>([]);
@@ -186,9 +173,6 @@ export const SearchBar: React.FC = () => {
   const [searchSuggestions, setSearchSuggestions] = useState<string[]>([]);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
-  const skipNextTextSearchRef = useRef(false);
-  const vectorScoreMapRef = useRef<{ query: string; scores: Map<string, number> } | null>(null);
-  const [searchPhase, setSearchPhase] = useState<string | null>(null);
   const filterChipBaseClass = 'linear-filter-chip flex items-center space-x-2 px-3 py-1.5 text-sm';
   const filterChipActiveClass = 'is-active font-medium';
   const filterChipInactiveClass = '';
@@ -367,195 +351,24 @@ export const SearchBar: React.FC = () => {
     return filtered;
   };
 
+  // View-UI 部分（实时搜索开关/历史/建议下拉与搜索历史 localStorage）留在 View，
+  // 搜索编排（向量 → 关键词，含 HyDE/rerank 与降级路径）在 useSearchActions.aiSearch。
   const handleAISearch = async () => {
     if (!searchQuery.trim()) return;
-    
+
     // Switch to AI search mode and trigger advanced search
     setIsRealTimeSearch(false);
     setShowSearchHistory(false);
     setShowSuggestions(false);
-    
+
     // Add to search history if not empty and not already in history
     if (searchQuery.trim() && !searchHistory.includes(searchQuery.trim())) {
       const newHistory = [searchQuery.trim(), ...searchHistory.slice(0, 9)];
       setSearchHistory(newHistory);
       localStorage.setItem('github-stars-search-history', JSON.stringify(newHistory));
     }
-    
-    // Trigger AI search immediately
-    setIsSearching(true);
-    setSearchPhase(null);
-    vectorScoreMapRef.current = null;
-    console.log('🔍 Starting AI search for query:', searchQuery);
 
-    try {
-      let filtered = repositories;
-
-      // ====== 向量搜索分支 ======
-      const vsConfig = useAppStore.getState().vectorSearchConfig;
-      const embConfigs = useAppStore.getState().embeddingConfigs;
-      const activeEmbConfig = embConfigs.find(c => c.id === vsConfig?.embeddingConfigId);
-
-      if (vsConfig?.enabled && vsConfig?.workerUrl && activeEmbConfig) {
-        try {
-          const embeddingClient = new EmbeddingClient(activeEmbConfig);
-          const vectorService = new VectorSearchService(vsConfig);
-
-          // 1. HyDE 查询预处理：用 LLM 生成理想仓库描述再嵌入（可选，5 秒超时降级）
-          let embeddingQuery = searchQuery;
-          const hydeConfig = aiConfigs.find(config => config.id === activeAIConfig);
-          if (vsConfig.enableHyDE !== false && hydeConfig) {
-            const hydeAbort = new AbortController();
-            let hydeTimer: ReturnType<typeof setTimeout> | null = null;
-            try {
-              setSearchPhase(t('AI 分析查询...', 'AI analyzing query...'));
-              const hydeService = new AIService(hydeConfig, language);
-              embeddingQuery = await Promise.race([
-                hydeService.generateHyDEQuery(searchQuery, hydeAbort.signal).catch(() => searchQuery),
-                new Promise<string>((resolve) => {
-                  hydeTimer = setTimeout(() => {
-                    hydeAbort.abort();
-                    resolve(searchQuery);
-                  }, 5000);
-                }),
-              ]);
-              if (embeddingQuery !== searchQuery) {
-                console.log('🔮 HyDE generated:', embeddingQuery.slice(0, 100));
-              }
-            } catch (hydeError) {
-              console.warn('HyDE failed, using raw query:', hydeError);
-              embeddingQuery = searchQuery;
-            } finally {
-              if (hydeTimer) clearTimeout(hydeTimer);
-            }
-          }
-
-          // 2. 前端调用 Embedding API 生成查询向量
-          setSearchPhase(t('生成查询向量...', 'Generating query vector...'));
-          const queryVectors = await embeddingClient.embed([embeddingQuery], 'query');
-          if (queryVectors && queryVectors.length > 0) {
-            // 2. 前端将查询向量发送到 Worker
-            setSearchPhase(t('检索向量库...', 'Searching vector index...'));
-            const vectorResults = await vectorService.query(queryVectors[0], {
-              topK: vsConfig.searchTopK ?? 30,
-              threshold: vsConfig.searchThreshold ?? 0.35,
-            });
-
-            if (vectorResults.length > 0) {
-              // 3. 轻量关键词加分：精确匹配的字段给予分数微调
-              const queryLower = searchQuery.toLowerCase();
-              const boostedResults = vectorResults.map(r => {
-                let bonus = 0;
-                const name = (r.metadata?.full_name || '').toLowerCase();
-                const desc = (r.metadata?.description || '').toLowerCase();
-                const tags = (r.metadata?.tags || []).map(tag => tag.toLowerCase());
-                if (name.includes(queryLower)) bonus += 0.05;
-                if (desc.includes(queryLower)) bonus += 0.03;
-                if (tags.some(tag => tag.includes(queryLower))) bonus += 0.02;
-                return { ...r, score: r.score + bonus };
-              });
-
-              // 4. 从本地仓库数据中取出匹配结果，按相似度排序
-              const scoreMap = new Map(boostedResults.map(r => [r.id, r.score]));
-              const scoredRepos = filtered
-                .filter(repo => scoreMap.has(String(repo.id)))
-                .map(repo => ({
-                  repo,
-                  score: scoreMap.get(String(repo.id)) || 0,
-                }))
-                .sort((a, b) => b.score - a.score)
-                .map(item => item.repo);
-
-              if (scoredRepos.length > 0) {
-                // 4. AI 语义重排序：用 LLM 对向量搜索结果做真正的语义排序
-                let reranked = scoredRepos;
-                let rerankSucceeded = false;
-                const rerankConfig = aiConfigs.find(config => config.id === activeAIConfig);
-                if (rerankConfig && vsConfig.enableReranking !== false) {
-                  try {
-                    setSearchPhase(t('AI 语义重排序...', 'AI semantic reranking...'));
-                    const rerankService = new AIService(rerankConfig, language);
-                    reranked = await rerankService.searchRepositoriesWithSemanticReranking(scoredRepos, searchQuery);
-                    rerankSucceeded = true;
-                    console.log('🤖 AI semantically reranked results:', reranked.length);
-                  } catch (rerankError) {
-                    console.warn('AI semantic reranking failed, using vector order:', rerankError);
-                  }
-                }
-
-                // 保存 LLM 重排序顺序，applyFilters 可能按 UI 排序覆盖它
-                const rerankOrder = rerankSucceeded
-                  ? new Map(reranked.map((repo, index) => [String(repo.id), index]))
-                  : null;
-                const finalFiltered = applyFilters([...reranked]);
-                if (rerankOrder) {
-                  // 恢复 LLM 语义排序顺序
-                  finalFiltered.sort((a, b) =>
-                    (rerankOrder.get(String(a.id)) ?? Number.MAX_SAFE_INTEGER)
-                    - (rerankOrder.get(String(b.id)) ?? Number.MAX_SAFE_INTEGER)
-                  );
-                } else {
-                  finalFiltered.sort((a, b) => (scoreMap.get(String(b.id)) ?? 0) - (scoreMap.get(String(a.id)) ?? 0));
-                }
-                console.log('🎯 Vector search results:', finalFiltered.length);
-                vectorScoreMapRef.current = { query: searchQuery, scores: scoreMap };
-                skipNextTextSearchRef.current = true;
-                setSearchResults(finalFiltered);
-                setSearchFilters({ query: searchQuery });
-                return;
-              }
-            }
-          }
-          // 向量搜索无结果 → 继续走关键词搜索
-          console.log('⚠️ Vector search returned no results, falling back to keyword search');
-        } catch (vectorError) {
-          console.warn('❌ Vector search failed, falling back to keyword search:', vectorError);
-        }
-      }
-      // ====== 向量搜索分支结束 ======
-
-      const activeConfig = aiConfigs.find(config => config.id === activeAIConfig);
-      console.log('🤖 AI Config found:', !!activeConfig, 'Active AI Config ID:', activeAIConfig);
-      console.log('📋 Available AI Configs:', aiConfigs.length);
-      console.log('🔧 AI Configs:', aiConfigs.map(c => ({ id: c.id, name: c.name, hasApiKey: !!c.apiKey })));
-
-      if (activeConfig) {
-        try {
-          console.log('🚀 Calling AI service...');
-          setSearchPhase(t('AI 语义分析...', 'AI semantic analysis...'));
-          const aiService = new AIService(activeConfig, language);
-
-          // 先尝试AI搜索
-          const aiResults = await aiService.searchRepositoriesWithReranking(filtered, searchQuery);
-          console.log('✅ AI search completed, results:', aiResults.length);
-          
-          filtered = aiResults;
-        } catch (error) {
-          console.warn('❌ AI search failed, falling back to basic search:', error);
-          filtered = performBasicTextSearch(filtered, searchQuery);
-          console.log('🔄 Basic search fallback results:', filtered.length);
-        }
-      } else {
-        console.log('⚠️ No AI config found, using basic text search');
-        // Basic text search if no AI config
-        filtered = performBasicTextSearch(filtered, searchQuery);
-        console.log('📝 Basic search results:', filtered.length);
-      }
-      
-      // Apply other filters and update results
-      const finalFiltered = applyFilters(filtered);
-      console.log('🎯 Final filtered results:', finalFiltered.length);
-      console.log('📋 Final filtered repositories:', finalFiltered.map(r => r.name));
-      setSearchResults(finalFiltered);
-      
-      // Update search filters to mark that AI search was performed
-      setSearchFilters({ query: searchQuery });
-    } catch (error) {
-      console.error('💥 Search failed:', error);
-    } finally {
-      setIsSearching(false);
-      setSearchPhase(null);
-    }
+    await aiSearch(searchQuery, applyFilters);
   };
 
   const handleClearSearch = () => {
@@ -711,233 +524,8 @@ export const SearchBar: React.FC = () => {
 
   const t = (zh: string, en: string) => language === 'zh' ? zh : en;
 
-  const handleStarSync = async (mode: 'auto' | 'stars-only' | 'stars-and-lists' = 'auto') => {
-    if (!githubToken) {
-      toast(t('GitHub token 未找到，请重新登录。', 'GitHub token not found. Please login again.'), 'error');
-      return;
-    }
-
-    setSyncingStars(true);
-    try {
-      const githubApi = new GitHubApiService(githubToken);
-      const newRepositories = await githubApi.getAllStarredRepositories();
-
-      const storeRepos = useAppStore.getState().repositories;
-      const existingRepoMap = new Map(storeRepos.map(repo => [repo.id, repo]));
-      const mergedRepositories = newRepositories.map(newRepo => {
-        const existing = existingRepoMap.get(newRepo.id);
-        if (existing) {
-          return {
-            ...existing,
-            name: newRepo.name,
-            full_name: newRepo.full_name,
-            description: newRepo.description,
-            html_url: newRepo.html_url,
-            stargazers_count: newRepo.stargazers_count,
-            forks_count: newRepo.forks_count,
-            forks: newRepo.forks,
-            language: newRepo.language,
-            updated_at: newRepo.updated_at,
-            pushed_at: newRepo.pushed_at,
-            starred_at: newRepo.starred_at,
-            owner: newRepo.owner,
-            topics: newRepo.topics,
-            // 回填历史仓库缺失的 license 字段（GitHub 源元数据，跟随 newRepo）
-            license: newRepo.license ?? null,
-          };
-        }
-        return newRepo;
-      });
-
-      // 解析本次同步范围：
-      // - 'auto'：跟随持久化配置 syncMode
-      // - 'stars-only'：强制仅星标（忽略 syncMode，供下拉菜单显式选择）
-      // - 'stars-and-lists'：强制星标及 list（供下拉菜单显式选择）
-      const syncLists = mode === 'stars-and-lists' || (mode === 'auto' && syncMode === 'stars-and-lists');
-      let finalRepositories = mergedRepositories;
-
-      if (syncLists) {
-        const listRepoMap = new Map(finalRepositories.map(repo => [repo.full_name.toLowerCase(), repo]));
-        const appliedTagsCount: Record<string, number> = {};
-        try {
-          const listsApi = createGitHubListsApiService(githubToken);
-          const login = user?.login;
-          if (!login) {
-            throw new Error(t('无法获取 GitHub 用户名，请重新登录。', 'Failed to get GitHub username. Please login again.'));
-          }
-          const lists = await listsApi.getUserLists(login);
-
-          // 构造"list 名(小写) → 本地分类"的映射，避免每次循环重复查询。
-          // 值使用本地分类的原始名称（保留其大小写），而非 list 名：
-          // 锁定分类的筛选用精确相等比较，若直接存 GitHub 侧的大小写，
-          // 仓库会从分类结果中消失（如 list 名为 "web apps" 而分类为 "Web Apps"）。
-          const categoryByLowerName = new Map(
-            allCategories
-              .filter(c => c.id !== 'all' && !isReservedCategoryName(c.name))
-              .map(c => [c.name.toLowerCase(), c.name])
-          );
-
-          // 为云端存在、但本地无同名分类的 list 自动创建自定义分类。
-          // 修复"GitHub list 有很多新分类但本地从没拉到过"——原逻辑只贴 custom_tags
-          // 标签，不建分类，导致左侧分类树永远只有历史分类。
-          // 用每 list 递增的下标做 id 后缀，避免同一毫秒内多个 list 撞 id。
-          let createdCategoriesCount = 0;
-          lists.forEach((list, idx) => {
-            const lower = list.name.toLowerCase();
-            if (isReservedCategoryName(list.name) || categoryByLowerName.has(lower)) return;
-            const newCategory = {
-              id: `custom-sync-${Date.now()}-${idx}`,
-              name: list.name,
-              icon: ' 📋',
-              isCustom: true,
-              keywords: [],
-            };
-            addCustomCategory(newCategory);
-            // 纳入本次运行使用的映射，使后续 listMatchesCategory 命中、可设分类并加锁
-            categoryByLowerName.set(lower, list.name);
-            createdCategoriesCount++;
-          });
-
-          // DEC-4：只判定锁定状态。
-          // 区分"本次同步开始前已存在"的锁定与"本次运行中新产生"的锁定：
-          // - 预存在的锁定：不覆盖其分类与锁定，但仍追加本次命中的 list 名为
-          //   custom_tags（修复 #273：否则一旦仓库被锁过，之后云端 list 的任何
-          //   变化都被跳过，导致"无法将云端 list 拉取到本地"）。
-          // - 本次运行中被前面的 list 刚锁定：保留已分配的分类/锁定，继续追加后续 list 的标签
-          const preExistingLocked = new Set(
-            finalRepositories
-              .filter(r => r.category_locked)
-              .map(r => r.full_name.toLowerCase())
-          );
-
-          for (const list of lists) {
-            let appliedCount = 0;
-            for (const fullName of list.items) {
-              const key = fullName.toLowerCase();
-              const repo = listRepoMap.get(key);
-              if (!repo) continue;
-
-              const customTags = repo.custom_tags ? [...repo.custom_tags] : [];
-              if (!customTags.includes(list.name)) {
-                customTags.push(list.name);
-              }
-
-              // 预存在锁定：不覆盖其分类与锁定，仅追加 list 名为标签，让云端
-              // list 关系仍能反映到本地（修复 #273）。
-              if (preExistingLocked.has(key)) {
-                // 仅当标签确有变化才写回，避免无谓的 last_edited 抖动
-                if (customTags.length !== (repo.custom_tags?.length ?? 0)) {
-                  listRepoMap.set(key, { ...repo, custom_tags: customTags });
-                }
-                appliedCount++;
-                continue;
-              }
-
-              // 本次运行中刚被锁定的仓库：保留已分配的分类与锁定，仅追加标签
-              if (repo.category_locked) {
-                listRepoMap.set(key, { ...repo, custom_tags: customTags });
-                appliedCount++;
-                continue;
-              }
-
-              // 若 list 名对应某个本地分类：设置分类并加锁；否则仅加标签（多分类靠标签匹配）
-              const listMatchesCategory = categoryByLowerName.has(list.name.toLowerCase());
-              const updatedRepo: Repository = listMatchesCategory
-                ? {
-                    ...repo,
-                    custom_tags: customTags,
-                    custom_category: categoryByLowerName.get(list.name.toLowerCase()),
-                    category_locked: true,
-                    last_edited: new Date().toISOString(),
-                  }
-                : {
-                    ...repo,
-                    custom_tags: customTags,
-                  };
-
-              listRepoMap.set(key, updatedRepo);
-              appliedCount++;
-            }
-            if (appliedCount > 0) {
-              appliedTagsCount[list.name] = appliedCount;
-            }
-          }
-
-          finalRepositories = finalRepositories.map(repo =>
-            listRepoMap.get(repo.full_name.toLowerCase()) || repo
-          );
-
-          if (Object.keys(appliedTagsCount).length > 0) {
-            const appliedTotal = Object.values(appliedTagsCount).reduce((a, b) => a + b, 0);
-            const listSummary = Object.entries(appliedTagsCount)
-              .map(([name, count]) => `${name}(${count})`)
-              .join('、');
-            const createdHint = createdCategoriesCount > 0
-              ? t(
-                  `（新建 ${createdCategoriesCount} 个分类）`,
-                  ` (${createdCategoriesCount} new categor${createdCategoriesCount > 1 ? 'ies' : 'y'} created)`
-                )
-              : '';
-            toast(t(
-              `已同步 ${lists.length} 个 list，并应用到 ${appliedTotal} 个未锁定仓库：${listSummary}${createdHint}`,
-              `Synced ${lists.length} lists, applied to ${appliedTotal} unlocked repositories: ${listSummary}${createdHint}`
-            ), 'info');
-          } else if (createdCategoriesCount > 0) {
-            // 命中数为 0，但本次新建了分类（云端 list 与本地无交集但仍有其名分类）
-            toast(t(
-              `已同步 ${lists.length} 个 list（新建 ${createdCategoriesCount} 个分类）。`,
-              `Synced ${lists.length} lists (${createdCategoriesCount} new categor${createdCategoriesCount > 1 ? 'ies' : 'y'} created).`
-            ), 'info');
-          }
-        } catch (listError) {
-          console.error('List sync failed:', listError);
-          toast(t(
-            'List 同步失败，星标仓库已同步。请稍后重试，或检查 GitHub Token 权限（需 user scope）。',
-            'List sync failed, starred repositories were synced. Retry later, or check the GitHub Token has the user scope.'
-          ), 'error');
-          // 不中断：星标同步结果仍然生效
-        }
-      }
-
-      const existingRepoIds = new Set(storeRepos.map(repo => repo.id));
-      const newRepoCount = newRepositories.filter(repo => !existingRepoIds.has(repo.id)).length;
-
-      setRepositories(finalRepositories);
-      await forceSyncToBackend();
-      
-      setLastSync(new Date().toISOString());
-
-      if (newRepoCount > 0) {
-        toast(t(`同步完成！发现 ${newRepoCount} 个新仓库。`, `Sync completed! Found ${newRepoCount} new repositories.`), 'success');
-      } else {
-        toast(t('同步完成！所有仓库都是最新的。', 'Sync completed! All repositories are up to date.'), 'info');
-      }
-
-    } catch (error) {
-      console.error('Sync failed:', error);
-      if (error instanceof Error && error.message.includes('token')) {
-        toast(t('GitHub token 已过期或无效，请重新登录。', 'GitHub token has expired or is invalid. Please login again.'), 'error');
-      } else {
-        toast(t('同步失败，请检查网络连接或稍后重试。', 'Sync failed. Please check your network connection or try again later.'), 'error');
-      }
-    } finally {
-      setSyncingStars(false);
-    }
-  };
-
-  const formatLastSync = (timestamp: string | null) => {
-    if (!timestamp) return t('从未同步', 'Never');
-    const date = new Date(timestamp);
-    if (Number.isNaN(date.getTime())) return t('从未同步', 'Never');
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-    if (diffHours < 1) return t('刚刚', 'Just now');
-    if (diffHours < 24) return t(`${diffHours}小时前`, `${diffHours}h ago`);
-    return date.toLocaleDateString(language === 'zh' ? 'zh-CN' : 'en-US');
-  };
-
-  // 同步星标仓库及 list：先确认（警告会覆盖未锁定仓库的分类并加锁），再执行
+  // 同步星标仓库及 list：先确认（警告会覆盖未锁定仓库的分类并加锁），再执行。
+  // 'auto'/'stars-only' 入口原无确认，勿加（B8）。
   const handleStarAndListSync = async () => {
     const confirmed = await confirm(
       t('同步星标仓库及 list', 'Sync starred repos & lists'),
@@ -954,7 +542,19 @@ export const SearchBar: React.FC = () => {
       { type: 'warning' }
     );
     if (!confirmed) return;
-    await handleStarSync('stars-and-lists');
+    await syncStars('stars-and-lists');
+  };
+
+  const formatLastSync = (timestamp: string | null) => {
+    if (!timestamp) return t('从未同步', 'Never');
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) return t('从未同步', 'Never');
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+    if (diffHours < 1) return t('刚刚', 'Just now');
+    if (diffHours < 24) return t(`${diffHours}小时前`, `${diffHours}h ago`);
+    return date.toLocaleDateString(language === 'zh' ? 'zh-CN' : 'en-US');
   };
 
   // 全局快捷键支持（Ctrl/Cmd+K、Ctrl/Cmd+Shift+F、/、Escape）
@@ -1206,7 +806,7 @@ export const SearchBar: React.FC = () => {
                 <div className="ui-button-primary inline-flex items-stretch overflow-hidden">
                   <Button
                     type="button"
-                    onClick={() => { void handleStarSync(); }}
+                    onClick={() => { void syncStars(); }}
                     disabled={isSyncingStars}
                     className="inline-flex items-center gap-1.5 rounded-none border-0 bg-transparent px-3 py-2 text-inherit shadow-none hover:bg-primary/90 disabled:opacity-50"
                     title={t('同步星标仓库列表', 'Sync starred repositories')}
@@ -1230,7 +830,7 @@ export const SearchBar: React.FC = () => {
               <DropdownMenuContent align="end" className="w-64">
                 <DropdownMenuItem
                   disabled={isSyncingStars}
-                  onSelect={() => { void handleStarSync('stars-only'); }}
+                  onSelect={() => { void syncStars('stars-only'); }}
                   className="justify-start text-sm"
                 >
                   <span className="whitespace-nowrap">{t('只同步星标仓库', 'Sync starred repos only')}</span>

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -21,7 +21,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { Button } from './ui/button';
 import { Dialog, DialogContent, DialogTitle } from './ui/dialog';
 import { isElectron } from '../services/electronProxy';
-import { backend } from '../services/backendAdapter';
+import { useBackendAvailability } from '../features/settings/hooks/useBackendAvailability';
 import {
   GeneralPanel,
   AIConfigPanel,
@@ -218,6 +218,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
   const tabResetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const t = (zh: string, en: string) => (language === 'zh' ? zh : en);
+  const backendAvailable = useBackendAvailability();
 
   const handleClose = () => {
     if (onClose) {
@@ -366,7 +367,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
       label: t('诊断日志', 'Diagnostic Logs'),
       icon: <ScrollText className="w-5 h-5" />,
     },
-    ...((isElectron() || backend.isAvailable) ? [{
+    ...((isElectron() || backendAvailable) ? [{
       id: 'network' as SettingsTab,
       label: t('网络设置', 'Network'),
       icon: <Wifi className="w-5 h-5" />,
@@ -377,7 +378,7 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({
       icon: <Search className="w-5 h-5" />,
     },
     // MCP requires a long-lived process: backend or Electron main. Hide for pure SPA.
-    ...((isElectron() || backend.isAvailable) ? [{
+    ...((isElectron() || backendAvailable) ? [{
       id: 'mcp' as SettingsTab,
       label: t('MCP服务', 'MCP Server'),
       icon: <Cable className="w-5 h-5" />,

--- a/src/components/SubscriptionRepoCard.tsx
+++ b/src/components/SubscriptionRepoCard.tsx
@@ -67,6 +67,7 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
   // 处理添加/取消Star：已 Star 时打开自定义确认 Modal，否则执行添加
   const handleStar = (e: React.MouseEvent) => {
     e.stopPropagation();
+    if (!githubToken || isStarring) return;
     if (isStarred) {
       setUnstarConfirmOpen(true);
       return;

--- a/src/components/SubscriptionRepoCard.tsx
+++ b/src/components/SubscriptionRepoCard.tsx
@@ -1,16 +1,13 @@
-import React, { useState, useMemo, useCallback, useRef, useEffect } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import { Star, StarOff, ExternalLink, Bot, GitFork, Sparkles, BookOpen, AlertTriangle } from 'lucide-react';
 import { getPlatformIcon as getSharedPlatformIcon } from './platformMeta';
 import type { DiscoveryRepo } from '../types';
-import { useAppStore, getAllCategories } from '../store/useAppStore';
-import { analyzeRepository, createFailedAnalysisResult } from '../services/aiAnalysisHelper';
-import { forceSyncToBackend } from '../services/autoSync';
-import { GitHubApiService } from '../services/githubApi';
+import { useAppStore } from '../store/useAppStore';
+import { useDiscoveryRepoActions } from '../features/discovery/hooks/useDiscoveryRepoActions';
 import { ReadmeModal } from './ReadmeModal';
 import { Modal } from './Modal';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
-import { useDialog } from '../hooks/useDialog';
 import { Button } from './ui/button';
 
 interface SubscriptionRepoCardProps {
@@ -23,41 +20,15 @@ interface SubscriptionRepoCardProps {
 export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo, onStar, onAnalyze, desktopSafeMode = false }) => {
   const language = useAppStore(state => state.language);
   const githubToken = useAppStore(state => state.githubToken);
-  const aiConfigs = useAppStore(state => state.aiConfigs);
-  const activeAIConfig = useAppStore(state => state.activeAIConfig);
-  const customCategories = useAppStore(state => state.customCategories);
-  const updateDiscoveryRepo = useAppStore(state => state.updateDiscoveryRepo);
-  const repositories = useAppStore(state => state.repositories);
-  const addRepository = useAppStore(state => state.addRepository);
-  const deleteRepository = useAppStore(state => state.deleteRepository);
-
-  const { toast } = useDialog();
 
   const t = useCallback((zh: string, en: string) => language === 'zh' ? zh : en, [language]);
 
-  const [isStarring, setIsStarring] = useState(false);
-  const [isAnalyzing, setIsAnalyzing] = useState(false);
-  const [readmeModalOpen, setReadmeModalOpen] = useState(false);
-  // 本地乐观状态，用于立即反映Star操作结果
-  const [optimisticStarred, setOptimisticStarred] = useState<boolean | null>(null);
-  // 取消Star确认对话框状态
-  const [unstarConfirmOpen, setUnstarConfirmOpen] = useState(false);
-  const [pendingUnstarAction, setPendingUnstarAction] = useState<(() => void) | null>(null);
-  const abortControllerRef = useRef<AbortController | null>(null);
+  const { analyze, star, executeUnstar, isAnalyzing, isStarring, isStarred } =
+    useDiscoveryRepoActions({ repo });
 
-  useEffect(() => {
-    return () => {
-      abortControllerRef.current?.abort();
-    };
-  }, []);
-  
-  // 检查仓库是否已在本地存在（已被Star）
-  const isStarredComputed = useMemo(() => {
-    return repositories.some(r => r.full_name === repo.full_name);
-  }, [repositories, repo.full_name]);
-  
-  // 优先使用乐观状态，否则使用计算状态
-  const isStarred = optimisticStarred !== null ? optimisticStarred : isStarredComputed;
+  const [readmeModalOpen, setReadmeModalOpen] = useState(false);
+  // 取消Star确认对话框状态（确认 UI 留 View；动作本体在 useDiscoveryRepoActions）
+  const [unstarConfirmOpen, setUnstarConfirmOpen] = useState(false);
 
   const formatNumber = (num: number) => {
     if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`;
@@ -87,100 +58,21 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
     return <Icon className="w-3 h-3" />;
   };
 
-  // 执行取消Star操作
-  const executeUnstar = useCallback(async () => {
-    if (!githubToken) return;
-    
-    setIsStarring(true);
-    
-    try {
-      const githubApi = new GitHubApiService(githubToken);
-      const [owner, name] = repo.full_name.split('/');
-      
-      // 乐观更新：立即更新UI状态
-      setOptimisticStarred(false);
-      
-      await githubApi.unstarRepository(owner, name);
-      
-      // 从本地删除
-      const existingRepo = repositories.find(r => r.full_name === repo.full_name);
-      if (existingRepo) {
-        deleteRepository(existingRepo.id);
-      }
-      
-      await forceSyncToBackend();
-      
-      // 操作成功，清除乐观状态
-      setOptimisticStarred(null);
-    } catch (error) {
-      // 操作失败，回滚乐观状态
-      setOptimisticStarred(null);
-      console.error('Failed to unstar repository:', error);
-      const errorMessage = t('取消 Star 失败，请检查网络连接或 GitHub Token 权限。', 'Failed to unstar repository. Please check your network connection or GitHub Token permissions.');
-      toast(errorMessage, 'error');
-    } finally {
-      setIsStarring(false);
-      setPendingUnstarAction(null);
-    }
-  }, [githubToken, repo, repositories, deleteRepository, t, toast]);
+  // 执行取消Star操作：确认 UI（自定义 Modal）留 View，动作本体在 hook。
+  const confirmUnstar = () => {
+    setUnstarConfirmOpen(false);
+    void executeUnstar();
+  };
 
-  // 处理添加/取消Star
-  const handleStar = useCallback(async (e: React.MouseEvent) => {
+  // 处理添加/取消Star：已 Star 时打开自定义确认 Modal，否则执行添加
+  const handleStar = (e: React.MouseEvent) => {
     e.stopPropagation();
-    if (!githubToken || isStarring) return;
-
     if (isStarred) {
-      // 取消Star - 显示自定义确认对话框
-      setPendingUnstarAction(() => executeUnstar);
       setUnstarConfirmOpen(true);
       return;
     }
-    
-    // 添加Star
-    setIsStarring(true);
-    
-    try {
-      const githubApi = new GitHubApiService(githubToken);
-      const [owner, name] = repo.full_name.split('/');
-      
-      // 乐观更新：立即更新UI状态
-      setOptimisticStarred(true);
-      
-      await githubApi.starRepository(owner, name);
-      
-      // 将DiscoveryRepo转换为Repository并添加到本地，保留AI分析结果
-      const repositoryToAdd = {
-        ...repo,
-        // 移除Discovery/Subscription特有的字段
-        rank: undefined,
-        channel: undefined,
-        platform: undefined,
-        // 添加Star时间
-        starred_at: new Date().toISOString(),
-      };
-      
-      addRepository(repositoryToAdd);
-      
-      if (onStar) {
-        onStar(repo);
-      }
-      
-      await forceSyncToBackend();
-      
-      // 操作成功，清除乐观状态
-      setOptimisticStarred(null);
-
-      toast(t('已成功添加 Star', 'Successfully starred'), 'success');
-    } catch (error) {
-      // 操作失败，回滚乐观状态
-      setOptimisticStarred(null);
-      console.error('Failed to star repository:', error);
-      const errorMessage = t('Star 操作失败，请检查网络连接或 GitHub Token 权限。', 'Failed to star repository. Please check your network connection or GitHub Token permissions.');
-      toast(errorMessage, 'error');
-    } finally {
-      setIsStarring(false);
-    }
-  }, [githubToken, isStarring, repo, onStar, t, toast, isStarred, addRepository, executeUnstar]);
+    void star(onStar);
+  };
 
   // 处理在ZRead打开
   const handleOpenInZRead = useCallback((e: React.MouseEvent) => {
@@ -189,89 +81,11 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
     window.open(zreadUrl, '_blank');
   }, [repo.full_name]);
 
-  // 处理单个项目AI分析
-  const handleAnalyze = useCallback(async (e: React.MouseEvent) => {
+  // 处理单个项目AI分析（校验/中止/patch/toast 均在 hook）
+  const handleAnalyze = (e: React.MouseEvent) => {
     e.stopPropagation();
-
-    if (!githubToken) {
-      toast(t('GitHub Token 未找到，请重新登录。', 'GitHub token not found. Please login again.'), 'error');
-      return;
-    }
-
-    const activeConfig = aiConfigs.find(c => c.id === activeAIConfig);
-    if (!activeConfig) {
-      toast(t('请先在设置中配置AI服务。', 'Please configure AI service in settings first.'), 'error');
-      return;
-    }
-
-    if (activeConfig.apiKeyStatus === 'decrypt_failed' || activeConfig.apiKeyStatus === 'empty') {
-      toast(t('AI服务的API密钥无法解密或为空，请在设置中重新输入并保存该配置。', 'The AI service API key could not be decrypted or is empty. Please re-enter and save the configuration in settings.'), 'error');
-      return;
-    }
-
-    if (!activeConfig.baseUrl || !activeConfig.apiKey || !activeConfig.model) {
-      toast(t('AI服务配置不完整，请检查API端点、密钥和模型名称。', 'AI service configuration is incomplete. Please check the API endpoint, key, and model name.'), 'error');
-      return;
-    }
-
-    if (isAnalyzing) return;
-
-    abortControllerRef.current?.abort();
-    const controller = new AbortController();
-    abortControllerRef.current = controller;
-
-    setIsAnalyzing(true);
-
-    try {
-      const allCategories = getAllCategories(customCategories, language);
-
-      const result = await analyzeRepository({
-        repository: repo,
-        githubToken,
-        aiConfig: activeConfig,
-        language,
-        categories: allCategories,
-        signal: controller.signal,
-      });
-
-      if (controller.signal.aborted) return;
-
-      const updatedRepo: DiscoveryRepo = {
-        ...repo,
-        ai_summary: result.summary,
-        ai_tags: result.tags,
-        ai_platforms: result.platforms,
-        analyzed_at: result.analyzed_at,
-        analysis_failed: result.analysis_failed,
-        analysis_error: undefined,
-      };
-      updateDiscoveryRepo(updatedRepo);
-      
-      if (onAnalyze) {
-        onAnalyze(updatedRepo);
-      }
-    } catch (error) {
-      if (!controller.signal.aborted) {
-        console.error('AI analysis error:', error);
-        const errorMsg = error instanceof Error && error.message
-          ? error.message
-          : t('AI分析失败，请检查AI配置和网络连接', 'AI analysis failed, please check AI configuration and network connection');
-        const failedResult = createFailedAnalysisResult(errorMsg);
-        const failedRepo: DiscoveryRepo = {
-          ...repo,
-          analyzed_at: failedResult.analyzed_at,
-          analysis_failed: failedResult.analysis_failed,
-          analysis_error: failedResult.analysis_error,
-        };
-        updateDiscoveryRepo(failedRepo);
-        toast(t('AI分析失败，请检查AI配置。', 'AI analysis failed. Please check your AI configuration.'), 'error');
-      }
-    } finally {
-      if (!controller.signal.aborted) {
-        setIsAnalyzing(false);
-      }
-    }
-  }, [githubToken, aiConfigs, activeAIConfig, language, repo, isAnalyzing, customCategories, updateDiscoveryRepo, onAnalyze, t, toast]);
+    void analyze(onAnalyze);
+  };
 
   // 判断是否已分析
   const isAnalyzed = !!repo.analyzed_at && !repo.analysis_failed;
@@ -501,7 +315,6 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
       isOpen={unstarConfirmOpen}
       onClose={() => {
         setUnstarConfirmOpen(false);
-        setPendingUnstarAction(null);
       }}
       title={t('确认取消 Star', 'Confirm Unstar')}
       maxWidth="max-w-sm"
@@ -519,7 +332,6 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
           <Button
             onClick={() => {
               setUnstarConfirmOpen(false);
-              setPendingUnstarAction(null);
             }}
             variant="ghost"
             className="px-4 py-2 rounded-lg text-sm font-medium text-muted-foreground dark:text-muted-foreground hover:bg-muted dark:hover:bg-accent transition-colors"
@@ -529,12 +341,7 @@ export const SubscriptionRepoCard: React.FC<SubscriptionRepoCardProps> = ({ repo
           <Button
             type="button"
             variant="destructive"
-            onClick={() => {
-              setUnstarConfirmOpen(false);
-              if (pendingUnstarAction) {
-                pendingUnstarAction();
-              }
-            }}
+            onClick={confirmUnstar}
             className="rounded-lg px-4 py-2 text-sm font-medium"
           >
             {t('确认取消', 'Confirm Unstar')}

--- a/src/features/discovery/hooks/useDiscoveryRepoActions.test.tsx
+++ b/src/features/discovery/hooks/useDiscoveryRepoActions.test.tsx
@@ -236,8 +236,8 @@ describe('useDiscoveryRepoActions.star', () => {
     mocks.starRepository.mockImplementation(() => new Promise((_resolve, reject) => {
       rejectStar = reject;
     }));
-    const { result } = renderHook(() => useDiscoveryRepoActions({ repo }));
     storeState.repositories = [{ id: 1, full_name: 'other/repo' }];
+    const { result } = renderHook(() => useDiscoveryRepoActions({ repo }));
 
     let pending!: Promise<void>;
     act(() => {

--- a/src/features/discovery/hooks/useDiscoveryRepoActions.test.tsx
+++ b/src/features/discovery/hooks/useDiscoveryRepoActions.test.tsx
@@ -259,6 +259,15 @@ describe('useDiscoveryRepoActions.star', () => {
     const { result } = renderHook(() => useDiscoveryRepoActions({ repo }));
     expect(result.current.isStarred).toBe(false);
     await act(async () => { await result.current.star(); });
+    expect(storeState.addRepository).toHaveBeenCalledTimes(1);
+    expect(storeState.addRepository.mock.calls[0][0]).toMatchObject({
+      id: repo.id,
+      full_name: repo.full_name,
+      rank: undefined,
+      channel: undefined,
+      platform: undefined,
+      starred_at: expect.any(String),
+    });
     expect(result.current.isStarred).toBe(false); // repositories fixture 不含该仓库，乐观态已清
     expect(result.current.isStarring).toBe(false);
   });

--- a/src/features/discovery/hooks/useDiscoveryRepoActions.test.tsx
+++ b/src/features/discovery/hooks/useDiscoveryRepoActions.test.tsx
@@ -1,0 +1,318 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DiscoveryRepo } from '../../../types';
+import { discoveryRepoToRepository, useDiscoveryRepoActions } from './useDiscoveryRepoActions';
+
+const mocks = vi.hoisted(() => ({
+  useAppStore: vi.fn(),
+  getAllCategories: vi.fn(() => []),
+  toast: vi.fn(),
+  analyzeRepository: vi.fn(),
+  createFailedAnalysisResult: vi.fn((error: string) => ({
+    analyzed_at: '2026-08-25T00:00:00.000Z',
+    analysis_failed: true,
+    analysis_error: error,
+  })),
+  forceSyncToBackend: vi.fn(),
+  starRepository: vi.fn(),
+  unstarRepository: vi.fn(),
+}));
+
+vi.mock('../../../store/useAppStore', () => ({
+  useAppStore: mocks.useAppStore,
+  getAllCategories: mocks.getAllCategories,
+}));
+
+vi.mock('../../../hooks/useDialog', () => ({
+  useDialog: () => ({ toast: mocks.toast, confirm: vi.fn() }),
+}));
+
+vi.mock('../../../services/aiAnalysisHelper', () => ({
+  analyzeRepository: mocks.analyzeRepository,
+  createFailedAnalysisResult: mocks.createFailedAnalysisResult,
+}));
+
+vi.mock('../../../services/autoSync', () => ({
+  forceSyncToBackend: mocks.forceSyncToBackend,
+}));
+
+vi.mock('../../../services/githubApi', () => ({
+  GitHubApiService: class {
+    starRepository = mocks.starRepository;
+    unstarRepository = mocks.unstarRepository;
+  },
+}));
+
+const repo: DiscoveryRepo = {
+  id: 7,
+  name: 'discovered-repo',
+  full_name: 'owner/discovered-repo',
+  description: 'A discovered repository',
+  html_url: 'https://github.com/owner/discovered-repo',
+  stargazers_count: 512,
+  forks_count: 12,
+  forks: 12,
+  language: 'TypeScript',
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-02T00:00:00.000Z',
+  pushed_at: '2026-01-03T00:00:00.000Z',
+  owner: { login: 'owner', avatar_url: 'https://example.com/avatar.png' },
+  topics: ['test'],
+  rank: 3,
+  channel: 'trending',
+  platform: 'Macos',
+};
+
+const createStoreState = () => ({
+  githubToken: 'github-token' as string | null,
+  aiConfigs: [{
+    id: 'ai-config',
+    name: 'Test AI',
+    baseUrl: 'https://example.com/v1',
+    apiKey: 'ai-key',
+    model: 'ai-model',
+  }] as Array<{ id: string; name: string; baseUrl?: string; apiKey?: string; model?: string; apiKeyStatus?: 'ok' | 'decrypt_failed' | 'empty' }>,
+  activeAIConfig: 'ai-config',
+  language: 'zh' as const,
+  customCategories: [],
+  repositories: [] as { id: number; full_name: string }[],
+  updateDiscoveryRepo: vi.fn(),
+  addRepository: vi.fn(),
+  deleteRepository: vi.fn(),
+});
+
+let storeState = createStoreState();
+const mockUseAppStore = vi.mocked(mocks.useAppStore);
+mockUseAppStore.mockImplementation((selector?: (state: typeof storeState) => unknown) =>
+  selector ? selector(storeState) : storeState);
+(mockUseAppStore as unknown as { getState: () => typeof storeState }).getState = () => storeState;
+
+describe('useDiscoveryRepoActions.analyze', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeState = createStoreState();
+  });
+
+  it('runs the four validations in order with the card-specific wording', async () => {
+    storeState.githubToken = null;
+    const { result, rerender } = renderHook(() => useDiscoveryRepoActions({ repo }));
+    await act(async () => { await result.current.analyze(); });
+    expect(mocks.toast).toHaveBeenNthCalledWith(1, 'GitHub Token 未找到，请重新登录。', 'error');
+
+    storeState.githubToken = 'github-token';
+    storeState.aiConfigs = [];
+    rerender();
+    await act(async () => { await result.current.analyze(); });
+    expect(mocks.toast).toHaveBeenNthCalledWith(2, '请先在设置中配置AI服务。', 'error');
+
+    storeState.aiConfigs = [{
+      id: 'ai-config',
+      name: 'Broken',
+      baseUrl: 'https://example.com/v1',
+      apiKey: 'ai-key',
+      model: 'ai-model',
+      apiKeyStatus: 'decrypt_failed',
+    }];
+    rerender();
+    await act(async () => { await result.current.analyze(); });
+    expect(mocks.toast).toHaveBeenNthCalledWith(3, 'AI服务的API密钥无法解密或为空，请在设置中重新输入并保存该配置。', 'error');
+
+    storeState.aiConfigs = [{ id: 'ai-config', name: 'Incomplete', baseUrl: '', apiKey: '', model: '' }];
+    rerender();
+    await act(async () => { await result.current.analyze(); });
+    expect(mocks.toast).toHaveBeenNthCalledWith(4, 'AI服务配置不完整，请检查API端点、密钥和模型名称。', 'error');
+    expect(mocks.analyzeRepository).not.toHaveBeenCalled();
+    expect(mocks.forceSyncToBackend).not.toHaveBeenCalled();
+  });
+
+  it('patches success fields without custom_category and without force sync; forwards onAnalyzed', async () => {
+    mocks.analyzeRepository.mockResolvedValue({
+      summary: 'AI summary',
+      tags: ['tag'],
+      platforms: ['cli'],
+      analyzed_at: '2026-09-05T00:00:00.000Z',
+      analysis_failed: false,
+    });
+    const onAnalyzed = vi.fn();
+    const { result } = renderHook(() => useDiscoveryRepoActions({ repo }));
+    await act(async () => { await result.current.analyze(onAnalyzed); });
+
+    expect(storeState.updateDiscoveryRepo).toHaveBeenCalledTimes(1);
+    const patch = storeState.updateDiscoveryRepo.mock.calls[0][0] as DiscoveryRepo;
+    expect(patch).toEqual({
+      ...repo,
+      ai_summary: 'AI summary',
+      ai_tags: ['tag'],
+      ai_platforms: ['cli'],
+      analyzed_at: '2026-09-05T00:00:00.000Z',
+      analysis_failed: false,
+      analysis_error: undefined,
+    });
+    expect('custom_category' in patch).toBe(false);
+    expect('category_locked' in patch).toBe(false);
+    expect(onAnalyzed).toHaveBeenCalledWith(patch);
+    expect(mocks.toast).not.toHaveBeenCalled();
+    expect(mocks.forceSyncToBackend).not.toHaveBeenCalled();
+  });
+
+  it('stores the failure result and toasts on analysis error', async () => {
+    mocks.analyzeRepository.mockRejectedValue(new Error('network down'));
+    const { result } = renderHook(() => useDiscoveryRepoActions({ repo }));
+    await act(async () => { await result.current.analyze(); });
+
+    expect(mocks.createFailedAnalysisResult).toHaveBeenCalledWith('network down');
+    expect(storeState.updateDiscoveryRepo).toHaveBeenCalledWith({
+      ...repo,
+      analyzed_at: '2026-08-25T00:00:00.000Z',
+      analysis_failed: true,
+      analysis_error: 'network down',
+    });
+    expect(mocks.toast).toHaveBeenCalledWith('AI分析失败，请检查AI配置。', 'error');
+  });
+
+  it('stays silent after unmount aborts an in-flight analysis', async () => {
+    let rejectAnalysis!: (error: Error) => void;
+    mocks.analyzeRepository.mockImplementation(({ signal }: { signal: AbortSignal }) =>
+      new Promise((_resolve, reject) => {
+        rejectAnalysis = (error: Error) => {
+          if (signal.aborted) {
+            reject(error);
+          }
+        };
+      }),
+    );
+    const { result, unmount } = renderHook(() => useDiscoveryRepoActions({ repo }));
+    let pending!: Promise<void>;
+    act(() => {
+      pending = result.current.analyze();
+    });
+    unmount();
+    rejectAnalysis(new Error('Aborted'));
+    await act(async () => { await pending.catch(() => undefined); });
+
+    expect(storeState.updateDiscoveryRepo).not.toHaveBeenCalled();
+    expect(mocks.toast).not.toHaveBeenCalled();
+  });
+});
+
+describe('useDiscoveryRepoActions.star', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeState = createStoreState();
+  });
+
+  it('keeps the optimistic → remote → addRepository → onStar → forceSync → clear → toast order', async () => {
+    mocks.starRepository.mockResolvedValue(undefined);
+    const onStar = vi.fn();
+    const { result } = renderHook(() => useDiscoveryRepoActions({ repo }));
+    await act(async () => { await result.current.star(onStar); });
+
+    expect(mocks.starRepository).toHaveBeenCalledWith('owner', 'discovered-repo');
+    expect(storeState.addRepository).toHaveBeenCalledTimes(1);
+    const added = storeState.addRepository.mock.calls[0][0];
+    expect(added).toEqual({
+      ...repo,
+      rank: undefined,
+      channel: undefined,
+      platform: undefined,
+      starred_at: expect.any(String),
+    });
+    expect(onStar).toHaveBeenCalledWith(repo);
+
+    const starRepoOrder = mocks.starRepository.mock.invocationCallOrder[0];
+    const addOrder = storeState.addRepository.mock.invocationCallOrder[0];
+    const onStarOrder = onStar.mock.invocationCallOrder[0];
+    const syncOrder = mocks.forceSyncToBackend.mock.invocationCallOrder[0];
+    expect(starRepoOrder).toBeLessThan(addOrder);
+    expect(addOrder).toBeLessThan(onStarOrder);
+    expect(onStarOrder).toBeLessThan(syncOrder);
+
+    expect(result.current.optimisticStarred).toBeNull();
+    expect(mocks.toast).toHaveBeenCalledWith('已成功添加 Star', 'success');
+  });
+
+  it('rolls back the optimistic state and toasts when starring fails', async () => {
+    let rejectStar!: (error: Error) => void;
+    mocks.starRepository.mockImplementation(() => new Promise((_resolve, reject) => {
+      rejectStar = reject;
+    }));
+    const { result } = renderHook(() => useDiscoveryRepoActions({ repo }));
+    storeState.repositories = [{ id: 1, full_name: 'other/repo' }];
+
+    let pending!: Promise<void>;
+    act(() => {
+      pending = result.current.star();
+    });
+    await waitFor(() => expect(result.current.optimisticStarred).toBe(true));
+
+    rejectStar(new Error('network'));
+    await act(async () => { await pending; });
+
+    expect(result.current.optimisticStarred).toBeNull();
+    expect(storeState.addRepository).not.toHaveBeenCalled();
+    expect(mocks.forceSyncToBackend).not.toHaveBeenCalled();
+    expect(mocks.toast).toHaveBeenCalledWith('Star 操作失败，请检查网络连接或 GitHub Token 权限。', 'error');
+  });
+
+  it('adds the repository for a repo that is not yet starred', async () => {
+    mocks.starRepository.mockResolvedValue(undefined);
+    const { result } = renderHook(() => useDiscoveryRepoActions({ repo }));
+    expect(result.current.isStarred).toBe(false);
+    await act(async () => { await result.current.star(); });
+    expect(result.current.isStarred).toBe(false); // repositories fixture 不含该仓库，乐观态已清
+    expect(result.current.isStarring).toBe(false);
+  });
+});
+
+describe('useDiscoveryRepoActions.executeUnstar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeState = createStoreState();
+  });
+
+  it('deletes the local repository by full_name, forces sync, and never toasts on success', async () => {
+    mocks.unstarRepository.mockResolvedValue(undefined);
+    storeState.repositories = [{ id: 42, full_name: repo.full_name }];
+    const { result, rerender } = renderHook(() => useDiscoveryRepoActions({ repo }));
+    rerender();
+    expect(result.current.isStarred).toBe(true);
+
+    await act(async () => { await result.current.executeUnstar(); });
+
+    expect(mocks.unstarRepository).toHaveBeenCalledWith('owner', 'discovered-repo');
+    expect(storeState.deleteRepository).toHaveBeenCalledWith(42);
+    const unstarOrder = mocks.unstarRepository.mock.invocationCallOrder[0];
+    const deleteOrder = storeState.deleteRepository.mock.invocationCallOrder[0];
+    const syncOrder = mocks.forceSyncToBackend.mock.invocationCallOrder[0];
+    expect(unstarOrder).toBeLessThan(deleteOrder);
+    expect(deleteOrder).toBeLessThan(syncOrder);
+    expect(result.current.optimisticStarred).toBeNull();
+    expect(mocks.toast).not.toHaveBeenCalled();
+  });
+
+  it('rolls back the optimistic state and toasts on failure', async () => {
+    mocks.unstarRepository.mockRejectedValue(new Error('boom'));
+    storeState.repositories = [{ id: 42, full_name: repo.full_name }];
+    const { result } = renderHook(() => useDiscoveryRepoActions({ repo }));
+
+    await act(async () => { await result.current.executeUnstar(); });
+
+    expect(result.current.optimisticStarred).toBeNull();
+    expect(storeState.deleteRepository).not.toHaveBeenCalled();
+    expect(mocks.forceSyncToBackend).not.toHaveBeenCalled();
+    expect(mocks.toast).toHaveBeenCalledWith('取消 Star 失败，请检查网络连接或 GitHub Token 权限。', 'error');
+  });
+});
+
+describe('discoveryRepoToRepository', () => {
+  it('nulls discovery-only fields and stamps starred_at', () => {
+    const converted = discoveryRepoToRepository(repo, '2026-09-05T00:00:00.000Z');
+    expect(converted).toEqual({
+      ...repo,
+      rank: undefined,
+      channel: undefined,
+      platform: undefined,
+      starred_at: '2026-09-05T00:00:00.000Z',
+    });
+  });
+});

--- a/src/features/discovery/hooks/useDiscoveryRepoActions.ts
+++ b/src/features/discovery/hooks/useDiscoveryRepoActions.ts
@@ -1,0 +1,246 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import type { DiscoveryRepo, Repository } from '../../../types';
+import { useAppStore, getAllCategories } from '../../../store/useAppStore';
+import { analyzeRepository, createFailedAnalysisResult } from '../../../services/aiAnalysisHelper';
+import { forceSyncToBackend } from '../../../services/autoSync';
+import { GitHubApiService } from '../../../services/githubApi';
+import { useDialog } from '../../../hooks/useDialog';
+import { applyDiscoveryAnalysisFailure, applyDiscoveryAnalysisSuccess } from '../../repositories/application/discoveryRepoPatches';
+
+export interface UseDiscoveryRepoActionsOptions {
+  repo: DiscoveryRepo;
+}
+
+export interface DiscoveryRepoActions {
+  analyze: (onAnalyzed?: (repo: DiscoveryRepo) => void) => Promise<void>;
+  star: (onStar?: (repo: DiscoveryRepo) => void) => Promise<void>;
+  executeUnstar: () => Promise<void>;
+  isAnalyzing: boolean;
+  isStarring: boolean;
+  isStarred: boolean;
+  optimisticStarred: boolean | null;
+}
+
+// 原 SubscriptionRepoCard.handleStar 的 repositoryToAdd 字面量提纯：
+// 抹去发现页特有字段（键保留、值置 undefined）并补 Star 时间。
+// cast 是必须的——Repository 没有 rank/channel/platform 键，运行时形状与原实现逐字一致。
+export const discoveryRepoToRepository = (repo: DiscoveryRepo, starredAt: string): Repository => ({
+  ...repo,
+  rank: undefined,
+  channel: undefined,
+  platform: undefined,
+  starred_at: starredAt,
+} as Repository);
+
+export const useDiscoveryRepoActions = ({ repo }: UseDiscoveryRepoActionsOptions): DiscoveryRepoActions => {
+  const {
+    githubToken,
+    aiConfigs,
+    activeAIConfig,
+    language,
+    customCategories,
+    repositories,
+    updateDiscoveryRepo,
+    addRepository,
+    deleteRepository,
+  } = useAppStore(useShallow((state) => ({
+    githubToken: state.githubToken,
+    aiConfigs: state.aiConfigs,
+    activeAIConfig: state.activeAIConfig,
+    language: state.language,
+    customCategories: state.customCategories,
+    repositories: state.repositories,
+    updateDiscoveryRepo: state.updateDiscoveryRepo,
+    addRepository: state.addRepository,
+    deleteRepository: state.deleteRepository,
+  })));
+
+  const { toast } = useDialog();
+
+  const t = useCallback((zh: string, en: string) => language === 'zh' ? zh : en, [language]);
+
+  const [isStarring, setIsStarring] = useState(false);
+  const [isAnalyzing, setIsAnalyzing] = useState(false);
+  // 本地乐观状态，用于立即反映Star操作结果
+  const [optimisticStarred, setOptimisticStarred] = useState<boolean | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, []);
+
+  // 检查仓库是否已在本地存在（已被Star）
+  const isStarredComputed = useMemo(() => {
+    return repositories.some(r => r.full_name === repo.full_name);
+  }, [repositories, repo.full_name]);
+
+  // 优先使用乐观状态，否则使用计算状态
+  const isStarred = optimisticStarred !== null ? optimisticStarred : isStarredComputed;
+
+  // 执行取消Star操作。无 confirm——取消 Star 的确认是 View 侧自定义 Modal（B8），
+  // View 确认按钮负责清 unstarConfirmOpen/pendingUnstarAction 后调用本方法。
+  const executeUnstar = useCallback(async () => {
+    if (!githubToken) return;
+
+    setIsStarring(true);
+
+    try {
+      const githubApi = new GitHubApiService(githubToken);
+      const [owner, name] = repo.full_name.split('/');
+
+      // 乐观更新：立即更新UI状态
+      setOptimisticStarred(false);
+
+      await githubApi.unstarRepository(owner, name);
+
+      // 从本地删除
+      const existingRepo = repositories.find(r => r.full_name === repo.full_name);
+      if (existingRepo) {
+        deleteRepository(existingRepo.id);
+      }
+
+      await forceSyncToBackend();
+
+      // 操作成功，清除乐观状态
+      setOptimisticStarred(null);
+    } catch (error) {
+      // 操作失败，回滚乐观状态
+      setOptimisticStarred(null);
+      console.error('Failed to unstar repository:', error);
+      const errorMessage = t('取消 Star 失败，请检查网络连接或 GitHub Token 权限。', 'Failed to unstar repository. Please check your network connection or GitHub Token permissions.');
+      toast(errorMessage, 'error');
+    } finally {
+      setIsStarring(false);
+    }
+  }, [githubToken, repo, repositories, deleteRepository, t, toast]);
+
+  // 添加Star（取消Star路径由 View 确认 Modal 承担，不在本方法内）
+  const star = useCallback(async (onStar?: (repo: DiscoveryRepo) => void) => {
+    if (!githubToken || isStarring) return;
+
+    setIsStarring(true);
+
+    try {
+      const githubApi = new GitHubApiService(githubToken);
+      const [owner, name] = repo.full_name.split('/');
+
+      // 乐观更新：立即更新UI状态
+      setOptimisticStarred(true);
+
+      await githubApi.starRepository(owner, name);
+
+      addRepository(discoveryRepoToRepository(repo, new Date().toISOString()));
+
+      if (onStar) {
+        onStar(repo);
+      }
+
+      await forceSyncToBackend();
+
+      // 操作成功，清除乐观状态
+      setOptimisticStarred(null);
+
+      toast(t('已成功添加 Star', 'Successfully starred'), 'success');
+    } catch (error) {
+      // 操作失败，回滚乐观状态
+      setOptimisticStarred(null);
+      console.error('Failed to star repository:', error);
+      const errorMessage = t('Star 操作失败，请检查网络连接或 GitHub Token 权限。', 'Failed to star repository. Please check your network connection or GitHub Token permissions.');
+      toast(errorMessage, 'error');
+    } finally {
+      setIsStarring(false);
+    }
+  }, [githubToken, isStarring, repo, t, toast, addRepository]);
+
+  // 单卡 AI 分析（无 forceSync、成功无 toast、重新分析无 confirm——与 RepositoryCard 不同，勿"补齐"）
+  const analyze = useCallback(async (onAnalyzed?: (repo: DiscoveryRepo) => void) => {
+    if (!githubToken) {
+      toast(t('GitHub Token 未找到，请重新登录。', 'GitHub token not found. Please login again.'), 'error');
+      return;
+    }
+
+    const activeConfig = aiConfigs.find(c => c.id === activeAIConfig);
+    if (!activeConfig) {
+      toast(t('请先在设置中配置AI服务。', 'Please configure AI service in settings first.'), 'error');
+      return;
+    }
+
+    if (activeConfig.apiKeyStatus === 'decrypt_failed' || activeConfig.apiKeyStatus === 'empty') {
+      toast(t('AI服务的API密钥无法解密或为空，请在设置中重新输入并保存该配置。', 'The AI service API key could not be decrypted or is empty. Please re-enter and save the configuration in settings.'), 'error');
+      return;
+    }
+
+    if (!activeConfig.baseUrl || !activeConfig.apiKey || !activeConfig.model) {
+      toast(t('AI服务配置不完整，请检查API端点、密钥和模型名称。', 'AI service configuration is incomplete. Please check the API endpoint, key, and model name.'), 'error');
+      return;
+    }
+
+    if (isAnalyzing) return;
+
+    abortControllerRef.current?.abort();
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    setIsAnalyzing(true);
+
+    try {
+      const allCategories = getAllCategories(customCategories, language);
+
+      const result = await analyzeRepository({
+        repository: repo,
+        githubToken,
+        aiConfig: activeConfig,
+        language,
+        categories: allCategories,
+        signal: controller.signal,
+      });
+
+      if (controller.signal.aborted) return;
+
+      const updatedRepo = applyDiscoveryAnalysisSuccess(repo, {
+        summary: result.summary,
+        tags: result.tags,
+        platforms: result.platforms,
+        analyzedAt: result.analyzed_at,
+        analysisFailed: result.analysis_failed,
+      });
+      updateDiscoveryRepo(updatedRepo);
+
+      if (onAnalyzed) {
+        onAnalyzed(updatedRepo);
+      }
+    } catch (error) {
+      if (!controller.signal.aborted) {
+        console.error('AI analysis error:', error);
+        const errorMsg = error instanceof Error && error.message
+          ? error.message
+          : t('AI分析失败，请检查AI配置和网络连接', 'AI analysis failed, please check AI configuration and network connection');
+        const failedResult = createFailedAnalysisResult(errorMsg);
+        const failedRepo = applyDiscoveryAnalysisFailure(repo, {
+          analyzedAt: failedResult.analyzed_at,
+          analysisFailed: failedResult.analysis_failed,
+          analysisError: failedResult.analysis_error,
+        });
+        updateDiscoveryRepo(failedRepo);
+        toast(t('AI分析失败，请检查AI配置。', 'AI analysis failed. Please check your AI configuration.'), 'error');
+      }
+    } finally {
+      if (!controller.signal.aborted) {
+        setIsAnalyzing(false);
+      }
+    }
+  }, [githubToken, aiConfigs, activeAIConfig, language, repo, isAnalyzing, customCategories, updateDiscoveryRepo, t, toast]);
+
+  return useMemo(() => ({
+    analyze,
+    star,
+    executeUnstar,
+    isAnalyzing,
+    isStarring,
+    isStarred,
+    optimisticStarred,
+  }), [analyze, star, executeUnstar, isAnalyzing, isStarring, isStarred, optimisticStarred]);
+};

--- a/src/features/gists/hooks/useGistActions.test.tsx
+++ b/src/features/gists/hooks/useGistActions.test.tsx
@@ -1,0 +1,329 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Gist } from '../../../types';
+import { applyGistAnalysisFailure, applyGistAnalysisSuccess, useGistActions } from './useGistActions';
+
+const mocks = vi.hoisted(() => ({
+  useAppStore: vi.fn(),
+  toast: vi.fn(),
+  confirm: vi.fn(),
+  forceSyncToBackend: vi.fn(),
+  getGistForAnalysis: vi.fn(),
+  getGistContentPreview: vi.fn(),
+  unstarGist: vi.fn(),
+  deleteGist: vi.fn(),
+  getGistFileRaw: vi.fn(),
+  analyzeGist: vi.fn(),
+}));
+
+vi.mock('../../../store/useAppStore', () => ({
+  useAppStore: mocks.useAppStore,
+}));
+
+vi.mock('../../../hooks/useDialog', () => ({
+  useDialog: () => ({ toast: mocks.toast, confirm: mocks.confirm }),
+}));
+
+vi.mock('../../../services/autoSync', () => ({
+  forceSyncToBackend: mocks.forceSyncToBackend,
+}));
+
+vi.mock('../../../services/githubApiFactory', () => ({
+  createGitHubApiService: () => ({
+    getGistForAnalysis: mocks.getGistForAnalysis,
+    getGistContentPreview: mocks.getGistContentPreview,
+    unstarGist: mocks.unstarGist,
+    deleteGist: mocks.deleteGist,
+    getGistFileRaw: mocks.getGistFileRaw,
+  }),
+}));
+
+vi.mock('../../../services/aiService', () => ({
+  AIService: class {
+    analyzeGist = mocks.analyzeGist;
+  },
+}));
+
+const createStoreState = () => ({
+  user: { login: 'me', avatar_url: 'https://example.com/me.png' },
+  githubToken: 'github-token' as string | null,
+  gists: [],
+  starredGists: [],
+  gistSearchFilters: { query: '' },
+  gistSearchResults: [],
+  selectedGistCategory: 'all' as const,
+  aiConfigs: [{
+    id: 'ai-config',
+    name: 'Test AI',
+    baseUrl: 'https://example.com/v1',
+    apiKey: 'ai-key',
+    model: 'ai-model',
+  }],
+  activeAIConfig: 'ai-config',
+  language: 'zh' as const,
+  setGists: vi.fn(),
+  setStarredGists: vi.fn(),
+  updateGist: vi.fn(),
+  deleteGist: vi.fn(),
+  setGistSearchFilters: vi.fn(),
+  setGistSearchResults: vi.fn(),
+  setSelectedGistCategory: vi.fn(),
+  setAnalyzingGist: vi.fn(),
+  analyzingGistIds: new Set<string>(),
+});
+
+let storeState = createStoreState();
+const mockUseAppStore = vi.mocked(mocks.useAppStore);
+mockUseAppStore.mockImplementation((selector?: (state: typeof storeState) => unknown) =>
+  selector ? selector(storeState) : storeState);
+(mockUseAppStore as unknown as { getState: () => typeof storeState }).getState = () => storeState;
+
+const gist: Gist = {
+  id: 'gist-1',
+  description: 'A gist',
+  public: true,
+  html_url: 'https://gist.github.com/me/gist-1',
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-02T00:00:00.000Z',
+  comments: 0,
+  owner: { login: 'me', avatar_url: 'https://example.com/me.png' },
+  files: {
+    'a.ts': { filename: 'a.ts', type: 'text/plain', language: 'TypeScript', size: 10, content: 'const a = 1;' },
+  },
+};
+
+const gistDetail: Gist = {
+  ...gist,
+  files: {
+    'a.ts': { filename: 'a.ts', type: 'text/plain', language: 'TypeScript', size: 20, content: 'const a = 1; // full' },
+  },
+};
+
+describe('useGistActions card actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeState = createStoreState();
+  });
+
+  describe('analyzeOne', () => {
+    it('validates token, config presence and completeness in order before analyzing', async () => {
+      storeState.githubToken = null;
+      const { result, rerender } = renderHook(() => useGistActions());
+      await act(async () => { await result.current.analyzeOne(gist); });
+      expect(mocks.toast).toHaveBeenCalledTimes(1);
+      expect(mocks.toast).toHaveBeenCalledWith('GitHub token 未找到，请重新登录。', 'error');
+
+      storeState.githubToken = 'github-token';
+      storeState.aiConfigs = [];
+      rerender();
+      await act(async () => { await result.current.analyzeOne(gist); });
+      expect(mocks.toast).toHaveBeenLastCalledWith('请先在设置中配置AI服务。', 'error');
+
+      storeState.aiConfigs = [{ id: 'ai-config', name: 'Broken', baseUrl: '', apiKey: '', model: '' }];
+      rerender();
+      await act(async () => { await result.current.analyzeOne(gist); });
+      expect(mocks.toast).toHaveBeenLastCalledWith('AI服务配置不完整，请检查设置。', 'error');
+      expect(mocks.getGistForAnalysis).not.toHaveBeenCalled();
+    });
+
+    it('asks for confirmation when the gist was analyzed before and aborts on cancel', async () => {
+      storeState.gists = [];
+      const analyzedGist = { ...gist, analyzed_at: '2026-01-03T00:00:00.000Z' };
+      mocks.confirm.mockResolvedValue(false);
+      const { result } = renderHook(() => useGistActions());
+      await act(async () => { await result.current.analyzeOne(analyzedGist); });
+      expect(mocks.confirm).toHaveBeenCalledWith(
+        '重新分析确认',
+        '此 gist 已经分析过，是否覆盖现有摘要？',
+        { type: 'warning' },
+      );
+      expect(mocks.getGistForAnalysis).not.toHaveBeenCalled();
+      expect(storeState.setAnalyzingGist).not.toHaveBeenCalled();
+    });
+
+    it('patches the success fields from the fetched detail and does not force sync', async () => {
+      mocks.getGistForAnalysis.mockResolvedValue(gistDetail);
+      mocks.getGistContentPreview.mockReturnValue('preview');
+      mocks.analyzeGist.mockResolvedValue('  summary text  ');
+      const { result } = renderHook(() => useGistActions());
+      await act(async () => { await result.current.analyzeOne(gist); });
+
+      expect(mocks.confirm).not.toHaveBeenCalled();
+      expect(storeState.setAnalyzingGist).toHaveBeenCalledWith('gist-1', true);
+      expect(storeState.setAnalyzingGist).toHaveBeenLastCalledWith('gist-1', false);
+      expect(storeState.updateGist).toHaveBeenCalledTimes(1);
+      const patch = storeState.updateGist.mock.calls[0][0] as Gist;
+      expect(patch.ai_summary).toBe('summary text');
+      expect(patch.analyzed_at).toEqual(expect.any(String));
+      expect(patch.analysis_failed).toBe(false);
+      expect(patch.analysis_error).toBeUndefined();
+      // 成功 patch 以拉取到的 detail 为底（内容比列表缓存更完整）
+      expect(patch.files['a.ts'].content).toBe('const a = 1; // full');
+      expect(mocks.toast).toHaveBeenCalledWith('Gist AI分析完成', 'success');
+      expect(mocks.forceSyncToBackend).not.toHaveBeenCalled();
+    });
+
+    it('patches failure fields and toasts on analysis error', async () => {
+      mocks.getGistForAnalysis.mockRejectedValue(new Error('boom'));
+      const { result } = renderHook(() => useGistActions());
+      await act(async () => { await result.current.analyzeOne(gist); });
+
+      expect(storeState.updateGist).toHaveBeenCalledTimes(1);
+      const patch = storeState.updateGist.mock.calls[0][0] as Gist;
+      expect(patch.analyzed_at).toEqual(expect.any(String));
+      expect(patch.analysis_failed).toBe(true);
+      expect(patch.analysis_error).toBe('boom');
+      expect(mocks.toast).toHaveBeenCalledWith('Gist AI分析失败', 'error');
+      expect(storeState.setAnalyzingGist).toHaveBeenLastCalledWith('gist-1', false);
+    });
+  });
+
+  describe('unstarGist', () => {
+    it('aborts silently without token and when confirm is declined', async () => {
+      storeState.githubToken = null;
+      const { result, rerender } = renderHook(() => useGistActions());
+      await act(async () => { await result.current.unstarGist(gist, vi.fn()); });
+      expect(mocks.confirm).not.toHaveBeenCalled();
+      expect(mocks.unstarGist).not.toHaveBeenCalled();
+
+      storeState.githubToken = 'github-token';
+      rerender();
+      mocks.confirm.mockResolvedValue(false);
+      await act(async () => { await result.current.unstarGist(gist, vi.fn()); });
+      expect(mocks.confirm).toHaveBeenCalledTimes(1);
+      expect(mocks.unstarGist).not.toHaveBeenCalled();
+    });
+
+    it('calls onUnstarred before the store update and toasts success', async () => {
+      mocks.confirm.mockResolvedValue(true);
+      const onUnstarred = vi.fn();
+      const { result } = renderHook(() => useGistActions());
+      await act(async () => { await result.current.unstarGist(gist, onUnstarred); });
+
+      expect(mocks.unstarGist).toHaveBeenCalledWith('gist-1');
+      const onUnstarredOrder = onUnstarred.mock.invocationCallOrder[0];
+      const updateOrder = storeState.updateGist.mock.invocationCallOrder[0];
+      expect(onUnstarredOrder).toBeLessThan(updateOrder);
+      expect(storeState.updateGist).toHaveBeenCalledWith({ ...gist, starred: false });
+      expect(mocks.toast).toHaveBeenCalledWith('已取消收藏', 'success');
+    });
+
+    it('toasts failure without store update when the api call rejects', async () => {
+      mocks.confirm.mockResolvedValue(true);
+      mocks.unstarGist.mockRejectedValue(new Error('network'));
+      const onUnstarred = vi.fn();
+      const { result } = renderHook(() => useGistActions());
+      await act(async () => { await result.current.unstarGist(gist, onUnstarred); });
+
+      expect(onUnstarred).not.toHaveBeenCalled();
+      expect(storeState.updateGist).not.toHaveBeenCalled();
+      expect(mocks.toast).toHaveBeenCalledWith('取消收藏失败', 'error');
+    });
+  });
+
+  describe('deleteGist', () => {
+    it('skips silently without token or when the gist is not owned by the user', async () => {
+      storeState.githubToken = null;
+      const { result, rerender } = renderHook(() => useGistActions());
+      await act(async () => { await result.current.deleteGist(gist, vi.fn()); });
+      expect(mocks.deleteGist).not.toHaveBeenCalled();
+
+      storeState.githubToken = 'github-token';
+      rerender();
+      const foreignGist = { ...gist, owner: { login: 'someone-else', avatar_url: '' } };
+      await act(async () => { await result.current.deleteGist(foreignGist, vi.fn()); });
+      expect(mocks.confirm).not.toHaveBeenCalled();
+      expect(mocks.deleteGist).not.toHaveBeenCalled();
+    });
+
+    it('aborts when confirm is declined', async () => {
+      mocks.confirm.mockResolvedValue(false);
+      const { result } = renderHook(() => useGistActions());
+      await act(async () => { await result.current.deleteGist(gist, vi.fn()); });
+      expect(mocks.confirm).toHaveBeenCalledWith(
+        '删除 Gist',
+        '确定要删除这个 gist 吗？此操作不可撤销。',
+        { type: 'danger', confirmText: '删除' },
+      );
+      expect(mocks.deleteGist).not.toHaveBeenCalled();
+    });
+
+    it('removes the store record, then calls onDeleted, then toasts success', async () => {
+      mocks.confirm.mockResolvedValue(true);
+      const onDeleted = vi.fn();
+      const { result } = renderHook(() => useGistActions());
+      await act(async () => { await result.current.deleteGist(gist, onDeleted); });
+
+      expect(mocks.deleteGist).toHaveBeenCalledWith('gist-1');
+      const storeDeleteOrder = storeState.deleteGist.mock.invocationCallOrder[0];
+      const onDeletedOrder = onDeleted.mock.invocationCallOrder[0];
+      expect(storeDeleteOrder).toBeLessThan(onDeletedOrder);
+      expect(mocks.toast).toHaveBeenCalledWith('Gist 已删除', 'success');
+    });
+
+    it('maps permission errors into the scoped hint toast', async () => {
+      mocks.confirm.mockResolvedValue(true);
+      mocks.deleteGist.mockRejectedValue(new Error('403 forbidden'));
+      const { result } = renderHook(() => useGistActions());
+      await act(async () => { await result.current.deleteGist(gist, vi.fn()); });
+
+      expect(mocks.toast).toHaveBeenCalledWith(
+        '删除 Gist 失败：403 forbidden（请确认 token 已勾选 gist 权限，并在设置中重新输入 token 登录）',
+        'error',
+      );
+    });
+  });
+
+  describe('fetchGistFileRaw', () => {
+    it('throws the verbatim no-token message', async () => {
+      storeState.githubToken = null;
+      const { result } = renderHook(() => useGistActions());
+      await expect(result.current.fetchGistFileRaw('https://raw.example/x')).rejects.toThrow(
+        '未配置 GitHub token，无法加载文件内容',
+      );
+      expect(mocks.getGistFileRaw).not.toHaveBeenCalled();
+    });
+
+    it('passes the raw url and signal through to the api service', async () => {
+      mocks.getGistFileRaw.mockResolvedValue('file body');
+      const { result } = renderHook(() => useGistActions());
+      const controller = new AbortController();
+      await act(async () => {
+        await expect(result.current.fetchGistFileRaw('https://raw.example/x', controller.signal)).resolves.toBe('file body');
+      });
+      expect(mocks.getGistFileRaw).toHaveBeenCalledWith('https://raw.example/x', controller.signal);
+    });
+  });
+
+  describe('isAnalyzingGist', () => {
+    it('reflects the store analyzing set', () => {
+      storeState.analyzingGistIds = new Set(['gist-1']);
+      const { result } = renderHook(() => useGistActions());
+      expect(result.current.isAnalyzingGist('gist-1')).toBe(true);
+      expect(result.current.isAnalyzingGist('gist-2')).toBe(false);
+    });
+  });
+});
+
+describe('gist analysis patch helpers', () => {
+  it('applyGistAnalysisSuccess trims the summary and resets failure state on the detail', () => {
+    const patched = applyGistAnalysisSuccess(gistDetail, '  trimmed  ', '2026-09-05T00:00:00.000Z');
+    expect(patched).toEqual({
+      ...gistDetail,
+      ai_summary: 'trimmed',
+      analyzed_at: '2026-09-05T00:00:00.000Z',
+      analysis_failed: false,
+      analysis_error: undefined,
+    });
+  });
+
+  it('applyGistAnalysisFailure marks failure on the original gist', () => {
+    const patched = applyGistAnalysisFailure(gist, 'boom', '2026-09-05T00:00:00.000Z');
+    expect(patched).toEqual({
+      ...gist,
+      analyzed_at: '2026-09-05T00:00:00.000Z',
+      analysis_failed: true,
+      analysis_error: 'boom',
+    });
+  });
+});

--- a/src/features/gists/hooks/useGistActions.ts
+++ b/src/features/gists/hooks/useGistActions.ts
@@ -11,12 +11,37 @@ import { filterAndSortGists } from '../../../utils/gistUtils';
 
 export type { GistCreateInput, GistUpdateInput };
 
+// GistCard 单卡分析 patch 字面量提纯（成功/失败两态）。
+export const applyGistAnalysisSuccess = (detail: Gist, summary: string, now: string): Gist => ({
+  ...detail,
+  ai_summary: summary.trim(),
+  analyzed_at: now,
+  analysis_failed: false,
+  analysis_error: undefined,
+});
+
+export const applyGistAnalysisFailure = (gist: Gist, error: string, now: string): Gist => ({
+  ...gist,
+  analyzed_at: now,
+  analysis_failed: true,
+  analysis_error: error,
+});
+
 export const useGistActions = () => {
   const state = useAppStore(useShallow(selectGistViewState));
   const { toast, confirm } = useDialog();
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [isSearching, setIsSearching] = useState(false);
   const [isAnalyzingAll, setIsAnalyzingAll] = useState(false);
+  const [isMutating, setIsMutating] = useState(false);
+  // isAnalyzingGist(id) 的渲染值恒等于 store 集合值：原 GistCard 的本地 isAnalyzingLocal
+  // 与 setAnalyzingGist 同置同清，渲染上与集合值等价，故本 hook 只操作 store 集合、
+  // 不再设本地 flag（勿"修复"回双 flag 写法）。
+  const analyzingGistIds = useAppStore((s) => s.analyzingGistIds);
+  const isAnalyzingGist = useCallback(
+    (gistId: string) => analyzingGistIds.has(gistId),
+    [analyzingGistIds],
+  );
   const t = useCallback((zh: string, en: string) => state.language === 'zh' ? zh : en, [state.language]);
 
   const refreshGists = useCallback(async () => {
@@ -165,15 +190,128 @@ export const useGistActions = () => {
     }
   }, [state, t, toast]);
 
+  // 单卡 AI 分析（原 GistCard.handleAnalyze）：无 Abort、无 forceSync；
+  // 重新分析覆盖确认在本 hook 内（View 只保留 stopPropagation 前置）。
+  const analyzeOne = useCallback(async (gist: Gist) => {
+    if (!state.githubToken) {
+      toast(t('GitHub token 未找到，请重新登录。', 'GitHub token not found. Please login again.'), 'error');
+      return;
+    }
+    const activeConfig = state.aiConfigs.find(config => config.id === state.activeAIConfig);
+    if (!activeConfig) {
+      toast(t('请先在设置中配置AI服务。', 'Please configure AI service in settings first.'), 'error');
+      return;
+    }
+    if (!activeConfig.baseUrl || !activeConfig.apiKey || !activeConfig.model || activeConfig.apiKeyStatus === 'decrypt_failed' || activeConfig.apiKeyStatus === 'empty') {
+      toast(t('AI服务配置不完整，请检查设置。', 'AI service configuration is incomplete. Please check settings.'), 'error');
+      return;
+    }
+
+    if (gist.analyzed_at) {
+      const shouldContinue = await confirm(
+        t('重新分析确认', 'Re-analyze Confirmation'),
+        t('此 gist 已经分析过，是否覆盖现有摘要？', 'This gist has already been analyzed. Overwrite the existing summary?'),
+        { type: 'warning' }
+      );
+      if (!shouldContinue) return;
+    }
+
+    state.setAnalyzingGist(gist.id, true);
+    try {
+      const githubApi = createGitHubApiService(state.githubToken);
+      const detail = await githubApi.getGistForAnalysis(gist.id, gist);
+      const aiService = new AIService(activeConfig, state.language);
+      const summary = await aiService.analyzeGist(detail, githubApi.getGistContentPreview(detail));
+      state.updateGist(applyGistAnalysisSuccess(detail, summary, new Date().toISOString()));
+      toast(t('Gist AI分析完成', 'Gist AI analysis completed'), 'success');
+    } catch (error) {
+      state.updateGist(applyGistAnalysisFailure(gist, error instanceof Error ? error.message : String(error), new Date().toISOString()));
+      toast(t('Gist AI分析失败', 'Gist AI analysis failed'), 'error');
+    } finally {
+      state.setAnalyzingGist(gist.id, false);
+    }
+  }, [state, t, toast, confirm]);
+
+  const unstarGist = useCallback(async (gist: Gist, onUnstarred?: (gistId: string) => void) => {
+    if (!state.githubToken) return;
+    const confirmed = await confirm(
+      t('取消收藏 Gist', 'Unstar Gist'),
+      t('确定要取消收藏这个 gist 吗？', 'Are you sure you want to unstar this gist?'),
+      { type: 'warning', confirmText: t('取消收藏', 'Unstar') }
+    );
+    if (!confirmed) return;
+
+    setIsMutating(true);
+    try {
+      await createGitHubApiService(state.githubToken).unstarGist(gist.id);
+      onUnstarred?.(gist.id);
+      state.updateGist({ ...gist, starred: false });
+      toast(t('已取消收藏', 'Unstarred'), 'success');
+    } catch {
+      toast(t('取消收藏失败', 'Failed to unstar'), 'error');
+    } finally {
+      setIsMutating(false);
+    }
+  }, [state, t, toast, confirm]);
+
+  // 注意：本方法有意遮蔽经由 ...state 展开的同名 store action（签名不同：
+  // 接收 Gist 对象并内置确认/报错）。需要原始 store action 的调用方应自行
+  // 从 useAppStore 订阅（GistView 的 onDeleted 即如此）。
+  const deleteGist = useCallback(async (gist: Gist, onDeleted?: (gistId: string) => void) => {
+    if (!state.githubToken || gist.owner?.login !== state.user?.login) return;
+    const confirmed = await confirm(
+      t('删除 Gist', 'Delete Gist'),
+      t('确定要删除这个 gist 吗？此操作不可撤销。', 'Are you sure you want to delete this gist? This cannot be undone.'),
+      { type: 'danger', confirmText: t('删除', 'Delete') }
+    );
+    if (!confirmed) return;
+
+    setIsMutating(true);
+    try {
+      await createGitHubApiService(state.githubToken).deleteGist(gist.id);
+      state.deleteGist(gist.id);
+      onDeleted?.(gist.id);
+      toast(t('Gist 已删除', 'Gist deleted'), 'success');
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : '';
+      const isPermission = /403|404|forbidden|scope|permission/i.test(msg);
+      toast(
+        t(
+          `删除 Gist 失败${msg ? `：${msg}` : ''}${isPermission ? '（请确认 token 已勾选 gist 权限，并在设置中重新输入 token 登录）' : ''}`,
+          `Failed to delete gist${msg ? `: ${msg}` : ''}${isPermission ? ' (Make sure your token has the gist scope and re-login with the updated token)' : ''}`
+        ),
+        'error'
+      );
+    } finally {
+      setIsMutating(false);
+    }
+  }, [state, t, toast, confirm]);
+
+  // 大文件按需拉取（原 GistDetailModal.HighlightedCode effect 的服务调用部分）。
+  // 无 token 时抛出的错误文案与原 setRawError 直写逐字一致，由 View catch 落 rawError。
+  // Abort/retry/局部缓存归 View：signal 由调用方传入。
+  const fetchGistFileRaw = useCallback(async (rawUrl: string, signal?: AbortSignal): Promise<string> => {
+    if (!state.githubToken) {
+      throw new Error(t('未配置 GitHub token，无法加载文件内容', 'GitHub token not configured, cannot load file content'));
+    }
+    return createGitHubApiService(state.githubToken).getGistFileRaw(rawUrl, signal);
+  }, [state.githubToken, t]);
+
   return {
     ...state,
     isRefreshing,
     isSearching,
     isAnalyzingAll,
+    isMutating,
     refreshGists,
     aiSearch,
     analyzeVisibleGists,
     fetchGistDetail,
     submitGist,
+    analyzeOne,
+    unstarGist,
+    deleteGist,
+    fetchGistFileRaw,
+    isAnalyzingGist,
   };
 };

--- a/src/features/gists/hooks/useGistActions.ts
+++ b/src/features/gists/hooks/useGistActions.ts
@@ -290,12 +290,17 @@ export const useGistActions = () => {
   // 大文件按需拉取（原 GistDetailModal.HighlightedCode effect 的服务调用部分）。
   // 无 token 时抛出的错误文案与原 setRawError 直写逐字一致，由 View catch 落 rawError。
   // Abort/retry/局部缓存归 View：signal 由调用方传入。
+  // 依赖只含 token：语言切换不得换引用（否则 View 的拉取 effect 会随 language 变化
+  // 重新发起网络请求），无 token 文案在抛错时经 getState() 读取当前语言。
   const fetchGistFileRaw = useCallback(async (rawUrl: string, signal?: AbortSignal): Promise<string> => {
     if (!state.githubToken) {
-      throw new Error(t('未配置 GitHub token，无法加载文件内容', 'GitHub token not configured, cannot load file content'));
+      const currentLanguage = useAppStore.getState().language;
+      throw new Error(currentLanguage === 'zh'
+        ? '未配置 GitHub token，无法加载文件内容'
+        : 'GitHub token not configured, cannot load file content');
     }
     return createGitHubApiService(state.githubToken).getGistFileRaw(rawUrl, signal);
-  }, [state.githubToken, t]);
+  }, [state.githubToken]);
 
   return {
     ...state,

--- a/src/features/releases/hooks/useReleaseTimelineActions.test.tsx
+++ b/src/features/releases/hooks/useReleaseTimelineActions.test.tsx
@@ -1,0 +1,164 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useReleaseTimelineActions } from './useReleaseTimelineActions';
+
+const mocks = vi.hoisted(() => ({
+  useAppStore: vi.fn(),
+  toast: vi.fn(),
+  confirm: vi.fn(),
+  getAllWatchedRepositories: vi.fn(),
+  setReleaseSourceRepositories: vi.fn(),
+  forceSyncToBackend: vi.fn(),
+}));
+
+vi.mock('../../../store/useAppStore', () => ({
+  useAppStore: mocks.useAppStore,
+}));
+
+vi.mock('../../../hooks/useDialog', () => ({
+  useDialog: () => ({ toast: mocks.toast, confirm: mocks.confirm }),
+}));
+
+vi.mock('../../../services/githubApi', () => ({
+  GitHubApiService: class {
+    getAllWatchedRepositories = mocks.getAllWatchedRepositories;
+  },
+}));
+
+vi.mock('../../../services/autoSync', () => ({
+  forceSyncToBackend: mocks.forceSyncToBackend,
+}));
+
+vi.mock('../../../services/backendAdapter', () => ({
+  backend: { isAvailable: false, markAllReleasesAsRead: vi.fn() },
+}));
+
+const createStoreState = () => ({
+  // selectReleaseTimelineState 全字段
+  releases: [],
+  repositories: [],
+  releaseSubscriptions: new Set<number>(),
+  releaseSourceSettings: {
+    enabledSourceIds: ['watch-custom-release'],
+    watchCustomReleaseRepos: [
+      { full_name: 'owner/watched', html_url: 'https://github.com/owner/watched', release_hidden: true },
+    ],
+    customReleaseRepos: [],
+  },
+  readReleases: new Set<number>(),
+  githubToken: 'github-token' as string | null,
+  language: 'zh' as const,
+  assetFilters: new Map(),
+  addReleases: vi.fn(),
+  upsertReleases: vi.fn(),
+  markReleaseAsRead: vi.fn(),
+  markAssetAsRead: vi.fn(),
+  markAllReleasesAsRead: vi.fn(),
+  batchUnsubscribeReleases: vi.fn(),
+  removeReleasesByRepoFullName: vi.fn(),
+  updateRepository: vi.fn(),
+  removeReleaseSourceRepository: vi.fn(),
+  updateReleaseSourceRepository: vi.fn(),
+  releaseViewMode: 'grouped' as const,
+  releaseSelectedFilters: new Set<string>(),
+  releaseSearchQuery: '',
+  releaseExpandedRepositories: new Set<string>(),
+  releaseIsRefreshing: false,
+  setReleaseViewMode: vi.fn(),
+  toggleReleaseSelectedFilter: vi.fn(),
+  clearReleaseSelectedFilters: vi.fn(),
+  setReleaseSearchQuery: vi.fn(),
+  toggleReleaseExpandedRepository: vi.fn(),
+  setReleaseIsRefreshing: vi.fn(),
+  includePreRelease: false,
+  setIncludePreRelease: vi.fn(),
+  releaseShowMode: 'all' as const,
+  setReleaseShowMode: vi.fn(),
+  releaseLatestMode: 'latest' as const,
+  setReleaseLatestMode: vi.fn(),
+  // 独立单值 selector
+  setReleaseSourceRepositories: mocks.setReleaseSourceRepositories,
+});
+
+let storeState = createStoreState();
+const mockUseAppStore = vi.mocked(mocks.useAppStore);
+mockUseAppStore.mockImplementation((selector?: (state: typeof storeState) => unknown) =>
+  selector ? selector(storeState) : storeState);
+(mockUseAppStore as unknown as { getState: () => typeof storeState }).getState = () => storeState;
+
+describe('useReleaseTimelineActions.syncWatchedSources', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeState = createStoreState();
+  });
+
+  it('returns silently without token or while a sync is running', async () => {
+    storeState.githubToken = null;
+    const { result } = renderHook(() => useReleaseTimelineActions());
+    await act(async () => { await result.current.syncWatchedSources(); });
+    expect(mocks.getAllWatchedRepositories).not.toHaveBeenCalled();
+    expect(mocks.toast).not.toHaveBeenCalled();
+    expect(mocks.setReleaseSourceRepositories).not.toHaveBeenCalled();
+  });
+
+  it('maps watched repositories, keeps release_hidden, writes the store and toasts success', async () => {
+    mocks.getAllWatchedRepositories.mockResolvedValue([
+      {
+        id: 1,
+        name: 'watched',
+        full_name: 'owner/watched',
+        html_url: 'https://github.com/owner/watched',
+        owner: { login: 'owner', avatar_url: 'https://example.com/a.png' },
+        description: 'desc',
+        language: 'TypeScript',
+        stargazers_count: 5,
+        forks_count: 1,
+        forks: 1,
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-02T00:00:00.000Z',
+        pushed_at: '2026-01-03T00:00:00.000Z',
+        topics: [],
+      },
+      {
+        id: 2,
+        name: 'fresh',
+        full_name: 'owner/fresh',
+        html_url: 'https://github.com/owner/fresh',
+        owner: { login: 'owner', avatar_url: 'https://example.com/a.png' },
+        description: 'd2',
+        language: 'Go',
+        stargazers_count: 7,
+        forks_count: 2,
+        forks: 2,
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-02T00:00:00.000Z',
+        pushed_at: '2026-01-03T00:00:00.000Z',
+        topics: [],
+      },
+    ]);
+    const { result } = renderHook(() => useReleaseTimelineActions());
+    await act(async () => { await result.current.syncWatchedSources(); });
+
+    expect(mocks.setReleaseSourceRepositories).toHaveBeenCalledTimes(1);
+    const [sourceId, repos] = mocks.setReleaseSourceRepositories.mock.calls[0];
+    expect(sourceId).toBe('watch-custom-release');
+    expect(repos).toHaveLength(2);
+    const previouslyHidden = repos.find((repo: { full_name: string }) => repo.full_name === 'owner/watched');
+    expect(previouslyHidden.release_hidden).toBe(true);
+    const fresh = repos.find((repo: { full_name: string }) => repo.full_name === 'owner/fresh');
+    expect(fresh.release_hidden).toBeUndefined();
+    expect(mocks.toast).toHaveBeenCalledWith('已同步 2 个 Watch 仓库。', 'success');
+    expect(result.current.isSyncingWatchedSources).toBe(false);
+    expect(mocks.forceSyncToBackend).not.toHaveBeenCalled();
+  });
+
+  it('toasts a failure without writing the store when the api rejects', async () => {
+    mocks.getAllWatchedRepositories.mockRejectedValue(new Error('rate limited'));
+    const { result } = renderHook(() => useReleaseTimelineActions());
+    await act(async () => { await result.current.syncWatchedSources(); });
+
+    expect(mocks.setReleaseSourceRepositories).not.toHaveBeenCalled();
+    expect(mocks.toast).toHaveBeenCalledWith('同步 Watch 仓库失败，请检查网络或 Token 权限。', 'error');
+    expect(result.current.isSyncingWatchedSources).toBe(false);
+  });
+});

--- a/src/features/releases/hooks/useReleaseTimelineActions.test.tsx
+++ b/src/features/releases/hooks/useReleaseTimelineActions.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useReleaseTimelineActions } from './useReleaseTimelineActions';
 
@@ -150,6 +150,53 @@ describe('useReleaseTimelineActions.syncWatchedSources', () => {
     expect(mocks.toast).toHaveBeenCalledWith('已同步 2 个 Watch 仓库。', 'success');
     expect(result.current.isSyncingWatchedSources).toBe(false);
     expect(mocks.forceSyncToBackend).not.toHaveBeenCalled();
+  });
+
+  it('reads release_hidden from the latest state after the request resolves', async () => {
+    // 模拟同步期间用户在设置面板切换隐藏状态：await 挂起时改 store，
+    // 完成后写入的 sourceRepos 必须保留切换后的值而非调用时的旧快照。
+    let resolveWatched!: (repos: unknown[]) => void;
+    mocks.getAllWatchedRepositories.mockImplementation(() => new Promise((resolve) => {
+      resolveWatched = resolve;
+    }));
+    const { result } = renderHook(() => useReleaseTimelineActions());
+
+    let pending!: Promise<void>;
+    act(() => {
+      pending = result.current.syncWatchedSources();
+    });
+    await waitFor(() => expect(mocks.getAllWatchedRepositories).toHaveBeenCalled());
+    act(() => {
+      storeState.releaseSourceSettings = {
+        ...storeState.releaseSourceSettings,
+        watchCustomReleaseRepos: [
+          { full_name: 'owner/watched', html_url: 'https://github.com/owner/watched', release_hidden: false },
+        ],
+      };
+    });
+    resolveWatched([
+      {
+        id: 1,
+        name: 'watched',
+        full_name: 'owner/watched',
+        html_url: 'https://github.com/owner/watched',
+        owner: { login: 'owner', avatar_url: 'https://example.com/a.png' },
+        description: 'desc',
+        language: 'TypeScript',
+        stargazers_count: 5,
+        forks_count: 1,
+        forks: 1,
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-02T00:00:00.000Z',
+        pushed_at: '2026-01-03T00:00:00.000Z',
+        topics: [],
+      },
+    ]);
+    await act(async () => { await pending; });
+
+    const repos = mocks.setReleaseSourceRepositories.mock.calls[0][1];
+    expect(repos[0].release_hidden).toBeUndefined();
+    expect(mocks.toast).toHaveBeenCalledWith('已同步 1 个 Watch 仓库。', 'success');
   });
 
   it('toasts a failure without writing the store when the api rejects', async () => {

--- a/src/features/releases/hooks/useReleaseTimelineActions.ts
+++ b/src/features/releases/hooks/useReleaseTimelineActions.ts
@@ -12,6 +12,7 @@ import {
   getSourcesForReleaseRepository,
   normalizeRepoKey,
   releaseBelongsToResolvedSources,
+  repositoryToCustomReleaseRepository,
   resolveReleaseSources,
   STARRED_RELEASE_SOURCE_ID,
   WATCH_CUSTOM_RELEASE_SOURCE_ID,
@@ -24,9 +25,13 @@ import { findReleasesWithChangedAssets } from '../../../utils/releaseAssets';
  */
 export const useReleaseTimelineActions = () => {
   const state = useAppStore(useShallow(selectReleaseTimelineState));
+  // 共享 selector 未收录的 store 写入用独立单值 selector 获取（B1）；
+  // store action 引用稳定，单值订阅不会引入多余重渲染。
+  const setReleaseSourceRepositories = useAppStore((s) => s.setReleaseSourceRepositories);
   const { toast, confirm } = useDialog();
   const [lastRefreshTime, setLastRefreshTime] = useState<string | null>(null);
   const [isMarkingAllRead, setIsMarkingAllRead] = useState(false);
+  const [isSyncingWatchedSources, setIsSyncingWatchedSources] = useState(false);
   const t = useCallback((zh: string, en: string) => state.language === 'zh' ? zh : en, [state.language]);
 
   const handleRefresh = useCallback(async () => {
@@ -189,13 +194,49 @@ export const useReleaseTimelineActions = () => {
     toast(t('已取消订阅该仓库的 Release。', 'Unsubscribed from repository releases.'), 'success');
   }, [state, t, toast, confirm]);
 
+  // 同步 Watch 仓库为 Release 来源（原 ReleaseSourceSettingsModal →
+  // WatchCustomReleaseSyncPanel.handleSync）：无 confirm、无 forceSync、无 Abort。
+  const syncWatchedSources = useCallback(async () => {
+    if (!state.githubToken || isSyncingWatchedSources) return;
+
+    setIsSyncingWatchedSources(true);
+    try {
+      const githubApi = new GitHubApiService(state.githubToken);
+      // 只拉 /user/subscriptions（含私有仓）。/users/{login}/subscriptions 已被 GitHub 改为
+      // 恒定返回 204 空响应体，且其结果本就是前者的公开子集，并行合并只会拖垮整个同步。
+      const watchedRepos = await githubApi.getAllWatchedRepositories();
+      const hiddenByRepo = new Map(
+        state.releaseSourceSettings.watchCustomReleaseRepos.map(repo => [normalizeRepoKey(repo.full_name), repo.release_hidden]),
+      );
+      const sourceRepos = watchedRepos.map(repo => ({
+        ...repositoryToCustomReleaseRepository(repo, WATCH_CUSTOM_RELEASE_SOURCE_ID),
+        release_hidden: hiddenByRepo.get(normalizeRepoKey(repo.full_name)) || undefined,
+      }));
+      setReleaseSourceRepositories(WATCH_CUSTOM_RELEASE_SOURCE_ID, sourceRepos);
+      toast(
+        t(
+          `已同步 ${sourceRepos.length} 个 Watch 仓库。`,
+          `Synced ${sourceRepos.length} Watch repositories.`
+        ),
+        'success'
+      );
+    } catch (error) {
+      console.error('Failed to sync watched repositories:', error);
+      toast(t('同步 Watch 仓库失败，请检查网络或 Token 权限。', 'Failed to sync Watch repositories. Check network or token permissions.'), 'error');
+    } finally {
+      setIsSyncingWatchedSources(false);
+    }
+  }, [state, isSyncingWatchedSources, setReleaseSourceRepositories, t, toast]);
+
   return {
     ...state,
     lastRefreshTime,
     isMarkingAllRead,
+    isSyncingWatchedSources,
     handleRefresh,
     handleMarkAllRead,
     handleUnsubscribeRelease,
+    syncWatchedSources,
   };
 };
 

--- a/src/features/releases/hooks/useReleaseTimelineActions.ts
+++ b/src/features/releases/hooks/useReleaseTimelineActions.ts
@@ -205,8 +205,10 @@ export const useReleaseTimelineActions = () => {
       // 只拉 /user/subscriptions（含私有仓）。/users/{login}/subscriptions 已被 GitHub 改为
       // 恒定返回 204 空响应体，且其结果本就是前者的公开子集，并行合并只会拖垮整个同步。
       const watchedRepos = await githubApi.getAllWatchedRepositories();
+      // hiddenByRepo 在 await 之后从最新 state 读取：同步期间用户仍可在设置面板
+      // 切换 release_hidden，旧快照会在 setReleaseSourceRepositories 时覆盖该修改。
       const hiddenByRepo = new Map(
-        state.releaseSourceSettings.watchCustomReleaseRepos.map(repo => [normalizeRepoKey(repo.full_name), repo.release_hidden]),
+        useAppStore.getState().releaseSourceSettings.watchCustomReleaseRepos.map(repo => [normalizeRepoKey(repo.full_name), repo.release_hidden]),
       );
       const sourceRepos = watchedRepos.map(repo => ({
         ...repositoryToCustomReleaseRepository(repo, WATCH_CUSTOM_RELEASE_SOURCE_ID),

--- a/src/features/repositories/__tests__/discoveryRepoPatches.test.ts
+++ b/src/features/repositories/__tests__/discoveryRepoPatches.test.ts
@@ -57,6 +57,24 @@ describe('applyDiscoveryAnalysisSuccess', () => {
     expect(patched.channel).toBe('trending');
     expect(patched.platform).toBe('Macos');
   });
+
+  it('clears a pre-existing analysis_error on success', () => {
+    const previouslyFailed: DiscoveryRepo = {
+      ...repo,
+      analysis_failed: true,
+      analysis_error: 'previous failure',
+    };
+    const patched = applyDiscoveryAnalysisSuccess(previouslyFailed, {
+      summary: 'recovered',
+      tags: [],
+      platforms: [],
+      analyzedAt: '2026-09-05T00:00:00.000Z',
+      analysisFailed: false,
+    });
+    expect(patched.analysis_error).toBeUndefined();
+    expect(patched.analysis_failed).toBe(false);
+    expect(patched.ai_summary).toBe('recovered');
+  });
 });
 
 describe('applyDiscoveryAnalysisFailure', () => {

--- a/src/features/repositories/__tests__/discoveryRepoPatches.test.ts
+++ b/src/features/repositories/__tests__/discoveryRepoPatches.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { DiscoveryRepo } from '../../../../types';
-import { applyDiscoveryAnalysisFailure, applyDiscoveryAnalysisSuccess } from '../discoveryRepoPatches';
+import type { DiscoveryRepo } from '../../../types';
+import { applyDiscoveryAnalysisFailure, applyDiscoveryAnalysisSuccess } from '../application/discoveryRepoPatches';
 
 const repo: DiscoveryRepo = {
   id: 7,

--- a/src/features/repositories/application/__tests__/discoveryRepoPatches.test.ts
+++ b/src/features/repositories/application/__tests__/discoveryRepoPatches.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import type { DiscoveryRepo } from '../../../../types';
+import { applyDiscoveryAnalysisFailure, applyDiscoveryAnalysisSuccess } from '../discoveryRepoPatches';
+
+const repo: DiscoveryRepo = {
+  id: 7,
+  name: 'discovered-repo',
+  full_name: 'owner/discovered-repo',
+  description: 'A discovered repository',
+  html_url: 'https://github.com/owner/discovered-repo',
+  stargazers_count: 512,
+  forks_count: 12,
+  forks: 12,
+  language: 'TypeScript',
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-02T00:00:00.000Z',
+  pushed_at: '2026-01-03T00:00:00.000Z',
+  owner: { login: 'owner', avatar_url: 'https://example.com/avatar.png' },
+  topics: ['test'],
+  rank: 3,
+  channel: 'trending',
+  platform: 'Macos',
+};
+
+describe('applyDiscoveryAnalysisSuccess', () => {
+  it('patches analysis fields without touching custom_category/category_locked', () => {
+    const patched = applyDiscoveryAnalysisSuccess(repo, {
+      summary: 'AI summary',
+      tags: ['ai', 'tools'],
+      platforms: ['cli'],
+      analyzedAt: '2026-09-05T00:00:00.000Z',
+      analysisFailed: false,
+    });
+
+    expect(patched).toEqual({
+      ...repo,
+      ai_summary: 'AI summary',
+      ai_tags: ['ai', 'tools'],
+      ai_platforms: ['cli'],
+      analyzed_at: '2026-09-05T00:00:00.000Z',
+      analysis_failed: false,
+      analysis_error: undefined,
+    });
+    expect('custom_category' in patched).toBe(false);
+    expect('category_locked' in patched).toBe(false);
+  });
+
+  it('keeps discovery-specific fields (rank/channel/platform)', () => {
+    const patched = applyDiscoveryAnalysisSuccess(repo, {
+      summary: undefined,
+      tags: undefined,
+      platforms: undefined,
+      analyzedAt: '2026-09-05T00:00:00.000Z',
+      analysisFailed: false,
+    });
+    expect(patched.rank).toBe(3);
+    expect(patched.channel).toBe('trending');
+    expect(patched.platform).toBe('Macos');
+  });
+});
+
+describe('applyDiscoveryAnalysisFailure', () => {
+  it('marks the failure fields and keeps the original analysis_error input', () => {
+    const patched = applyDiscoveryAnalysisFailure(repo, {
+      analyzedAt: '2026-09-05T00:00:00.000Z',
+      analysisFailed: true,
+      analysisError: 'boom',
+    });
+
+    expect(patched).toEqual({
+      ...repo,
+      analyzed_at: '2026-09-05T00:00:00.000Z',
+      analysis_failed: true,
+      analysis_error: 'boom',
+    });
+    expect(patched.ai_summary).toBeUndefined();
+  });
+});

--- a/src/features/repositories/application/discoveryRepoPatches.ts
+++ b/src/features/repositories/application/discoveryRepoPatches.ts
@@ -1,0 +1,40 @@
+import type { DiscoveryRepo } from '../../../types';
+
+export interface DiscoveryAnalysisSuccessInput {
+  summary: string | undefined;
+  tags: string[] | undefined;
+  platforms: string[] | undefined;
+  analyzedAt: string;
+  analysisFailed: boolean | undefined;
+}
+
+export interface DiscoveryAnalysisFailureInput {
+  analyzedAt: string;
+  analysisFailed: boolean | undefined;
+  analysisError: string | undefined;
+}
+
+// 发现页单卡分析的 patch 形状：与 repositoryPatches.applyAnalysisSuccess 不是同一形状
+// ——这里不含 custom_category/category_locked，输入输出均 DiscoveryRepo（保留 rank/channel/platform）。
+export const applyDiscoveryAnalysisSuccess = (
+  repo: DiscoveryRepo,
+  input: DiscoveryAnalysisSuccessInput,
+): DiscoveryRepo => ({
+  ...repo,
+  ai_summary: input.summary,
+  ai_tags: input.tags,
+  ai_platforms: input.platforms,
+  analyzed_at: input.analyzedAt,
+  analysis_failed: input.analysisFailed,
+  analysis_error: undefined,
+});
+
+export const applyDiscoveryAnalysisFailure = (
+  repo: DiscoveryRepo,
+  input: DiscoveryAnalysisFailureInput,
+): DiscoveryRepo => ({
+  ...repo,
+  analyzed_at: input.analyzedAt,
+  analysis_failed: input.analysisFailed,
+  analysis_error: input.analysisError,
+});

--- a/src/features/repositories/hooks/useRepositoryReleaseSheet.test.tsx
+++ b/src/features/repositories/hooks/useRepositoryReleaseSheet.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Repository, RouteMode } from '../../../types';
+import type { Release, Repository, RouteMode } from '../../../types';
 import { useRepositoryReleaseSheet } from './useRepositoryReleaseSheet';
 
 const mocks = vi.hoisted(() => ({
@@ -11,12 +11,14 @@ const mocks = vi.hoisted(() => ({
   },
   githubGetRepositoryReleasesPage: vi.fn(),
   toast: vi.fn(),
+  sendToRpcDownload: vi.fn(),
+  analyzeReleaseSummary: vi.fn(),
   store: {
     language: 'zh' as const,
     githubToken: 'token' as string | null,
     rpcDownloadConfig: { enabled: false, host: '', port: 6800, secret: '' },
     backendApiSecret: null as string | null,
-    aiConfigs: [],
+    aiConfigs: [] as Array<{ id: string; name: string; baseUrl: string; apiKey: string; model: string }>,
     activeAIConfig: null as string | null,
     routeMode: 'auto' as RouteMode,
   },
@@ -30,6 +32,14 @@ vi.mock('../../../services/githubApi', () => ({
 }));
 vi.mock('../../../hooks/useDialog', () => ({
   useDialog: () => ({ toast: mocks.toast, confirm: vi.fn() }),
+}));
+vi.mock('../../../services/rpcDownloadService', () => ({
+  sendToRpcDownload: mocks.sendToRpcDownload,
+}));
+vi.mock('../../../services/aiService', () => ({
+  AIService: class {
+    analyzeReleaseSummary = mocks.analyzeReleaseSummary;
+  },
 }));
 vi.mock('../../../store/useAppStore', () => ({
   useAppStore: Object.assign(
@@ -224,5 +234,59 @@ describe('useRepositoryReleaseSheet', () => {
     expect(mocks.backend.downloadGitHubResource).not.toHaveBeenCalled();
     expect(openSpy).toHaveBeenCalledWith('https://github.com/owner/repo/releases/download/v1/browser-fallback.zip', '_blank', 'noopener,noreferrer');
     openSpy.mockRestore();
+  });
+
+  it('keeps an in-flight AI summary alive when artifact states update (cancel effect keyed on stable fn)', async () => {
+    mocks.store.rpcDownloadConfig = { enabled: true, host: '', port: 6800, secret: '' };
+    mocks.store.aiConfigs = [{ id: 'ai-config', name: 'Test AI', baseUrl: 'https://example.com/v1', apiKey: 'k', model: 'm' }];
+    mocks.store.activeAIConfig = 'ai-config';
+    // abort 感知 mock：真实 fetch 在 signal 中止时会以 AbortError 拒绝
+    let resolveSummary!: (value: string) => void;
+    mocks.analyzeReleaseSummary.mockImplementation((_b: string, _m: unknown, signal: AbortSignal) =>
+      new Promise<string>((resolve, reject) => {
+        resolveSummary = (value: string) => {
+          if (signal.aborted) {
+            const abortError = new Error('Aborted');
+            abortError.name = 'AbortError';
+            reject(abortError);
+          } else {
+            resolve(value);
+          }
+        };
+      }));
+    mocks.sendToRpcDownload.mockResolvedValue({ success: true });
+    const { result } = renderHook(() => useRepositoryReleaseSheet(repository));
+
+    const sheetRelease: Release = {
+      id: rawRelease.id,
+      tag_name: rawRelease.tag_name,
+      name: rawRelease.name,
+      body: rawRelease.body,
+      published_at: rawRelease.published_at,
+      html_url: rawRelease.html_url,
+      assets: [],
+      prerelease: false,
+      repository: { id: repository.id, full_name: repository.full_name, name: repository.name },
+    };
+
+    let pending!: Promise<void>;
+    act(() => {
+      pending = result.current.generateSummary(sheetRelease);
+    });
+    // RPC 状态更新会换掉 artifactActions 对象引用；总结请求不得被取消 effect 误中止
+    await act(async () => {
+      await result.current.sendAssetToRpc({
+        id: 'asset-4',
+        name: 'a.zip',
+        url: 'https://github.com/owner/repo/releases/download/v1/a.zip',
+        size: 1,
+        isSourceCode: false,
+        updatedAt: '2026-01-03T00:00:00.000Z',
+      });
+    });
+    resolveSummary('# Summary');
+    await act(async () => { await pending; });
+
+    expect(result.current.summaries[sheetRelease.id]).toEqual({ status: 'done', content: '# Summary' });
   });
 });

--- a/src/features/repositories/hooks/useRepositoryReleaseSheet.ts
+++ b/src/features/repositories/hooks/useRepositoryReleaseSheet.ts
@@ -121,10 +121,10 @@ export const useRepositoryReleaseSheet = (repository: Repository) => {
   // RPC 发送与 AI 总结动作委托共享 hook（避免第三份拷贝）；summaries/downloadStates
   // 的对外形状由 hook 供给，downloadStates 的 key 已版本化为 computeRpcDownloadKey(link)。
   const artifactActions = useReleaseArtifactActions();
-  // cancelSummaryRequests 是共享 hook 内零依赖的稳定 useCallback——取消 effect 只能
-  // 挂它而不是整个 artifactActions 对象（后者随 summaries/RPC 状态更新换引用，
-  // 若挂进依赖，每次状态更新都会触发 cleanup 自我中止进行中的请求）。
-  const { cancelSummaryRequests } = artifactActions;
+  // 共享 hook 返回的 artifactActions 对象随 summaries/RPC 状态更新换引用——依赖只能
+  // 挂它解构出的引用稳定成员（useCallback 零依赖或仅依赖 store 值），否则每次状态
+  // 更新都会连带换 cancel effect / loadReleases / sendAssetToRpc 的身份。
+  const { cancelSummaryRequests, reset: resetArtifactStates, sendRpcDownload } = artifactActions;
   const [releases, setReleases] = useState<Release[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -166,7 +166,7 @@ export const useRepositoryReleaseSheet = (repository: Repository) => {
     setIsLoading(true);
     setError(null);
     setBrowserDownloadStates({});
-    artifactActions.reset();
+    resetArtifactStates();
 
     try {
       const { owner, name } = getRepositoryCoordinates(repository.full_name);
@@ -213,13 +213,13 @@ export const useRepositoryReleaseSheet = (repository: Repository) => {
         setIsLoading(false);
       }
     }
-  }, [artifactActions, fetchAllPages, githubToken, repository, t]);
+  }, [resetArtifactStates, fetchAllPages, githubToken, repository, t]);
 
   const sendAssetToRpc = useCallback(async (link: ReleaseDownloadLink) => {
     // enabled 守卫留在 sheet：ReleaseCard 侧由按钮显隐承担（共享 hook 不重复判断）
     if (!rpcDownloadConfig.enabled) return;
-    await artifactActions.sendRpcDownload(link);
-  }, [artifactActions, rpcDownloadConfig.enabled]);
+    await sendRpcDownload(link);
+  }, [sendRpcDownload, rpcDownloadConfig.enabled]);
 
   const downloadAsset = useCallback(async (link: ReleaseDownloadLink) => {
     if (rpcDownloadConfig.enabled) {

--- a/src/features/repositories/hooks/useRepositoryReleaseSheet.ts
+++ b/src/features/repositories/hooks/useRepositoryReleaseSheet.ts
@@ -1,25 +1,16 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import type { AIConfig, Release, ReleaseAsset, Repository } from '../../../types';
+import type { Release, ReleaseAsset, Repository } from '../../../types';
 import { backend } from '../../../services/backendAdapter';
 import { GitHubApiService } from '../../../services/githubApi';
-import { sendToRpcDownload } from '../../../services/rpcDownloadService';
-import { AIService } from '../../../services/aiService';
 import { shouldBypassBackend } from '../../../services/routeMode';
 import { useAppStore } from '../../../store/useAppStore';
 import { useDialog } from '../../../hooks/useDialog';
+import { computeRpcDownloadKey, useReleaseArtifactActions } from '../../../hooks/useReleaseArtifactActions';
 import type { ReleaseDownloadLink } from '../../../utils/releaseDownloadLinks';
 
 const REMOTE_RELEASE_PAGE_SIZE = 100;
 const MAX_LIVE_RELEASES = 200;
-
-export type ReleaseSummaryState = {
-  status: 'idle' | 'loading' | 'done' | 'error';
-  content?: string;
-  error?: string;
-};
-
-type DownloadState = 'idle' | 'sending' | 'sent';
 
 const isAbortError = (error: unknown): boolean => (
   error instanceof DOMException && error.name === 'AbortError'
@@ -121,37 +112,29 @@ export const useRepositoryReleaseSheet = (repository: Repository) => {
     language,
     githubToken,
     rpcDownloadConfig,
-    backendApiSecret,
-    aiConfigs,
-    activeAIConfig,
   } = useAppStore(useShallow((state) => ({
     language: state.language,
     githubToken: state.githubToken,
     rpcDownloadConfig: state.rpcDownloadConfig,
-    backendApiSecret: state.backendApiSecret,
-    aiConfigs: state.aiConfigs,
-    activeAIConfig: state.activeAIConfig,
   })));
   const { toast } = useDialog();
+  // RPC 发送与 AI 总结动作委托共享 hook（避免第三份拷贝）；summaries/downloadStates
+  // 的对外形状由 hook 供给，downloadStates 的 key 已版本化为 computeRpcDownloadKey(link)。
+  const artifactActions = useReleaseArtifactActions();
   const [releases, setReleases] = useState<Release[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [summaries, setSummaries] = useState<Record<number, ReleaseSummaryState>>({});
-  const [downloadStates, setDownloadStates] = useState<Record<string, DownloadState>>({});
+  // 非 RPC（浏览器）下载路径的行内 sending 状态不属 RPC 委托范围，留在本 hook；
+  // 同样使用版本化 key，与 RPC 状态合并后对外暴露。
+  const [browserDownloadStates, setBrowserDownloadStates] = useState<Record<string, 'idle' | 'sending'>>({});
   const fetchAbortRef = useRef<AbortController | null>(null);
-  const summaryAbortRefs = useRef<Record<number, AbortController | undefined>>({});
-  const activeConfig = useMemo<AIConfig | undefined>(
-    () => aiConfigs.find((config) => config.id === activeAIConfig),
-    [activeAIConfig, aiConfigs],
-  );
   const t = useCallback((zh: string, en: string) => language === 'zh' ? zh : en, [language]);
 
   const cancelPendingRequests = useCallback(() => {
     fetchAbortRef.current?.abort();
     fetchAbortRef.current = null;
-    Object.values(summaryAbortRefs.current).forEach((controller) => controller?.abort());
-    summaryAbortRefs.current = {};
-  }, []);
+    artifactActions.cancelSummaryRequests();
+  }, [artifactActions]);
 
   useEffect(() => cancelPendingRequests, [cancelPendingRequests]);
 
@@ -178,8 +161,8 @@ export const useRepositoryReleaseSheet = (repository: Repository) => {
     fetchAbortRef.current = controller;
     setIsLoading(true);
     setError(null);
-    setSummaries({});
-    setDownloadStates({});
+    setBrowserDownloadStates({});
+    artifactActions.reset();
 
     try {
       const { owner, name } = getRepositoryCoordinates(repository.full_name);
@@ -226,27 +209,13 @@ export const useRepositoryReleaseSheet = (repository: Repository) => {
         setIsLoading(false);
       }
     }
-  }, [fetchAllPages, githubToken, repository, t]);
+  }, [artifactActions, fetchAllPages, githubToken, repository, t]);
 
   const sendAssetToRpc = useCallback(async (link: ReleaseDownloadLink) => {
-    if (!rpcDownloadConfig.enabled || downloadStates[link.url] === 'sending' || downloadStates[link.url] === 'sent') return;
-
-    setDownloadStates((previous) => ({ ...previous, [link.url]: 'sending' }));
-    try {
-      const result = await sendToRpcDownload(link.url, link.name, backendApiSecret || undefined);
-      if (!result.success) {
-        throw new Error(result.error || t('发送失败', 'Failed to send download'));
-      }
-      setDownloadStates((previous) => ({ ...previous, [link.url]: 'sent' }));
-      toast(t('已发送到远程下载器', 'Sent to remote downloader'), 'success');
-    } catch (downloadError) {
-      setDownloadStates((previous) => ({ ...previous, [link.url]: 'idle' }));
-      toast(
-        getErrorMessage(downloadError) || t('远程下载服务未运行，请检查配置', 'Remote download service is not running. Check its configuration.'),
-        'error',
-      );
-    }
-  }, [backendApiSecret, downloadStates, rpcDownloadConfig.enabled, t, toast]);
+    // enabled 守卫留在 sheet：ReleaseCard 侧由按钮显隐承担（共享 hook 不重复判断）
+    if (!rpcDownloadConfig.enabled) return;
+    await artifactActions.sendRpcDownload(link);
+  }, [artifactActions, rpcDownloadConfig.enabled]);
 
   const downloadAsset = useCallback(async (link: ReleaseDownloadLink) => {
     if (rpcDownloadConfig.enabled) {
@@ -254,8 +223,9 @@ export const useRepositoryReleaseSheet = (repository: Repository) => {
       return;
     }
 
-    if (downloadStates[link.url] === 'sending') return;
-    setDownloadStates((previous) => ({ ...previous, [link.url]: 'sending' }));
+    const downloadKey = computeRpcDownloadKey(link);
+    if (browserDownloadStates[downloadKey] === 'sending') return;
+    setBrowserDownloadStates((previous) => ({ ...previous, [downloadKey]: 'sending' }));
 
     try {
       let blob: Blob;
@@ -274,66 +244,28 @@ export const useRepositoryReleaseSheet = (repository: Repository) => {
         blob = await backend.downloadGitHubResource(link.authenticatedPath);
       } else {
         window.open(link.url, '_blank', 'noopener,noreferrer');
-        setDownloadStates((previous) => ({ ...previous, [link.url]: 'idle' }));
+        setBrowserDownloadStates((previous) => ({ ...previous, [downloadKey]: 'idle' }));
         return;
       }
       downloadBrowserBlob(blob, link.name);
-      setDownloadStates((previous) => ({ ...previous, [link.url]: 'idle' }));
+      setBrowserDownloadStates((previous) => ({ ...previous, [downloadKey]: 'idle' }));
     } catch (downloadError) {
-      setDownloadStates((previous) => ({ ...previous, [link.url]: 'idle' }));
+      setBrowserDownloadStates((previous) => ({ ...previous, [downloadKey]: 'idle' }));
       toast(`${t('下载失败', 'Download failed')}: ${getErrorMessage(downloadError)}`, 'error');
     }
-  }, [downloadStates, githubToken, rpcDownloadConfig.enabled, sendAssetToRpc, t, toast]);
+  }, [browserDownloadStates, githubToken, rpcDownloadConfig.enabled, sendAssetToRpc, t, toast]);
 
-  const generateSummary = useCallback(async (release: Release) => {
-    const existing = summaries[release.id];
-    if (existing?.status === 'loading' || (existing?.status === 'done' && existing.content)) return;
-
-    if (!activeConfig) {
-      const configMessage = t('请先在设置中配置 AI 服务。', 'Please configure AI service in Settings first.');
-      setSummaries((previous) => ({
-        ...previous,
-        [release.id]: { status: 'error', error: configMessage },
-      }));
-      return;
-    }
-
-    summaryAbortRefs.current[release.id]?.abort();
-    const controller = new AbortController();
-    summaryAbortRefs.current[release.id] = controller;
-    setSummaries((previous) => ({ ...previous, [release.id]: { status: 'loading' } }));
-
-    try {
-      const aiService = new AIService(activeConfig, language);
-      const content = await aiService.analyzeReleaseSummary(
-        release.body || '',
-        {
-          repoName: release.repository.full_name,
-          tagName: release.tag_name,
-          releaseName: release.name && release.name !== release.tag_name ? release.name : undefined,
-        },
-        controller.signal,
-      );
-      if (controller.signal.aborted) return;
-      setSummaries((previous) => ({ ...previous, [release.id]: { status: 'done', content } }));
-    } catch (summaryError) {
-      if (isAbortError(summaryError) || controller.signal.aborted) return;
-      const message = getErrorMessage(summaryError);
-      setSummaries((previous) => ({ ...previous, [release.id]: { status: 'error', error: message } }));
-      toast(t(`总结生成失败：${message}`, `Summary failed: ${message}`), 'error');
-    } finally {
-      if (summaryAbortRefs.current[release.id] === controller) {
-        delete summaryAbortRefs.current[release.id];
-      }
-    }
-  }, [activeConfig, language, summaries, t, toast]);
+  const generateSummary = artifactActions.generateSummary;
 
   return {
     releases,
     isLoading,
     error,
-    summaries,
-    downloadStates,
+    summaries: artifactActions.summaries,
+    downloadStates: useMemo(
+      () => ({ ...browserDownloadStates, ...artifactActions.rpcDownloadStates }),
+      [browserDownloadStates, artifactActions.rpcDownloadStates],
+    ),
     isRpcEnabled: rpcDownloadConfig.enabled,
     loadReleases,
     sendAssetToRpc,

--- a/src/features/repositories/hooks/useRepositoryReleaseSheet.ts
+++ b/src/features/repositories/hooks/useRepositoryReleaseSheet.ts
@@ -121,6 +121,10 @@ export const useRepositoryReleaseSheet = (repository: Repository) => {
   // RPC 发送与 AI 总结动作委托共享 hook（避免第三份拷贝）；summaries/downloadStates
   // 的对外形状由 hook 供给，downloadStates 的 key 已版本化为 computeRpcDownloadKey(link)。
   const artifactActions = useReleaseArtifactActions();
+  // cancelSummaryRequests 是共享 hook 内零依赖的稳定 useCallback——取消 effect 只能
+  // 挂它而不是整个 artifactActions 对象（后者随 summaries/RPC 状态更新换引用，
+  // 若挂进依赖，每次状态更新都会触发 cleanup 自我中止进行中的请求）。
+  const { cancelSummaryRequests } = artifactActions;
   const [releases, setReleases] = useState<Release[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -133,8 +137,8 @@ export const useRepositoryReleaseSheet = (repository: Repository) => {
   const cancelPendingRequests = useCallback(() => {
     fetchAbortRef.current?.abort();
     fetchAbortRef.current = null;
-    artifactActions.cancelSummaryRequests();
-  }, [artifactActions]);
+    cancelSummaryRequests();
+  }, [cancelSummaryRequests]);
 
   useEffect(() => cancelPendingRequests, [cancelPendingRequests]);
 

--- a/src/features/repositories/hooks/useSearchActions.test.tsx
+++ b/src/features/repositories/hooks/useSearchActions.test.tsx
@@ -127,16 +127,23 @@ const createStoreState = () => ({
 
 let storeState = createStoreState();
 const mockUseAppStore = vi.mocked(mocks.useAppStore);
-mockUseAppStore.mockImplementation((selector?: (state: typeof storeState) => unknown) =>
-  selector ? selector(storeState) : storeState);
-(mockUseAppStore as unknown as { getState: () => typeof storeState }).getState = () => storeState;
 
 const identity = <T,>(repos: T[]): T[] => repos;
 
+// resetAllMocks 会连同 useAppStore 的 mockImplementation 一起清掉，每次重建。
+// 用 resetAllMocks 而非 clearAllMocks：后者不清实现，mockRejectedValue 等会
+// 泄漏进后续用例，形成用例顺序依赖。
+const setupStoreMocks = () => {
+  storeState = createStoreState();
+  mockUseAppStore.mockImplementation((selector?: (state: typeof storeState) => unknown) =>
+    selector ? selector(storeState) : storeState);
+  (mockUseAppStore as unknown as { getState: () => typeof storeState }).getState = () => storeState;
+};
+
 describe('useSearchActions.aiSearch (vector hit)', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    storeState = createStoreState();
+    vi.resetAllMocks();
+    setupStoreMocks();
   });
 
   it('queries with default topK 30 / threshold 0.35, boosts scores and sets the skip ref', async () => {
@@ -268,8 +275,8 @@ describe('useSearchActions.aiSearch (vector hit)', () => {
 
 describe('useSearchActions.keywordSearch', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    storeState = createStoreState();
+    vi.resetAllMocks();
+    setupStoreMocks();
   });
 
   it('falls back to basic text search when AI reranking fails and vector search found nothing', async () => {
@@ -316,8 +323,8 @@ describe('useSearchActions.keywordSearch', () => {
 
 describe('useSearchActions.syncStars', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    storeState = createStoreState();
+    vi.resetAllMocks();
+    setupStoreMocks();
   });
 
   it('keeps the setRepositories → forceSyncToBackend → setLastSync order and applies lists', async () => {

--- a/src/features/repositories/hooks/useSearchActions.test.tsx
+++ b/src/features/repositories/hooks/useSearchActions.test.tsx
@@ -1,0 +1,482 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Category, Repository, VectorSearchConfig } from '../../../types';
+import {
+  applyListsToRepositories,
+  buildSearchPatch,
+  mergeStarredRepositories,
+  planListCategories,
+  useSearchActions,
+} from './useSearchActions';
+
+const mocks = vi.hoisted(() => ({
+  useAppStore: vi.fn(),
+  toast: vi.fn(),
+  embed: vi.fn(),
+  vectorQuery: vi.fn(),
+  generateHyDEQuery: vi.fn(),
+  searchRepositoriesWithSemanticReranking: vi.fn(),
+  searchRepositoriesWithReranking: vi.fn(),
+  getAllStarredRepositories: vi.fn(),
+  getUserLists: vi.fn(),
+  forceSyncToBackend: vi.fn(),
+}));
+
+vi.mock('../../../store/useAppStore', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../store/useAppStore')>();
+  return { ...actual, useAppStore: mocks.useAppStore };
+});
+
+vi.mock('../../../hooks/useDialog', () => ({
+  useDialog: () => ({ toast: mocks.toast, confirm: vi.fn() }),
+}));
+
+vi.mock('../../../services/vectorSearchService', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../services/vectorSearchService')>();
+  return {
+    ...actual,
+    EmbeddingClient: class {
+      embed = mocks.embed;
+    },
+    VectorSearchService: class {
+      query = mocks.vectorQuery;
+    },
+  };
+});
+
+vi.mock('../../../services/aiService', () => ({
+  AIService: class {
+    generateHyDEQuery = mocks.generateHyDEQuery;
+    searchRepositoriesWithSemanticReranking = mocks.searchRepositoriesWithSemanticReranking;
+    searchRepositoriesWithReranking = mocks.searchRepositoriesWithReranking;
+  },
+}));
+
+vi.mock('../../../services/githubApi', () => ({
+  GitHubApiService: class {
+    getAllStarredRepositories = mocks.getAllStarredRepositories;
+  },
+}));
+
+vi.mock('../../../services/githubApiFactory', () => ({
+  createGitHubListsApiService: () => ({
+    getUserLists: mocks.getUserLists,
+  }),
+}));
+
+vi.mock('../../../services/autoSync', () => ({
+  forceSyncToBackend: mocks.forceSyncToBackend,
+}));
+
+const baseRepo = (overrides: Partial<Repository> & { id: number; full_name: string }): Repository => ({
+  name: overrides.full_name.split('/')[1] ?? 'repo',
+  description: '',
+  html_url: `https://github.com/${overrides.full_name}`,
+  stargazers_count: 1,
+  forks_count: 0,
+  forks: 0,
+  language: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-02T00:00:00.000Z',
+  pushed_at: '2026-01-03T00:00:00.000Z',
+  owner: { login: 'owner', avatar_url: 'https://example.com/a.png' },
+  topics: [],
+  ...overrides,
+});
+
+const createStoreState = () => ({
+  repositories: [] as Repository[],
+  aiConfigs: [{
+    id: 'ai-config',
+    name: 'Test AI',
+    baseUrl: 'https://example.com/v1',
+    apiKey: 'ai-key',
+    model: 'ai-model',
+  }],
+  activeAIConfig: 'ai-config',
+  language: 'zh' as const,
+  setSearchFilters: vi.fn(),
+  setSearchResults: vi.fn(),
+  githubToken: 'github-token' as string | null,
+  setRepositories: vi.fn(),
+  setLastSync: vi.fn(),
+  setSyncingStars: vi.fn(),
+  syncMode: 'stars-only' as const,
+  user: { login: 'me' } as { login: string } | null,
+  addCustomCategory: vi.fn(),
+  customCategories: [] as Category[],
+  hiddenDefaultCategoryIds: [] as string[],
+  defaultCategoryOverrides: {},
+  vectorSearchConfig: {
+    enabled: false,
+    workerUrl: '',
+    authToken: '',
+    embeddingConfigId: 'emb',
+    indexMode: 'description' as const,
+    readmeMaxChars: 6000,
+  } as VectorSearchConfig,
+  embeddingConfigs: [{
+    id: 'emb',
+    name: 'Test embedding',
+    apiType: 'openai-compatible' as const,
+    baseUrl: 'https://example.com/v1',
+    apiKey: 'emb-key',
+    model: 'emb-model',
+  }],
+});
+
+let storeState = createStoreState();
+const mockUseAppStore = vi.mocked(mocks.useAppStore);
+mockUseAppStore.mockImplementation((selector?: (state: typeof storeState) => unknown) =>
+  selector ? selector(storeState) : storeState);
+(mockUseAppStore as unknown as { getState: () => typeof storeState }).getState = () => storeState;
+
+const identity = <T,>(repos: T[]): T[] => repos;
+
+describe('useSearchActions.aiSearch (vector hit)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeState = createStoreState();
+  });
+
+  it('queries with default topK 30 / threshold 0.35, boosts scores and sets the skip ref', async () => {
+    storeState.vectorSearchConfig = {
+      enabled: true,
+      workerUrl: 'https://worker.example',
+      authToken: 'worker-token',
+      embeddingConfigId: 'emb',
+      indexMode: 'description',
+      readmeMaxChars: 6000,
+      enableHyDE: false,
+      enableReranking: false,
+    };
+    storeState.repositories = [
+      baseRepo({ id: 1, full_name: 'owner/foo-bar' }),
+      baseRepo({ id: 2, full_name: 'owner/other', description: 'has foo inside' }),
+      baseRepo({ id: 3, full_name: 'owner/tagged', topics: [] }),
+    ];
+    // 预置与 list 同名的本地分类，使本用例不触发新建分类分支
+    storeState.customCategories = [{ id: 'custom-1', name: 'MyList', icon: 'x', isCustom: true, keywords: [] }];
+    mocks.embed.mockResolvedValue([[0.1, 0.2]]);
+    mocks.vectorQuery.mockResolvedValue([
+      { id: '1', score: 0.9, metadata: { full_name: 'owner/foo-bar', description: '', tags: [] } },
+      { id: '2', score: 0.8, metadata: { full_name: '', description: 'the foo thing', tags: [] } },
+      { id: '3', score: 0.7, metadata: { full_name: '', description: '', tags: ['FOO'] } },
+    ]);
+
+    const { result } = renderHook(() => useSearchActions());
+    await act(async () => { await result.current.aiSearch('foo', identity); });
+
+    expect(mocks.vectorQuery).toHaveBeenCalledWith([0.1, 0.2], { topK: 30, threshold: 0.35 });
+    expect(result.current.vectorScoreMapRef.current).toEqual({
+      query: 'foo',
+      scores: new Map([['1', 0.9 + 0.05], ['2', 0.8 + 0.03], ['3', 0.7 + 0.02]]),
+    });
+    expect(result.current.skipNextTextSearchRef.current).toBe(true);
+    // 加分后按分数降序：3(0.72+0.02=0.74)? —— 见下：tag 加分 0.02 → 0.72
+    expect(storeState.setSearchResults).toHaveBeenCalledWith([
+      storeState.repositories[0],
+      storeState.repositories[1],
+      storeState.repositories[2],
+    ]);
+    expect(storeState.setSearchFilters).toHaveBeenCalledWith({ query: 'foo' });
+    expect(mocks.toast).not.toHaveBeenCalled();
+    expect(result.current.isSearching).toBe(false);
+  });
+
+  it('falls back to vector order without a toast when AI reranking fails', async () => {
+    storeState.vectorSearchConfig = {
+      enabled: true,
+      workerUrl: 'https://worker.example',
+      authToken: 'worker-token',
+      embeddingConfigId: 'emb',
+      indexMode: 'description',
+      readmeMaxChars: 6000,
+      enableHyDE: false,
+    };
+    storeState.repositories = [
+      baseRepo({ id: 1, full_name: 'owner/aaa' }),
+      baseRepo({ id: 2, full_name: 'owner/bbb' }),
+    ];
+    mocks.embed.mockResolvedValue([[0.1]]);
+    mocks.vectorQuery.mockResolvedValue([
+      { id: '1', score: 0.9, metadata: { full_name: '', description: '', tags: [] } },
+      { id: '2', score: 0.8, metadata: { full_name: '', description: '', tags: [] } },
+    ]);
+    mocks.searchRepositoriesWithSemanticReranking.mockRejectedValue(new Error('rerank down'));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useSearchActions());
+    await act(async () => { await result.current.aiSearch('anything', identity); });
+    warnSpy.mockRestore();
+
+    expect(mocks.searchRepositoriesWithSemanticReranking).toHaveBeenCalledTimes(1);
+    expect(mocks.toast).not.toHaveBeenCalled();
+    expect(storeState.setSearchResults).toHaveBeenCalledWith([
+      storeState.repositories[0],
+      storeState.repositories[1],
+    ]);
+  });
+
+  it('falls back to the raw query when HyDE misses the 5s budget', async () => {
+    vi.useFakeTimers();
+    try {
+      storeState.vectorSearchConfig = {
+        enabled: true,
+        workerUrl: 'https://worker.example',
+        authToken: 'worker-token',
+        embeddingConfigId: 'emb',
+        indexMode: 'description',
+        readmeMaxChars: 6000,
+      };
+      mocks.generateHyDEQuery.mockImplementation(() => new Promise<string>(() => undefined));
+      mocks.embed.mockResolvedValue([[0.1]]);
+      mocks.vectorQuery.mockResolvedValue([]);
+      mocks.searchRepositoriesWithReranking.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useSearchActions());
+      let promise!: Promise<void>;
+      act(() => { promise = result.current.aiSearch('foo', identity); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(5100); });
+      await act(async () => { await promise; });
+
+      expect(mocks.embed).toHaveBeenCalledWith(['foo'], 'query');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('uses the HyDE output when it resolves within the budget', async () => {
+    storeState.vectorSearchConfig = {
+      enabled: true,
+      workerUrl: 'https://worker.example',
+      authToken: 'worker-token',
+      embeddingConfigId: 'emb',
+      indexMode: 'description',
+      readmeMaxChars: 6000,
+    };
+    mocks.generateHyDEQuery.mockResolvedValue('an ideal description of foo');
+    mocks.embed.mockResolvedValue([[0.1]]);
+    mocks.vectorQuery.mockResolvedValue([]);
+    mocks.searchRepositoriesWithReranking.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useSearchActions());
+    await act(async () => { await result.current.aiSearch('foo', identity); });
+    expect(mocks.embed).toHaveBeenCalledWith(['an ideal description of foo'], 'query');
+  });
+});
+
+describe('useSearchActions.keywordSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeState = createStoreState();
+  });
+
+  it('falls back to basic text search when AI reranking fails and vector search found nothing', async () => {
+    storeState.vectorSearchConfig = {
+      enabled: true,
+      workerUrl: 'https://worker.example',
+      authToken: 'worker-token',
+      embeddingConfigId: 'emb',
+      indexMode: 'description',
+      readmeMaxChars: 6000,
+      enableHyDE: false,
+    };
+    storeState.repositories = [
+      baseRepo({ id: 1, full_name: 'owner/foo-repo' }),
+      baseRepo({ id: 2, full_name: 'owner/bar-repo' }),
+    ];
+    mocks.embed.mockResolvedValue([[0.1]]);
+    mocks.vectorQuery.mockResolvedValue([]);
+    mocks.searchRepositoriesWithReranking.mockRejectedValue(new Error('ai down'));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useSearchActions());
+    await act(async () => { await result.current.aiSearch('foo', identity); });
+    warnSpy.mockRestore();
+
+    expect(mocks.searchRepositoriesWithReranking).toHaveBeenCalledTimes(1);
+    expect(storeState.setSearchResults).toHaveBeenCalledWith([storeState.repositories[0]]);
+    expect(storeState.setSearchFilters).toHaveBeenCalledWith({ query: 'foo' });
+  });
+
+  it('uses basic text search directly when no AI config exists', async () => {
+    storeState.aiConfigs = [];
+    storeState.repositories = [
+      baseRepo({ id: 1, full_name: 'owner/foo-repo' }),
+      baseRepo({ id: 2, full_name: 'owner/bar-repo' }),
+    ];
+    const { result } = renderHook(() => useSearchActions());
+    await act(async () => { await result.current.keywordSearch('foo', identity); });
+
+    expect(mocks.searchRepositoriesWithReranking).not.toHaveBeenCalled();
+    expect(storeState.setSearchResults).toHaveBeenCalledWith([storeState.repositories[0]]);
+  });
+});
+
+describe('useSearchActions.syncStars', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeState = createStoreState();
+  });
+
+  it('keeps the setRepositories → forceSyncToBackend → setLastSync order and applies lists', async () => {
+    mocks.getAllStarredRepositories.mockResolvedValue([
+      baseRepo({ id: 1, full_name: 'owner/repo-one' }),
+    ]);
+    mocks.getUserLists.mockResolvedValue([{ id: 'l1', name: 'MyList', isPrivate: false, items: ['owner/repo-one'] }]);
+    storeState.repositories = [baseRepo({ id: 1, full_name: 'owner/repo-one' })];
+    // 预置与 list 同名的本地分类，使本用例不触发新建分类分支
+    storeState.customCategories = [{ id: 'custom-1', name: 'MyList', icon: 'x', isCustom: true, keywords: [] }];
+
+    const { result } = renderHook(() => useSearchActions());
+    await act(async () => { await result.current.syncStars('stars-and-lists'); });
+
+    expect(storeState.setRepositories).toHaveBeenCalledTimes(1);
+    const written = storeState.setRepositories.mock.calls[0][0] as Repository[];
+    expect(written[0].custom_tags).toContain('MyList');
+    // list 名命中同名本地分类 → 设分类并加锁
+    expect(written[0].custom_category).toBe('MyList');
+    expect(written[0].category_locked).toBe(true);
+    expect(written[0].last_edited).toEqual(expect.any(String));
+
+    const setOrder = storeState.setRepositories.mock.invocationCallOrder[0];
+    const syncOrder = mocks.forceSyncToBackend.mock.invocationCallOrder[0];
+    const lastSyncOrder = storeState.setLastSync.mock.invocationCallOrder[0];
+    expect(setOrder).toBeLessThan(syncOrder);
+    expect(syncOrder).toBeLessThan(lastSyncOrder);
+
+    expect(mocks.toast).toHaveBeenCalledWith(
+      '已同步 1 个 list，并应用到 1 个未锁定仓库：MyList(1)',
+      'info',
+    );
+    expect(mocks.toast).toHaveBeenCalledWith('同步完成！所有仓库都是最新的。', 'info');
+    expect(storeState.setSyncingStars).toHaveBeenCalledWith(true);
+    expect(storeState.setSyncingStars).toHaveBeenLastCalledWith(false);
+  });
+
+  it('creates missing categories for cloud lists', async () => {
+    mocks.getAllStarredRepositories.mockResolvedValue([baseRepo({ id: 1, full_name: 'owner/repo-one' })]);
+    mocks.getUserLists.mockResolvedValue([{ id: 'l1', name: 'BrandNewList', isPrivate: false, items: ['owner/repo-one'] }]);
+    storeState.repositories = [baseRepo({ id: 1, full_name: 'owner/repo-one' })];
+
+    const { result } = renderHook(() => useSearchActions());
+    await act(async () => { await result.current.syncStars('stars-and-lists'); });
+
+    expect(storeState.addCustomCategory).toHaveBeenCalledTimes(1);
+    const created = storeState.addCustomCategory.mock.calls[0][0];
+    expect(created.name).toBe('BrandNewList');
+    expect(created.id).toMatch(/^custom-sync-\d+-0$/);
+    expect(created.isCustom).toBe(true);
+    expect(mocks.toast).toHaveBeenCalledWith(
+      '已同步 1 个 list，并应用到 1 个未锁定仓库：BrandNewList(1)（新建 1 个分类）',
+      'info',
+    );
+  });
+
+  it('keeps the starred sync result when the list sync fails', async () => {
+    mocks.getAllStarredRepositories.mockResolvedValue([baseRepo({ id: 1, full_name: 'owner/repo-one' })]);
+    mocks.getUserLists.mockRejectedValue(new Error('lists unavailable'));
+    storeState.repositories = [baseRepo({ id: 1, full_name: 'owner/repo-one' })];
+
+    const { result } = renderHook(() => useSearchActions());
+    await act(async () => { await result.current.syncStars('stars-and-lists'); });
+
+    expect(mocks.toast).toHaveBeenCalledWith(
+      'List 同步失败，星标仓库已同步。请稍后重试，或检查 GitHub Token 权限（需 user scope）。',
+      'error',
+    );
+    expect(storeState.setRepositories).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 1, full_name: 'owner/repo-one' }),
+    ]);
+    expect(mocks.forceSyncToBackend).toHaveBeenCalledTimes(1);
+    expect(mocks.toast).toHaveBeenCalledWith('同步完成！所有仓库都是最新的。', 'info');
+  });
+
+  it('shows the token-expired message when the sync error mentions token', async () => {
+    mocks.getAllStarredRepositories.mockRejectedValue(new Error('Bad credentials: token expired'));
+    const { result } = renderHook(() => useSearchActions());
+    await act(async () => { await result.current.syncStars(); });
+
+    expect(mocks.toast).toHaveBeenCalledWith('GitHub token 已过期或无效，请重新登录。', 'error');
+    expect(storeState.setRepositories).not.toHaveBeenCalled();
+  });
+
+  it('toasts the token-missing message before doing anything', async () => {
+    storeState.githubToken = null;
+    const { result } = renderHook(() => useSearchActions());
+    await act(async () => { await result.current.syncStars(); });
+    expect(mocks.toast).toHaveBeenCalledWith('GitHub token 未找到，请重新登录。', 'error');
+    expect(mocks.getAllStarredRepositories).not.toHaveBeenCalled();
+    expect(storeState.setSyncingStars).not.toHaveBeenCalled();
+  });
+});
+
+describe('useSearchActions pure helpers', () => {
+  it('buildSearchPatch applies name/desc/tag boosts', () => {
+    const scores = buildSearchPatch('foo', [
+      { id: '1', score: 0.9, metadata: { full_name: 'x/foo', description: '', language: '', stars: 0, tags: [] } },
+      { id: '2', score: 0.8, metadata: { full_name: '', description: 'a foo b', language: '', stars: 0, tags: [] } },
+      { id: '3', score: 0.7, metadata: { full_name: '', description: '', language: '', stars: 0, tags: ['FOO'] } },
+      { id: '4', score: 0.6, metadata: { full_name: '', description: '', language: '', stars: 0, tags: [] } },
+    ]);
+    expect(scores.get('1')).toBe(0.9 + 0.05);
+    expect(scores.get('2')).toBe(0.8 + 0.03);
+    expect(scores.get('3')).toBe(0.7 + 0.02);
+    expect(scores.get('4')).toBe(0.6);
+  });
+
+  it('mergeStarredRepositories overwrites syncable fields and backfills license null', () => {
+    const storeRepos = [
+      baseRepo({ id: 1, full_name: 'owner/one', description: 'old', license: 'MIT', custom_tags: ['keep'] }),
+      baseRepo({ id: 2, full_name: 'owner/two' }),
+    ];
+    const newRepos = [
+      baseRepo({ id: 1, full_name: 'owner/one', description: 'new', stargazers_count: 99, license: undefined }),
+      baseRepo({ id: 3, full_name: 'owner/three' }),
+    ];
+    const merged = mergeStarredRepositories(newRepos, storeRepos);
+    expect(merged).toHaveLength(2);
+    expect(merged[0]).toMatchObject({ id: 1, description: 'new', stargazers_count: 99, custom_tags: ['keep'], license: null });
+    expect(merged[1]).toMatchObject({ id: 3 });
+  });
+
+  it('planListCategories skips reserved names and existing categories', () => {
+    const { toCreate, categoryByLowerName } = planListCategories(
+      [
+        { id: 'l1', name: 'fresh', isPrivate: false, items: [] },
+        { id: 'l2', name: 'none', isPrivate: false, items: [] },
+        { id: 'l3', name: 'existing', isPrivate: false, items: [] },
+      ],
+      [{ id: 'c1', name: 'Existing', icon: '', isCustom: false, keywords: [] }],
+      (idx) => `custom-sync-123-${idx}`,
+    );
+    expect(toCreate).toEqual([
+      { id: 'custom-sync-123-0', name: 'fresh', icon: ' 📋', isCustom: true, keywords: [] },
+    ]);
+    expect(categoryByLowerName.get('fresh')).toBe('fresh');
+    expect(categoryByLowerName.get('existing')).toBe('Existing');
+    expect(categoryByLowerName.has('none')).toBe(false);
+  });
+
+  it('applyListsToRepositories tags, locks by category and respects pre-existing locks', () => {
+    const categoryByLowerName = new Map([['web apps', 'Web Apps']]);
+    const repositories = [
+      baseRepo({ id: 1, full_name: 'owner/locked-early', category_locked: true, custom_category: 'Web Apps' }),
+      baseRepo({ id: 2, full_name: 'owner/normal' }),
+    ];
+    const lists = [
+      { id: 'l1', name: 'Web Apps', isPrivate: false, items: ['owner/locked-early', 'owner/normal'] },
+      { id: 'l2', name: 'Second List', isPrivate: false, items: ['owner/normal'] },
+    ];
+    const { repositories: mapped, appliedTagsCount } = applyListsToRepositories(repositories, lists, categoryByLowerName);
+
+    // 预存在锁定：仅追加标签，不改分类/锁定
+    expect(mapped[0]).toMatchObject({ custom_tags: ['Web Apps'], custom_category: 'Web Apps', category_locked: true });
+    expect(mapped[0].last_edited).toBeUndefined();
+    // 正常仓库：第一个 list 命中分类 → 设分类并加锁；第二个 list 时仓库已被锁定 → 仅追加标签
+    expect(mapped[1]).toMatchObject({ custom_tags: ['Web Apps', 'Second List'], custom_category: 'Web Apps', category_locked: true });
+    expect(mapped[1].last_edited).toEqual(expect.any(String));
+    expect(appliedTagsCount).toEqual({ 'Web Apps': 2, 'Second List': 1 });
+  });
+});

--- a/src/features/repositories/hooks/useSearchActions.test.tsx
+++ b/src/features/repositories/hooks/useSearchActions.test.tsx
@@ -101,7 +101,7 @@ const createStoreState = () => ({
   setRepositories: vi.fn(),
   setLastSync: vi.fn(),
   setSyncingStars: vi.fn(),
-  syncMode: 'stars-only' as const,
+  syncMode: 'stars-only' as 'stars-only' | 'stars-and-lists',
   user: { login: 'me' } as { login: string } | null,
   addCustomCategory: vi.fn(),
   customCategories: [] as Category[],
@@ -225,7 +225,7 @@ describe('useSearchActions.aiSearch (vector hit)', () => {
     ]);
   });
 
-  it('falls back to the raw query when HyDE misses the 5s budget', async () => {
+  it('falls back to the raw query when HyDE misses the 5s budget and aborts the HyDE request', async () => {
     vi.useFakeTimers();
     try {
       storeState.vectorSearchConfig = {
@@ -235,8 +235,14 @@ describe('useSearchActions.aiSearch (vector hit)', () => {
         embeddingConfigId: 'emb',
         indexMode: 'description',
         readmeMaxChars: 6000,
+        enableHyDE: true,
+        enableReranking: false,
       };
-      mocks.generateHyDEQuery.mockImplementation(() => new Promise<string>(() => undefined));
+      const hydeSignals: AbortSignal[] = [];
+      mocks.generateHyDEQuery.mockImplementation((_q: string, signal: AbortSignal) => {
+        hydeSignals.push(signal);
+        return new Promise<string>(() => undefined);
+      });
       mocks.embed.mockResolvedValue([[0.1]]);
       mocks.vectorQuery.mockResolvedValue([]);
       mocks.searchRepositoriesWithReranking.mockResolvedValue([]);
@@ -248,9 +254,105 @@ describe('useSearchActions.aiSearch (vector hit)', () => {
       await act(async () => { await promise; });
 
       expect(mocks.embed).toHaveBeenCalledWith(['foo'], 'query');
+      // 5s 预算耗尽后 HyDE 局部 controller 必须真正 abort 掉挂起的请求
+      expect(hydeSignals[0]?.aborted).toBe(true);
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('returns early for a blank query without touching search state', async () => {
+    const { result } = renderHook(() => useSearchActions());
+    await act(async () => { await result.current.aiSearch('   ', identity); });
+    expect(mocks.embed).not.toHaveBeenCalled();
+    expect(mocks.searchRepositoriesWithReranking).not.toHaveBeenCalled();
+    expect(storeState.setSearchResults).not.toHaveBeenCalled();
+    expect(storeState.setSearchFilters).not.toHaveBeenCalled();
+    expect(result.current.isSearching).toBe(false);
+    expect(result.current.skipNextTextSearchRef.current).toBe(false);
+  });
+
+  it('falls through to keyword search when the embedding returns no vectors', async () => {
+    storeState.vectorSearchConfig = {
+      enabled: true,
+      workerUrl: 'https://worker.example',
+      authToken: 'worker-token',
+      embeddingConfigId: 'emb',
+      indexMode: 'description',
+      readmeMaxChars: 6000,
+      enableHyDE: false,
+      enableReranking: false,
+    };
+    storeState.repositories = [
+      baseRepo({ id: 1, full_name: 'owner/foo-repo' }),
+      baseRepo({ id: 2, full_name: 'owner/bar-repo' }),
+    ];
+    mocks.embed.mockResolvedValue([]);
+    mocks.searchRepositoriesWithReranking.mockResolvedValue([storeState.repositories[0]]);
+
+    const { result } = renderHook(() => useSearchActions());
+    await act(async () => { await result.current.aiSearch('foo', identity); });
+
+    expect(mocks.vectorQuery).not.toHaveBeenCalled();
+    expect(storeState.setSearchResults).toHaveBeenCalledWith([storeState.repositories[0]]);
+    expect(storeState.setSearchFilters).toHaveBeenCalledWith({ query: 'foo' });
+  });
+
+  it('falls through to keyword search when vector hits match no local repository', async () => {
+    storeState.vectorSearchConfig = {
+      enabled: true,
+      workerUrl: 'https://worker.example',
+      authToken: 'worker-token',
+      embeddingConfigId: 'emb',
+      indexMode: 'description',
+      readmeMaxChars: 6000,
+      enableHyDE: false,
+      enableReranking: false,
+    };
+    storeState.repositories = [
+      baseRepo({ id: 1, full_name: 'owner/foo-repo' }),
+      baseRepo({ id: 2, full_name: 'owner/bar-repo' }),
+    ];
+    mocks.embed.mockResolvedValue([[0.1]]);
+    mocks.vectorQuery.mockResolvedValue([
+      { id: '99', score: 0.9, metadata: { full_name: '', description: '', tags: [] } },
+    ]);
+    mocks.searchRepositoriesWithReranking.mockResolvedValue([storeState.repositories[0]]);
+
+    const { result } = renderHook(() => useSearchActions());
+    await act(async () => { await result.current.aiSearch('foo', identity); });
+
+    expect(result.current.skipNextTextSearchRef.current).toBe(false);
+    expect(storeState.setSearchResults).toHaveBeenCalledWith([storeState.repositories[0]]);
+    expect(storeState.setSearchFilters).toHaveBeenCalledWith({ query: 'foo' });
+  });
+
+  it('falls back to keyword search when the vector pipeline throws', async () => {
+    storeState.vectorSearchConfig = {
+      enabled: true,
+      workerUrl: 'https://worker.example',
+      authToken: 'worker-token',
+      embeddingConfigId: 'emb',
+      indexMode: 'description',
+      readmeMaxChars: 6000,
+      enableHyDE: false,
+      enableReranking: false,
+    };
+    storeState.repositories = [
+      baseRepo({ id: 1, full_name: 'owner/foo-repo' }),
+      baseRepo({ id: 2, full_name: 'owner/bar-repo' }),
+    ];
+    mocks.embed.mockRejectedValue(new Error('embed down'));
+    mocks.searchRepositoriesWithReranking.mockResolvedValue([storeState.repositories[0]]);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useSearchActions());
+    await act(async () => { await result.current.aiSearch('foo', identity); });
+    warnSpy.mockRestore();
+
+    expect(storeState.setSearchResults).toHaveBeenCalledWith([storeState.repositories[0]]);
+    expect(storeState.setSearchFilters).toHaveBeenCalledWith({ query: 'foo' });
+    expect(result.current.isSearching).toBe(false);
   });
 
   it('uses the HyDE output when it resolves within the budget', async () => {
@@ -261,6 +363,8 @@ describe('useSearchActions.aiSearch (vector hit)', () => {
       embeddingConfigId: 'emb',
       indexMode: 'description',
       readmeMaxChars: 6000,
+      enableHyDE: true,
+      enableReranking: false,
     };
     mocks.generateHyDEQuery.mockResolvedValue('an ideal description of foo');
     mocks.embed.mockResolvedValue([[0.1]]);
@@ -398,6 +502,64 @@ describe('useSearchActions.syncStars', () => {
     ]);
     expect(mocks.forceSyncToBackend).toHaveBeenCalledTimes(1);
     expect(mocks.toast).toHaveBeenCalledWith('同步完成！所有仓库都是最新的。', 'info');
+  });
+
+  it('syncs lists when auto mode follows the stars-and-lists config', async () => {
+    mocks.getAllStarredRepositories.mockResolvedValue([baseRepo({ id: 1, full_name: 'owner/repo-one' })]);
+    mocks.getUserLists.mockResolvedValue([{ id: 'l1', name: 'MyList', isPrivate: false, items: ['owner/repo-one'] }]);
+    storeState.repositories = [baseRepo({ id: 1, full_name: 'owner/repo-one' })];
+    storeState.syncMode = 'stars-and-lists';
+    storeState.customCategories = [{ id: 'custom-1', name: 'MyList', icon: 'x', isCustom: true, keywords: [] }];
+
+    const { result } = renderHook(() => useSearchActions());
+    await act(async () => { await result.current.syncStars(); }); // mode 'auto'
+
+    expect(mocks.getUserLists).toHaveBeenCalledTimes(1);
+    const written = storeState.setRepositories.mock.calls[0][0] as Repository[];
+    expect(written[0].custom_tags).toContain('MyList');
+  });
+
+  it('keeps the starred result and toasts the list failure when the user login is missing', async () => {
+    mocks.getAllStarredRepositories.mockResolvedValue([baseRepo({ id: 1, full_name: 'owner/repo-one' })]);
+    storeState.user = null;
+
+    const { result } = renderHook(() => useSearchActions());
+    await act(async () => { await result.current.syncStars('stars-and-lists'); });
+
+    expect(mocks.getUserLists).not.toHaveBeenCalled();
+    expect(mocks.toast).toHaveBeenCalledWith(
+      'List 同步失败，星标仓库已同步。请稍后重试，或检查 GitHub Token 权限（需 user scope）。',
+      'error',
+    );
+    expect(storeState.setRepositories).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 1, full_name: 'owner/repo-one' }),
+    ]);
+    expect(mocks.forceSyncToBackend).toHaveBeenCalledTimes(1);
+  });
+
+  it('toasts the created-categories summary when no list item matches a local repo', async () => {
+    mocks.getAllStarredRepositories.mockResolvedValue([baseRepo({ id: 1, full_name: 'owner/repo-one' })]);
+    mocks.getUserLists.mockResolvedValue([{ id: 'l1', name: 'BrandNewList', isPrivate: false, items: [] }]);
+    storeState.repositories = [baseRepo({ id: 1, full_name: 'owner/repo-one' })];
+
+    const { result } = renderHook(() => useSearchActions());
+    await act(async () => { await result.current.syncStars('stars-and-lists'); });
+
+    expect(storeState.addCustomCategory).toHaveBeenCalledTimes(1);
+    expect(mocks.toast).toHaveBeenCalledWith('已同步 1 个 list（新建 1 个分类）。', 'info');
+  });
+
+  it('toasts the new-repositories count when the sync finds unseen repos', async () => {
+    storeState.repositories = [baseRepo({ id: 1, full_name: 'owner/repo-one' })];
+    mocks.getAllStarredRepositories.mockResolvedValue([
+      baseRepo({ id: 1, full_name: 'owner/repo-one' }),
+      baseRepo({ id: 2, full_name: 'owner/repo-two' }),
+    ]);
+
+    const { result } = renderHook(() => useSearchActions());
+    await act(async () => { await result.current.syncStars('stars-only'); });
+
+    expect(mocks.toast).toHaveBeenCalledWith('同步完成！发现 1 个新仓库。', 'success');
   });
 
   it('shows the token-expired message when the sync error mentions token', async () => {

--- a/src/features/repositories/hooks/useSearchActions.ts
+++ b/src/features/repositories/hooks/useSearchActions.ts
@@ -1,0 +1,537 @@
+import { useCallback, useMemo, useState, type MutableRefObject, useRef } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import type { Category, Repository } from '../../../types';
+import { useAppStore, getAllCategories } from '../../../store/useAppStore';
+import { AIService } from '../../../services/aiService';
+import { EmbeddingClient, VectorSearchService } from '../../../services/vectorSearchService';
+import { GitHubApiService } from '../../../services/githubApi';
+import { createGitHubListsApiService } from '../../../services/githubApiFactory';
+import { forceSyncToBackend } from '../../../services/autoSync';
+import { useDialog } from '../../../hooks/useDialog';
+import type { GitHubList } from '../../../services/githubListsApi';
+import type { VectorQueryResult } from '../../../services/vectorSearchService';
+import { isReservedCategoryName } from '../../../utils/categoryUtils';
+import { performBasicTextSearch } from '../../../utils/repoSearch';
+
+// ===== 提纯纯函数（来源逐字对应 SearchBar 基线行号） =====
+
+// SearchBar 446-459：轻量关键词加分 + scoreMap 构造。
+export const buildSearchPatch = (
+  query: string,
+  vectorResults: VectorQueryResult[],
+): Map<string, number> => {
+  const queryLower = query.toLowerCase();
+  const boostedResults = vectorResults.map(r => {
+    let bonus = 0;
+    const name = (r.metadata?.full_name || '').toLowerCase();
+    const desc = (r.metadata?.description || '').toLowerCase();
+    const tags = (r.metadata?.tags || []).map(tag => tag.toLowerCase());
+    if (name.includes(queryLower)) bonus += 0.05;
+    if (desc.includes(queryLower)) bonus += 0.03;
+    if (tags.some(tag => tag.includes(queryLower))) bonus += 0.02;
+    return { ...r, score: r.score + bonus };
+  });
+  return new Map(boostedResults.map(r => [r.id, r.score]));
+};
+
+// SearchBar 725-750：星标同步结果与本地仓库逐字段合并（license `?? null` 回填）。
+export const mergeStarredRepositories = (
+  newRepos: Repository[],
+  storeRepos: Repository[],
+): Repository[] => {
+  const existingRepoMap = new Map(storeRepos.map(repo => [repo.id, repo]));
+  return newRepos.map(newRepo => {
+    const existing = existingRepoMap.get(newRepo.id);
+    if (existing) {
+      return {
+        ...existing,
+        name: newRepo.name,
+        full_name: newRepo.full_name,
+        description: newRepo.description,
+        html_url: newRepo.html_url,
+        stargazers_count: newRepo.stargazers_count,
+        forks_count: newRepo.forks_count,
+        forks: newRepo.forks,
+        language: newRepo.language,
+        updated_at: newRepo.updated_at,
+        pushed_at: newRepo.pushed_at,
+        starred_at: newRepo.starred_at,
+        owner: newRepo.owner,
+        topics: newRepo.topics,
+        // 回填历史仓库缺失的 license 字段（GitHub 源元数据，跟随 newRepo）
+        license: newRepo.license ?? null,
+      };
+    }
+    return newRepo;
+  });
+};
+
+// SearchBar 774-799：构造"list 名(小写) → 本地分类"映射并为云端 list 规划缺失的自定义分类。
+// makeCategoryId 由 hook 注入（原实现内联 `custom-sync-${Date.now()}-${idx}`），保持可测性。
+export const planListCategories = (
+  lists: GitHubList[],
+  localCategories: Category[],
+  makeCategoryId: (idx: number) => string,
+): { toCreate: Category[]; categoryByLowerName: Map<string, string> } => {
+  // 值使用本地分类的原始名称（保留其大小写），而非 list 名：
+  // 锁定分类的筛选用精确相等比较，若直接存 GitHub 侧的大小写，
+  // 仓库会从分类结果中消失（如 list 名为 "web apps" 而分类为 "Web Apps"）。
+  const categoryByLowerName = new Map(
+    localCategories
+      .filter(c => c.id !== 'all' && !isReservedCategoryName(c.name))
+      .map(c => [c.name.toLowerCase(), c.name])
+  );
+  const toCreate: Category[] = [];
+  lists.forEach((list, idx) => {
+    const lower = list.name.toLowerCase();
+    if (isReservedCategoryName(list.name) || categoryByLowerName.has(lower)) return;
+    toCreate.push({
+      id: makeCategoryId(idx),
+      name: list.name,
+      icon: ' 📋',
+      isCustom: true,
+      keywords: [],
+    });
+    // 纳入本次运行使用的映射，使后续 listMatchesCategory 命中、可设分类并加锁
+    categoryByLowerName.set(lower, list.name);
+  });
+  return { toCreate, categoryByLowerName };
+};
+
+// SearchBar 807-868：preExistingLocked 集 + 打标签/设分类/加锁循环 + last_edited。
+export const applyListsToRepositories = (
+  repositories: Repository[],
+  lists: GitHubList[],
+  categoryByLowerName: Map<string, string>,
+): { repositories: Repository[]; appliedTagsCount: Record<string, number> } => {
+  const listRepoMap = new Map(repositories.map(repo => [repo.full_name.toLowerCase(), repo]));
+  const appliedTagsCount: Record<string, number> = {};
+
+  // DEC-4：只判定锁定状态。
+  // 区分"本次同步开始前已存在"的锁定与"本次运行中新产生"的锁定：
+  // - 预存在的锁定：不覆盖其分类与锁定，但仍追加本次命中的 list 名为
+  //   custom_tags（修复 #273：否则一旦仓库被锁过，之后云端 list 的任何
+  //   变化都被跳过，导致"无法将云端 list 拉取到本地"）。
+  // - 本次运行中被前面的 list 刚锁定：保留已分配的分类/锁定，继续追加后续 list 的标签
+  const preExistingLocked = new Set(
+    repositories
+      .filter(r => r.category_locked)
+      .map(r => r.full_name.toLowerCase())
+  );
+
+  for (const list of lists) {
+    let appliedCount = 0;
+    for (const fullName of list.items) {
+      const key = fullName.toLowerCase();
+      const repo = listRepoMap.get(key);
+      if (!repo) continue;
+
+      const customTags = repo.custom_tags ? [...repo.custom_tags] : [];
+      if (!customTags.includes(list.name)) {
+        customTags.push(list.name);
+      }
+
+      // 预存在锁定：不覆盖其分类与锁定，仅追加 list 名为标签，让云端
+      // list 关系仍能反映到本地（修复 #273）。
+      if (preExistingLocked.has(key)) {
+        // 仅当标签确有变化才写回，避免无谓的 last_edited 抖动
+        if (customTags.length !== (repo.custom_tags?.length ?? 0)) {
+          listRepoMap.set(key, { ...repo, custom_tags: customTags });
+        }
+        appliedCount++;
+        continue;
+      }
+
+      // 本次运行中刚被锁定的仓库：保留已分配的分类与锁定，仅追加标签
+      if (repo.category_locked) {
+        listRepoMap.set(key, { ...repo, custom_tags: customTags });
+        appliedCount++;
+        continue;
+      }
+
+      // 若 list 名对应某个本地分类：设置分类并加锁；否则仅加标签（多分类靠标签匹配）
+      const listMatchesCategory = categoryByLowerName.has(list.name.toLowerCase());
+      const updatedRepo: Repository = listMatchesCategory
+        ? {
+            ...repo,
+            custom_tags: customTags,
+            custom_category: categoryByLowerName.get(list.name.toLowerCase()),
+            category_locked: true,
+            last_edited: new Date().toISOString(),
+          }
+        : {
+            ...repo,
+            custom_tags: customTags,
+          };
+
+      listRepoMap.set(key, updatedRepo);
+      appliedCount++;
+    }
+    if (appliedCount > 0) {
+      appliedTagsCount[list.name] = appliedCount;
+    }
+  }
+
+  return {
+    repositories: repositories.map(repo =>
+      listRepoMap.get(repo.full_name.toLowerCase()) || repo
+    ),
+    appliedTagsCount,
+  };
+};
+
+// ===== Hook =====
+
+export interface SearchActions {
+  isSearching: boolean;
+  searchPhase: string | null;
+  // 渲染相关 ref：View 的过滤 effect 仍要读写，故以 RefObject 暴露。
+  // 实体挂 hook、以 RefObject 暴露给 View 原样读写——写点在 aiSearch（本 hook），
+  // 读点在 View 的过滤 effect（依赖 View 本地 applyFilters 闭包），整体搬入 hook
+  // 会扩大改动面、引入漂移风险，"只搬运不改语义"约束下这是风险最低的切法。
+  vectorScoreMapRef: MutableRefObject<{ query: string; scores: Map<string, number> } | null>;
+  skipNextTextSearchRef: MutableRefObject<boolean>;
+  aiSearch: (query: string, applyFilters: (repos: Repository[]) => Repository[]) => Promise<void>;
+  keywordSearch: (query: string, applyFilters: (repos: Repository[]) => Repository[]) => Promise<void>;
+  syncStars: (mode?: 'auto' | 'stars-only' | 'stars-and-lists') => Promise<void>;
+}
+
+export const useSearchActions = (): SearchActions => {
+  const {
+    repositories,
+    aiConfigs,
+    activeAIConfig,
+    language,
+    setSearchFilters,
+    setSearchResults,
+    githubToken,
+    setRepositories,
+    setLastSync,
+    setSyncingStars,
+    syncMode,
+    user,
+    addCustomCategory,
+    customCategories,
+    hiddenDefaultCategoryIds,
+    defaultCategoryOverrides,
+  } = useAppStore(useShallow((state) => ({
+    repositories: state.repositories,
+    aiConfigs: state.aiConfigs,
+    activeAIConfig: state.activeAIConfig,
+    language: state.language,
+    setSearchFilters: state.setSearchFilters,
+    setSearchResults: state.setSearchResults,
+    githubToken: state.githubToken,
+    setRepositories: state.setRepositories,
+    setLastSync: state.setLastSync,
+    setSyncingStars: state.setSyncingStars,
+    syncMode: state.syncMode,
+    user: state.user,
+    addCustomCategory: state.addCustomCategory,
+    customCategories: state.customCategories,
+    hiddenDefaultCategoryIds: state.hiddenDefaultCategoryIds,
+    defaultCategoryOverrides: state.defaultCategoryOverrides,
+  })));
+
+  const { toast } = useDialog();
+  const [isSearching, setIsSearching] = useState(false);
+  const [searchPhase, setSearchPhase] = useState<string | null>(null);
+  const vectorScoreMapRef = useRef<{ query: string; scores: Map<string, number> } | null>(null);
+  const skipNextTextSearchRef = useRef(false);
+  const t = useCallback((zh: string, en: string) => language === 'zh' ? zh : en, [language]);
+
+  const keywordSearch = useCallback(async (
+    query: string,
+    applyFilters: (repos: Repository[]) => Repository[],
+  ): Promise<void> => {
+    const activeConfig = aiConfigs.find(config => config.id === activeAIConfig);
+    console.log('🤖 AI Config found:', !!activeConfig, 'Active AI Config ID:', activeAIConfig);
+    console.log('📋 Available AI Configs:', aiConfigs.length);
+    console.log('🔧 AI Configs:', aiConfigs.map(c => ({ id: c.id, name: c.name, hasApiKey: !!c.apiKey })));
+
+    let filtered = repositories;
+    if (activeConfig) {
+      try {
+        console.log('🚀 Calling AI service...');
+        setSearchPhase(t('AI 语义分析...', 'AI semantic analysis...'));
+        const aiService = new AIService(activeConfig, language);
+
+        // 先尝试AI搜索
+        const aiResults = await aiService.searchRepositoriesWithReranking(repositories, query);
+        console.log('✅ AI search completed, results:', aiResults.length);
+
+        filtered = aiResults;
+      } catch (error) {
+        console.warn('❌ AI search failed, falling back to basic search:', error);
+        filtered = performBasicTextSearch(repositories, query);
+        console.log('🔄 Basic search fallback results:', filtered.length);
+      }
+    } else {
+      console.log('⚠️ No AI config found, using basic text search');
+      // Basic text search if no AI config
+      filtered = performBasicTextSearch(repositories, query);
+      console.log('📝 Basic search results:', filtered.length);
+    }
+
+    // Apply other filters and update results
+    const finalFiltered = applyFilters(filtered);
+    console.log('🎯 Final filtered results:', finalFiltered.length);
+    console.log('📋 Final filtered repositories:', finalFiltered.map(r => r.name));
+    setSearchResults(finalFiltered);
+
+    // Update search filters to mark that AI search was performed
+    setSearchFilters({ query });
+  }, [repositories, aiConfigs, activeAIConfig, language, setSearchResults, setSearchFilters, t]);
+
+  const aiSearch = useCallback(async (
+    query: string,
+    applyFilters: (repos: Repository[]) => Repository[],
+  ): Promise<void> => {
+    if (!query.trim()) return;
+
+    setIsSearching(true);
+    setSearchPhase(null);
+    vectorScoreMapRef.current = null;
+    console.log('🔍 Starting AI search for query:', query);
+
+    try {
+      // ====== 向量搜索分支 ======
+      // 保持原时机：非响应式 getState() 读取（原文件如此，不改成响应式 selector）
+      const vsConfig = useAppStore.getState().vectorSearchConfig;
+      const embConfigs = useAppStore.getState().embeddingConfigs;
+      const activeEmbConfig = embConfigs.find(c => c.id === vsConfig?.embeddingConfigId);
+
+      if (vsConfig?.enabled && vsConfig?.workerUrl && activeEmbConfig) {
+        try {
+          const embeddingClient = new EmbeddingClient(activeEmbConfig);
+          const vectorService = new VectorSearchService(vsConfig);
+
+          // 1. HyDE 查询预处理：用 LLM 生成理想仓库描述再嵌入（可选，5 秒超时降级）
+          let embeddingQuery = query;
+          const hydeConfig = aiConfigs.find(config => config.id === activeAIConfig);
+          if (vsConfig.enableHyDE !== false && hydeConfig) {
+            const hydeAbort = new AbortController();
+            let hydeTimer: ReturnType<typeof setTimeout> | null = null;
+            try {
+              setSearchPhase(t('AI 分析查询...', 'AI analyzing query...'));
+              const hydeService = new AIService(hydeConfig, language);
+              embeddingQuery = await Promise.race([
+                hydeService.generateHyDEQuery(query, hydeAbort.signal).catch(() => query),
+                new Promise<string>((resolve) => {
+                  hydeTimer = setTimeout(() => {
+                    hydeAbort.abort();
+                    resolve(query);
+                  }, 5000);
+                }),
+              ]);
+              if (embeddingQuery !== query) {
+                console.log('🔮 HyDE generated:', embeddingQuery.slice(0, 100));
+              }
+            } catch (hydeError) {
+              console.warn('HyDE failed, using raw query:', hydeError);
+              embeddingQuery = query;
+            } finally {
+              if (hydeTimer) clearTimeout(hydeTimer);
+            }
+          }
+
+          // 2. 前端调用 Embedding API 生成查询向量
+          setSearchPhase(t('生成查询向量...', 'Generating query vector...'));
+          const queryVectors = await embeddingClient.embed([embeddingQuery], 'query');
+          if (queryVectors && queryVectors.length > 0) {
+            // 2. 前端将查询向量发送到 Worker
+            setSearchPhase(t('检索向量库...', 'Searching vector index...'));
+            const vectorResults = await vectorService.query(queryVectors[0], {
+              topK: vsConfig.searchTopK ?? 30,
+              threshold: vsConfig.searchThreshold ?? 0.35,
+            });
+
+            if (vectorResults.length > 0) {
+              // 3. 轻量关键词加分：精确匹配的字段给予分数微调
+              const scoreMap = buildSearchPatch(query, vectorResults);
+
+              // 4. 从本地仓库数据中取出匹配结果，按相似度排序
+              const scoredRepos = repositories
+                .filter(repo => scoreMap.has(String(repo.id)))
+                .map(repo => ({
+                  repo,
+                  score: scoreMap.get(String(repo.id)) || 0,
+                }))
+                .sort((a, b) => b.score - a.score)
+                .map(item => item.repo);
+
+              if (scoredRepos.length > 0) {
+                // 4. AI 语义重排序：用 LLM 对向量搜索结果做真正的语义排序
+                let reranked = scoredRepos;
+                let rerankSucceeded = false;
+                const rerankConfig = aiConfigs.find(config => config.id === activeAIConfig);
+                if (rerankConfig && vsConfig.enableReranking !== false) {
+                  try {
+                    setSearchPhase(t('AI 语义重排序...', 'AI semantic reranking...'));
+                    const rerankService = new AIService(rerankConfig, language);
+                    reranked = await rerankService.searchRepositoriesWithSemanticReranking(scoredRepos, query);
+                    rerankSucceeded = true;
+                    console.log('🤖 AI semantically reranked results:', reranked.length);
+                  } catch (rerankError) {
+                    console.warn('AI semantic reranking failed, using vector order:', rerankError);
+                  }
+                }
+
+                // 保存 LLM 重排序顺序，applyFilters 可能按 UI 排序覆盖它
+                const rerankOrder = rerankSucceeded
+                  ? new Map(reranked.map((repo, index) => [String(repo.id), index]))
+                  : null;
+                const finalFiltered = applyFilters([...reranked]);
+                if (rerankOrder) {
+                  // 恢复 LLM 语义排序顺序
+                  finalFiltered.sort((a, b) =>
+                    (rerankOrder.get(String(a.id)) ?? Number.MAX_SAFE_INTEGER)
+                    - (rerankOrder.get(String(b.id)) ?? Number.MAX_SAFE_INTEGER)
+                  );
+                } else {
+                  finalFiltered.sort((a, b) => (scoreMap.get(String(b.id)) ?? 0) - (scoreMap.get(String(a.id)) ?? 0));
+                }
+                console.log('🎯 Vector search results:', finalFiltered.length);
+                vectorScoreMapRef.current = { query, scores: scoreMap };
+                skipNextTextSearchRef.current = true;
+                setSearchResults(finalFiltered);
+                setSearchFilters({ query });
+                return;
+              }
+            }
+          }
+          // 向量搜索无结果 → 继续走关键词搜索
+          console.log('⚠️ Vector search returned no results, falling back to keyword search');
+        } catch (vectorError) {
+          console.warn('❌ Vector search failed, falling back to keyword search:', vectorError);
+        }
+      }
+      // ====== 向量搜索分支结束 ======
+
+      await keywordSearch(query, applyFilters);
+    } catch (error) {
+      console.error('💥 Search failed:', error);
+    } finally {
+      setIsSearching(false);
+      setSearchPhase(null);
+    }
+  }, [repositories, aiConfigs, activeAIConfig, language, setSearchResults, setSearchFilters, keywordSearch, t]);
+
+  const syncStars = useCallback(async (mode: 'auto' | 'stars-only' | 'stars-and-lists' = 'auto') => {
+    if (!githubToken) {
+      toast(t('GitHub token 未找到，请重新登录。', 'GitHub token not found. Please login again.'), 'error');
+      return;
+    }
+
+    setSyncingStars(true);
+    try {
+      const githubApi = new GitHubApiService(githubToken);
+      const newRepositories = await githubApi.getAllStarredRepositories();
+
+      const storeRepos = useAppStore.getState().repositories;
+      const mergedRepositories = mergeStarredRepositories(newRepositories, storeRepos);
+
+      // 解析本次同步范围：
+      // - 'auto'：跟随持久化配置 syncMode
+      // - 'stars-only'：强制仅星标（忽略 syncMode，供下拉菜单显式选择）
+      // - 'stars-and-lists'：强制星标及 list（供下拉菜单显式选择）
+      const syncLists = mode === 'stars-and-lists' || (mode === 'auto' && syncMode === 'stars-and-lists');
+      let finalRepositories = mergedRepositories;
+
+      if (syncLists) {
+        const appliedTagsCount: Record<string, number> = {};
+        try {
+          const listsApi = createGitHubListsApiService(githubToken);
+          const login = user?.login;
+          if (!login) {
+            throw new Error(t('无法获取 GitHub 用户名，请重新登录。', 'Failed to get GitHub username. Please login again.'));
+          }
+          const lists = await listsApi.getUserLists(login);
+
+          // allCategories 与 View 的 useMemo 同源同值（getAllCategories 四参口径）
+          const allCategories = getAllCategories(customCategories, language, hiddenDefaultCategoryIds, defaultCategoryOverrides);
+          // 为云端存在、但本地无同名分类的 list 自动创建自定义分类。
+          // 修复"GitHub list 有很多新分类但本地从没拉到过"——原逻辑只贴 custom_tags
+          // 标签，不建分类，导致左侧分类树永远只有历史分类。
+          // 用每 list 递增的下标做 id 后缀，避免同一毫秒内多个 list 撞 id。
+          const { toCreate, categoryByLowerName } = planListCategories(
+            lists,
+            allCategories,
+            (idx) => `custom-sync-${Date.now()}-${idx}`,
+          );
+          toCreate.forEach((category) => addCustomCategory(category));
+          const createdCategoriesCount = toCreate.length;
+
+          const { repositories: listAppliedRepositories, appliedTagsCount: counts } =
+            applyListsToRepositories(finalRepositories, lists, categoryByLowerName);
+          finalRepositories = listAppliedRepositories;
+          Object.assign(appliedTagsCount, counts);
+
+          if (Object.keys(appliedTagsCount).length > 0) {
+            const appliedTotal = Object.values(appliedTagsCount).reduce((a, b) => a + b, 0);
+            const listSummary = Object.entries(appliedTagsCount)
+              .map(([name, count]) => `${name}(${count})`)
+              .join('、');
+            const createdHint = createdCategoriesCount > 0
+              ? t(
+                  `（新建 ${createdCategoriesCount} 个分类）`,
+                  ` (${createdCategoriesCount} new categor${createdCategoriesCount > 1 ? 'ies' : 'y'} created)`
+                )
+              : '';
+            toast(t(
+              `已同步 ${lists.length} 个 list，并应用到 ${appliedTotal} 个未锁定仓库：${listSummary}${createdHint}`,
+              `Synced ${lists.length} lists, applied to ${appliedTotal} unlocked repositories: ${listSummary}${createdHint}`
+            ), 'info');
+          } else if (createdCategoriesCount > 0) {
+            // 命中数为 0，但本次新建了分类（云端 list 与本地无交集但仍有其名分类）
+            toast(t(
+              `已同步 ${lists.length} 个 list（新建 ${createdCategoriesCount} 个分类）。`,
+              `Synced ${lists.length} lists (${createdCategoriesCount} new categor${createdCategoriesCount > 1 ? 'ies' : 'y'} created).`
+            ), 'info');
+          }
+        } catch (listError) {
+          console.error('List sync failed:', listError);
+          toast(t(
+            'List 同步失败，星标仓库已同步。请稍后重试，或检查 GitHub Token 权限（需 user scope）。',
+            'List sync failed, starred repositories were synced. Retry later, or check the GitHub Token has the user scope.'
+          ), 'error');
+          // 不中断：星标同步结果仍然生效
+        }
+      }
+
+      const existingRepoIds = new Set(storeRepos.map(repo => repo.id));
+      const newRepoCount = newRepositories.filter(repo => !existingRepoIds.has(repo.id)).length;
+
+      setRepositories(finalRepositories);
+      await forceSyncToBackend();
+
+      setLastSync(new Date().toISOString());
+
+      if (newRepoCount > 0) {
+        toast(t(`同步完成！发现 ${newRepoCount} 个新仓库。`, `Sync completed! Found ${newRepoCount} new repositories.`), 'success');
+      } else {
+        toast(t('同步完成！所有仓库都是最新的。', 'Sync completed! All repositories are up to date.'), 'info');
+      }
+
+    } catch (error) {
+      console.error('Sync failed:', error);
+      if (error instanceof Error && error.message.includes('token')) {
+        toast(t('GitHub token 已过期或无效，请重新登录。', 'GitHub token has expired or is invalid. Please login again.'), 'error');
+      } else {
+        toast(t('同步失败，请检查网络连接或稍后重试。', 'Sync failed. Please check your network connection or try again later.'), 'error');
+      }
+    } finally {
+      setSyncingStars(false);
+    }
+  }, [githubToken, setSyncingStars, syncMode, user, t, toast, addCustomCategory, customCategories, language, hiddenDefaultCategoryIds, defaultCategoryOverrides, setRepositories, setLastSync]);
+
+  return useMemo(() => ({
+    isSearching,
+    searchPhase,
+    vectorScoreMapRef,
+    skipNextTextSearchRef,
+    aiSearch,
+    keywordSearch,
+    syncStars,
+  }), [isSearching, searchPhase, aiSearch, keywordSearch, syncStars]);
+};

--- a/src/features/settings/hooks/useBackendAvailability.test.tsx
+++ b/src/features/settings/hooks/useBackendAvailability.test.tsx
@@ -1,0 +1,26 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useBackendAvailability } from './useBackendAvailability';
+
+const mocks = vi.hoisted(() => ({
+  backend: { isAvailable: false },
+}));
+
+vi.mock('../../../services/backendAdapter', () => ({ backend: mocks.backend }));
+
+describe('useBackendAvailability', () => {
+  beforeEach(() => {
+    mocks.backend.isAvailable = false;
+  });
+
+  it('returns false when the backend is unavailable', () => {
+    const { result } = renderHook(() => useBackendAvailability());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when the backend is available', () => {
+    mocks.backend.isAvailable = true;
+    const { result } = renderHook(() => useBackendAvailability());
+    expect(result.current).toBe(true);
+  });
+});

--- a/src/features/settings/hooks/useBackendAvailability.ts
+++ b/src/features/settings/hooks/useBackendAvailability.ts
@@ -1,0 +1,7 @@
+import { backend } from '../../../services/backendAdapter';
+
+/**
+ * 一次性同步读取 backend.isAvailable，无订阅、无本地状态——
+ * 与原 SettingsPanel 直接内联读取的语义逐字等价（勿引入订阅/状态）。
+ */
+export const useBackendAvailability = (): boolean => backend.isAvailable;

--- a/src/hooks/useReadmeFetch.test.tsx
+++ b/src/hooks/useReadmeFetch.test.tsx
@@ -1,0 +1,243 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_README_VARIANT, type ReadmeVariant } from '../utils/readmeVariants';
+import { pickReadmeCandidate, useReadmeFetch } from './useReadmeFetch';
+
+const mocks = vi.hoisted(() => ({
+  useAppStore: vi.fn(),
+  backend: {
+    isAvailable: true,
+    getRepositoryReadme: vi.fn(),
+    getRepositoryReadmeByPath: vi.fn(),
+    listRepositoryReadmeCandidates: vi.fn(),
+  },
+  getRepositoryReadme: vi.fn(),
+  getRepositoryReadmeByPath: vi.fn(),
+  listRepositoryReadmeCandidates: vi.fn(),
+  shouldBypassBackend: vi.fn(() => false),
+}));
+
+vi.mock('../store/useAppStore', () => ({
+  useAppStore: mocks.useAppStore,
+}));
+
+vi.mock('../services/backendAdapter', () => ({ backend: mocks.backend }));
+
+vi.mock('../services/githubApi', () => ({
+  GitHubApiService: class {
+    getRepositoryReadme = mocks.getRepositoryReadme;
+    getRepositoryReadmeByPath = mocks.getRepositoryReadmeByPath;
+    listRepositoryReadmeCandidates = mocks.listRepositoryReadmeCandidates;
+  },
+}));
+
+vi.mock('../services/routeMode', () => ({
+  shouldBypassBackend: mocks.shouldBypassBackend,
+}));
+
+const createStoreState = () => ({
+  githubToken: 'github-token' as string | null,
+  language: 'zh' as const,
+});
+
+let storeState = createStoreState();
+const mockUseAppStore = vi.mocked(mocks.useAppStore);
+mockUseAppStore.mockImplementation((selector?: (state: typeof storeState) => unknown) =>
+  selector ? selector(storeState) : storeState);
+(mockUseAppStore as unknown as { getState: () => typeof storeState }).getState = () => storeState;
+
+const defaultVariant: ReadmeVariant = { ...DEFAULT_README_VARIANT };
+
+describe('useReadmeFetch.fetchReadmeContent', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeState = createStoreState();
+    mocks.shouldBypassBackend.mockReturnValue(false);
+    mocks.backend.isAvailable = true;
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('goes through the backend when available and does not touch GitHub', async () => {
+    mocks.backend.getRepositoryReadme.mockResolvedValue('# Backend readme');
+    const { result } = renderHook(() => useReadmeFetch({ owner: 'owner', name: 'repo' }));
+    await act(async () => {
+      await expect(result.current.fetchReadmeContent(defaultVariant)).resolves.toBe('# Backend readme');
+    });
+    expect(mocks.backend.getRepositoryReadme).toHaveBeenCalledWith('owner', 'repo', expect.any(AbortSignal));
+    expect(mocks.getRepositoryReadme).not.toHaveBeenCalled();
+  });
+
+  it('bypasses the backend in browser route mode and fetches from GitHub', async () => {
+    mocks.shouldBypassBackend.mockReturnValue(true);
+    mocks.getRepositoryReadme.mockResolvedValue('# Direct readme');
+    const { result } = renderHook(() => useReadmeFetch({ owner: 'owner', name: 'repo' }));
+    await act(async () => {
+      await expect(result.current.fetchReadmeContent(defaultVariant)).resolves.toBe('# Direct readme');
+    });
+    expect(mocks.backend.getRepositoryReadme).not.toHaveBeenCalled();
+    expect(mocks.getRepositoryReadme).toHaveBeenCalledWith('owner', 'repo', expect.any(AbortSignal));
+  });
+
+  it('falls back to GitHub after a backend failure and warns', async () => {
+    mocks.backend.getRepositoryReadme.mockRejectedValue(new Error('backend boom'));
+    mocks.getRepositoryReadme.mockResolvedValue('# Fallback readme');
+    const { result } = renderHook(() => useReadmeFetch({ owner: 'owner', name: 'repo' }));
+    await act(async () => {
+      await expect(result.current.fetchReadmeContent(defaultVariant)).resolves.toBe('# Fallback readme');
+    });
+    expect(warnSpy).toHaveBeenCalledWith('Falling back to direct GitHub README fetch after backend failure:', expect.any(Error));
+    expect(mocks.getRepositoryReadme).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws the verbatim message when neither backend nor token is available', async () => {
+    mocks.backend.isAvailable = false;
+    storeState.githubToken = null;
+    const { result } = renderHook(() => useReadmeFetch({ owner: 'owner', name: 'repo' }));
+    await act(async () => {
+      await expect(result.current.fetchReadmeContent(defaultVariant)).rejects.toThrow('未登录且后端不可用，无法加载 README');
+    });
+    expect(mocks.getRepositoryReadme).not.toHaveBeenCalled();
+  });
+
+  it('uses the path variant against the backend and GitHub respectively', async () => {
+    const pathVariant: ReadmeVariant = { ...DEFAULT_README_VARIANT, key: 'readme-zh', path: 'README.zh.md', isDefault: false };
+    mocks.backend.getRepositoryReadmeByPath.mockResolvedValueOnce('# backend path');
+    mocks.getRepositoryReadmeByPath.mockResolvedValueOnce('# github path');
+
+    const { result } = renderHook(() => useReadmeFetch({ owner: 'owner', name: 'repo' }));
+    await act(async () => {
+      await expect(result.current.fetchReadmeContent(pathVariant)).resolves.toBe('# backend path');
+    });
+    expect(mocks.backend.getRepositoryReadmeByPath).toHaveBeenCalledWith('owner', 'repo', 'README.zh.md', expect.any(AbortSignal));
+
+    mocks.backend.getRepositoryReadmeByPath.mockRejectedValueOnce(new Error('boom'));
+    await act(async () => {
+      await expect(result.current.fetchReadmeContent(pathVariant)).resolves.toBe('# github path');
+    });
+    expect(mocks.getRepositoryReadmeByPath).toHaveBeenCalledWith('owner', 'repo', 'README.zh.md', expect.any(AbortSignal));
+  });
+
+  it('rejects with an AbortError-named error when cancelled after the backend resolves', async () => {
+    let resolveBackend!: (value: string) => void;
+    mocks.backend.getRepositoryReadme.mockImplementation(() => new Promise<string>((resolve) => {
+      resolveBackend = resolve;
+    }));
+    const { result } = renderHook(() => useReadmeFetch({ owner: 'owner', name: 'repo' }));
+
+    let pending!: Promise<string>;
+    act(() => {
+      pending = result.current.fetchReadmeContent(defaultVariant);
+    });
+    act(() => {
+      result.current.cancel();
+    });
+    resolveBackend('# stale');
+    await act(async () => {
+      await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    });
+  });
+
+  it('aborts the previous content request when a new one starts', async () => {
+    const signals: AbortSignal[] = [];
+    mocks.backend.getRepositoryReadme.mockImplementation((_owner: string, _name: string, signal: AbortSignal) => {
+      signals.push(signal);
+      return new Promise<string>(() => undefined);
+    });
+    const { result } = renderHook(() => useReadmeFetch({ owner: 'owner', name: 'repo' }));
+
+    act(() => {
+      void result.current.fetchReadmeContent(defaultVariant);
+    });
+    act(() => {
+      void result.current.fetchReadmeContent(defaultVariant);
+    });
+
+    expect(signals).toHaveLength(2);
+    expect(signals[0].aborted).toBe(true);
+    expect(signals[1].aborted).toBe(false);
+  });
+});
+
+describe('useReadmeFetch.fetchReadmeCandidates', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeState = createStoreState();
+    mocks.shouldBypassBackend.mockReturnValue(false);
+    mocks.backend.isAvailable = true;
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('returns candidates from the backend when available', async () => {
+    const candidates = [{ name: 'README.zh-CN.md', path: 'README.zh-CN.md' }];
+    mocks.backend.listRepositoryReadmeCandidates.mockResolvedValue(candidates);
+    const { result } = renderHook(() => useReadmeFetch({ owner: 'owner', name: 'repo' }));
+    await act(async () => {
+      await expect(result.current.fetchReadmeCandidates('main')).resolves.toBe(candidates);
+    });
+    expect(mocks.backend.listRepositoryReadmeCandidates).toHaveBeenCalledWith('owner', 'repo', 'main', expect.any(AbortSignal));
+  });
+
+  it('falls back to GitHub after a backend failure and warns with the variant-detection message', async () => {
+    mocks.backend.listRepositoryReadmeCandidates.mockRejectedValue(new Error('boom'));
+    mocks.listRepositoryReadmeCandidates.mockResolvedValue([]);
+    const { result } = renderHook(() => useReadmeFetch({ owner: 'owner', name: 'repo' }));
+    await act(async () => {
+      await expect(result.current.fetchReadmeCandidates('main')).resolves.toEqual([]);
+    });
+    expect(warnSpy).toHaveBeenCalledWith('Falling back to direct GitHub README variant detection after backend failure:', expect.any(Error));
+  });
+
+  it('returns an empty list instead of throwing when tokenless on the GitHub path', async () => {
+    mocks.backend.isAvailable = false;
+    storeState.githubToken = null;
+    const { result } = renderHook(() => useReadmeFetch({ owner: 'owner', name: 'repo' }));
+    await act(async () => {
+      await expect(result.current.fetchReadmeCandidates('main')).resolves.toEqual([]);
+    });
+    expect(mocks.listRepositoryReadmeCandidates).not.toHaveBeenCalled();
+  });
+
+  it('cancel aborts the in-flight candidates request', async () => {
+    const signals: AbortSignal[] = [];
+    mocks.backend.listRepositoryReadmeCandidates.mockImplementation((_o: string, _n: string, _b: string | undefined, signal: AbortSignal) => {
+      signals.push(signal);
+      return new Promise(() => undefined);
+    });
+    const { result } = renderHook(() => useReadmeFetch({ owner: 'owner', name: 'repo' }));
+
+    act(() => {
+      void result.current.fetchReadmeCandidates('main');
+    });
+    expect(signals[0].aborted).toBe(false);
+    act(() => {
+      result.current.cancel();
+    });
+    expect(signals[0].aborted).toBe(true);
+  });
+});
+
+describe('pickReadmeCandidate', () => {
+  const variantA: ReadmeVariant = { ...DEFAULT_README_VARIANT, key: 'a' };
+  const variantB: ReadmeVariant = { ...DEFAULT_README_VARIANT, key: 'b' };
+
+  it('returns the variant matching the selected key', () => {
+    expect(pickReadmeCandidate([variantA, variantB], 'b', variantA)).toBe(variantB);
+  });
+
+  it('falls back to the default variant for unknown or missing keys', () => {
+    expect(pickReadmeCandidate([variantA, variantB], 'missing', variantA)).toBe(variantA);
+    expect(pickReadmeCandidate([variantA, variantB], undefined, variantB)).toBe(variantB);
+  });
+});

--- a/src/hooks/useReadmeFetch.test.tsx
+++ b/src/hooks/useReadmeFetch.test.tsx
@@ -105,6 +105,17 @@ describe('useReadmeFetch.fetchReadmeContent', () => {
     expect(mocks.getRepositoryReadme).not.toHaveBeenCalled();
   });
 
+  it('rethrows the backend error instead of falling back when tokenless (content path)', async () => {
+    mocks.backend.getRepositoryReadme.mockRejectedValue(new Error('backend down'));
+    storeState.githubToken = null;
+    const { result } = renderHook(() => useReadmeFetch({ owner: 'owner', name: 'repo' }));
+    await act(async () => {
+      await expect(result.current.fetchReadmeContent(defaultVariant)).rejects.toThrow('backend down');
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(mocks.getRepositoryReadme).not.toHaveBeenCalled();
+  });
+
   it('uses the path variant against the backend and GitHub respectively', async () => {
     const pathVariant: ReadmeVariant = { ...DEFAULT_README_VARIANT, key: 'readme-zh', path: 'README.zh.md', isDefault: false };
     mocks.backend.getRepositoryReadmeByPath.mockResolvedValueOnce('# backend path');
@@ -227,6 +238,17 @@ describe('useReadmeFetch.fetchReadmeCandidates', () => {
     await act(async () => {
       await expect(result.current.fetchReadmeCandidates('main')).resolves.toEqual([]);
     });
+    expect(mocks.listRepositoryReadmeCandidates).not.toHaveBeenCalled();
+  });
+
+  it('rethrows the backend error instead of falling back when tokenless (candidates path)', async () => {
+    mocks.backend.listRepositoryReadmeCandidates.mockRejectedValue(new Error('backend down'));
+    storeState.githubToken = null;
+    const { result } = renderHook(() => useReadmeFetch({ owner: 'owner', name: 'repo' }));
+    await act(async () => {
+      await expect(result.current.fetchReadmeCandidates('main')).rejects.toThrow('backend down');
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
     expect(mocks.listRepositoryReadmeCandidates).not.toHaveBeenCalled();
   });
 

--- a/src/hooks/useReadmeFetch.test.tsx
+++ b/src/hooks/useReadmeFetch.test.tsx
@@ -143,6 +143,27 @@ describe('useReadmeFetch.fetchReadmeContent', () => {
     });
   });
 
+  it('rejects with AbortError when cancelled after a direct-GitHub response resolves', async () => {
+    mocks.backend.isAvailable = false;
+    let resolveDirect!: (value: string) => void;
+    mocks.getRepositoryReadme.mockImplementation(() => new Promise<string>((resolve) => {
+      resolveDirect = resolve;
+    }));
+    const { result } = renderHook(() => useReadmeFetch({ owner: 'owner', name: 'repo' }));
+
+    let pending!: Promise<string>;
+    act(() => {
+      pending = result.current.fetchReadmeContent(defaultVariant);
+    });
+    act(() => {
+      result.current.cancel();
+    });
+    resolveDirect('# stale direct');
+    await act(async () => {
+      await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+    });
+  });
+
   it('aborts the previous content request when a new one starts', async () => {
     const signals: AbortSignal[] = [];
     mocks.backend.getRepositoryReadme.mockImplementation((_owner: string, _name: string, signal: AbortSignal) => {
@@ -207,6 +228,29 @@ describe('useReadmeFetch.fetchReadmeCandidates', () => {
       await expect(result.current.fetchReadmeCandidates('main')).resolves.toEqual([]);
     });
     expect(mocks.listRepositoryReadmeCandidates).not.toHaveBeenCalled();
+  });
+
+  it('rejects with AbortError when a direct-GitHub candidates request is superseded after resolving', async () => {
+    mocks.backend.isAvailable = false;
+    const resolvers: Array<(value: unknown[]) => void> = [];
+    mocks.listRepositoryReadmeCandidates.mockImplementation(() =>
+      new Promise<unknown[]>((resolve) => {
+        resolvers.push(resolve);
+      }));
+    const { result } = renderHook(() => useReadmeFetch({ owner: 'owner', name: 'repo' }));
+
+    let first!: Promise<unknown[]>;
+    act(() => {
+      first = result.current.fetchReadmeCandidates('main');
+    });
+    act(() => {
+      void result.current.fetchReadmeCandidates('main');
+    });
+    // 仅 resolve 第一个（已被取代的）请求；第二个保持挂起，不影响断言
+    resolvers[0]([{ name: 'stale.md', path: 'stale.md' }]);
+    await act(async () => {
+      await expect(first).rejects.toMatchObject({ name: 'AbortError' });
+    });
   });
 
   it('cancel aborts the in-flight candidates request', async () => {

--- a/src/hooks/useReadmeFetch.ts
+++ b/src/hooks/useReadmeFetch.ts
@@ -68,7 +68,9 @@ export const useReadmeFetch = ({ owner, name }: UseReadmeFetchOptions): ReadmeFe
     };
 
     if (shouldBypassBackend() || !backend.isAvailable) {
-      return fetchFromGitHubApi();
+      const directContent = await fetchFromGitHubApi();
+      if (signal.aborted) throw abortOperation();
+      return directContent;
     }
 
     try {
@@ -105,7 +107,9 @@ export const useReadmeFetch = ({ owner, name }: UseReadmeFetchOptions): ReadmeFe
     };
 
     if (shouldBypassBackend() || !backend.isAvailable) {
-      return fetchFromGitHubApi();
+      const directCandidates = await fetchFromGitHubApi();
+      if (signal.aborted) throw abortOperation();
+      return directCandidates;
     }
 
     try {

--- a/src/hooks/useReadmeFetch.ts
+++ b/src/hooks/useReadmeFetch.ts
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { GitHubApiService } from '../services/githubApi';
+import { backend } from '../services/backendAdapter';
+import { shouldBypassBackend } from '../services/routeMode';
+import { useAppStore } from '../store/useAppStore';
+import type { GitHubReadmeCandidateItem, ReadmeVariant } from '../utils/readmeVariants';
+
+const isAbortError = (error: unknown, signal?: AbortSignal): boolean => {
+  return Boolean(signal?.aborted || (error as { name?: string })?.name === 'AbortError');
+};
+
+// controller 被 hook 自身 abort（被新请求取代或 cancel()）时，以 AbortError 命名的错误
+// 拒绝，调用方据此丢弃过期结果且不动 loading 态——等价于原先 View 持有 signal 的
+// "resolve 后 signal.aborted 检查"（View 已不再持有 controller）。
+const abortOperation = (): Error => new DOMException('Aborted', 'AbortError');
+
+export interface UseReadmeFetchOptions {
+  owner: string;
+  name: string;
+}
+
+export interface ReadmeFetchActions {
+  fetchReadmeContent: (variant: ReadmeVariant) => Promise<string>;
+  fetchReadmeCandidates: (defaultBranch: string | undefined) => Promise<GitHubReadmeCandidateItem[]>;
+  /** abort 两路 controller 并置 null；View 关闭 modal 时调，hook unmount 亦自动。 */
+  cancel: () => void;
+}
+
+export const useReadmeFetch = ({ owner, name }: UseReadmeFetchOptions): ReadmeFetchActions => {
+  const { githubToken, language } = useAppStore(useShallow((state) => ({
+    githubToken: state.githubToken,
+    language: state.language,
+  })));
+
+  const contentAbortRef = useRef<AbortController | null>(null);
+  const candidatesAbortRef = useRef<AbortController | null>(null);
+
+  const cancel = useCallback(() => {
+    if (contentAbortRef.current) {
+      contentAbortRef.current.abort();
+      contentAbortRef.current = null;
+    }
+    if (candidatesAbortRef.current) {
+      candidatesAbortRef.current.abort();
+      candidatesAbortRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => cancel, [cancel]);
+
+  const fetchReadmeContent = useCallback(async (variant: ReadmeVariant): Promise<string> => {
+    if (contentAbortRef.current) {
+      contentAbortRef.current.abort();
+    }
+    const controller = new AbortController();
+    contentAbortRef.current = controller;
+    const signal = controller.signal;
+
+    const fetchFromGitHubApi = async (): Promise<string> => {
+      if (!githubToken) {
+        throw new Error(language === 'zh' ? '未登录且后端不可用，无法加载 README' : 'Not logged in and backend unavailable, cannot load README');
+      }
+      const githubApi = new GitHubApiService(githubToken);
+      return variant.isDefault || !variant.path
+        ? githubApi.getRepositoryReadme(owner, name, signal)
+        : githubApi.getRepositoryReadmeByPath(owner, name, variant.path, signal);
+    };
+
+    if (shouldBypassBackend() || !backend.isAvailable) {
+      return fetchFromGitHubApi();
+    }
+
+    try {
+      const content = variant.isDefault || !variant.path
+        ? await backend.getRepositoryReadme(owner, name, signal)
+        : await backend.getRepositoryReadmeByPath(owner, name, variant.path, signal);
+      if (signal.aborted) throw abortOperation();
+      return content;
+    } catch (backendError) {
+      if (signal.aborted) throw abortOperation();
+      if (isAbortError(backendError, signal) || !githubToken) {
+        throw backendError;
+      }
+
+      console.warn('Falling back to direct GitHub README fetch after backend failure:', backendError);
+      const content = await fetchFromGitHubApi();
+      if (signal.aborted) throw abortOperation();
+      return content;
+    }
+  }, [owner, name, githubToken, language]);
+
+  const fetchReadmeCandidates = useCallback(async (defaultBranch: string | undefined): Promise<GitHubReadmeCandidateItem[]> => {
+    if (candidatesAbortRef.current) {
+      candidatesAbortRef.current.abort();
+    }
+    const controller = new AbortController();
+    candidatesAbortRef.current = controller;
+    const signal = controller.signal;
+
+    const fetchFromGitHubApi = async (): Promise<GitHubReadmeCandidateItem[]> => {
+      if (!githubToken) return [];
+      const githubApi = new GitHubApiService(githubToken);
+      return githubApi.listRepositoryReadmeCandidates(owner, name, defaultBranch, signal);
+    };
+
+    if (shouldBypassBackend() || !backend.isAvailable) {
+      return fetchFromGitHubApi();
+    }
+
+    try {
+      const candidates = await backend.listRepositoryReadmeCandidates(owner, name, defaultBranch, signal);
+      if (signal.aborted) throw abortOperation();
+      return candidates;
+    } catch (backendError) {
+      if (signal.aborted) throw abortOperation();
+      if (isAbortError(backendError, signal) || !githubToken) {
+        throw backendError;
+      }
+
+      console.warn('Falling back to direct GitHub README variant detection after backend failure:', backendError);
+      const candidates = await fetchFromGitHubApi();
+      if (signal.aborted) throw abortOperation();
+      return candidates;
+    }
+  }, [owner, name, githubToken]);
+
+  return useMemo(() => ({
+    fetchReadmeContent,
+    fetchReadmeCandidates,
+    cancel,
+  }), [fetchReadmeContent, fetchReadmeCandidates, cancel]);
+};
+
+// 原 ReadmeModal 变体选择的 find(...)||default 提纯。
+export const pickReadmeCandidate = (
+  variants: ReadmeVariant[],
+  selectedKey: string | undefined,
+  defaultVariant: ReadmeVariant,
+): ReadmeVariant => variants.find(variant => variant.key === selectedKey) || defaultVariant;

--- a/src/hooks/useReleaseArtifactActions.test.tsx
+++ b/src/hooks/useReleaseArtifactActions.test.tsx
@@ -266,6 +266,40 @@ describe('useReleaseArtifactActions.generateSummary', () => {
     expect(signals[0].aborted).toBe(true);
   });
 
+  it('reset cancels in-flight summaries so they cannot write back after clearing', async () => {
+    // abort 感知 mock：真实 fetch 在 signal 中止时会以 AbortError 拒绝
+    const resolvers: Array<(value: string) => void> = [];
+    mocks.analyzeReleaseSummary.mockImplementation((_b: string, _m: unknown, signal: AbortSignal) =>
+      new Promise<string>((resolve, reject) => {
+        resolvers.push((value: string) => {
+          if (signal.aborted) {
+            const abortError = new Error('Aborted');
+            abortError.name = 'AbortError';
+            reject(abortError);
+          } else {
+            resolve(value);
+          }
+        });
+      }));
+    const { result } = renderHook(() => useReleaseArtifactActions());
+
+    act(() => {
+      void result.current.generateSummary(release);
+    });
+    expect(result.current.summaries[100]?.status).toBe('loading');
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.summaries).toEqual({});
+
+    // 模拟迟到的完成：请求已被 reset 取消，结果不得回写
+    resolvers[0]('# stale');
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+    expect(result.current.summaries).toEqual({});
+    expect(mocks.toast).not.toHaveBeenCalled();
+  });
+
   it('reset clears summaries and rpc download states', async () => {
     mocks.sendToRpcDownload.mockResolvedValue({ success: true });
     mocks.analyzeReleaseSummary.mockResolvedValue('# Summary');

--- a/src/hooks/useReleaseArtifactActions.test.tsx
+++ b/src/hooks/useReleaseArtifactActions.test.tsx
@@ -1,0 +1,284 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Release } from '../types';
+import { computeRpcDownloadKey, useReleaseArtifactActions } from './useReleaseArtifactActions';
+
+const mocks = vi.hoisted(() => ({
+  useAppStore: vi.fn(),
+  toast: vi.fn(),
+  sendToRpcDownload: vi.fn(),
+  analyzeReleaseSummary: vi.fn(),
+}));
+
+vi.mock('../store/useAppStore', () => ({
+  useAppStore: mocks.useAppStore,
+}));
+
+vi.mock('../hooks/useDialog', () => ({
+  useDialog: () => ({ toast: mocks.toast, confirm: vi.fn() }),
+}));
+
+vi.mock('../services/rpcDownloadService', () => ({
+  sendToRpcDownload: mocks.sendToRpcDownload,
+}));
+
+vi.mock('../services/aiService', () => ({
+  AIService: class {
+    analyzeReleaseSummary = mocks.analyzeReleaseSummary;
+  },
+}));
+
+const createStoreState = () => ({
+  language: 'zh' as const,
+  backendApiSecret: 'secret-1' as string | null,
+  aiConfigs: [{
+    id: 'ai-config',
+    name: 'Test AI',
+    baseUrl: 'https://example.com/v1',
+    apiKey: 'ai-key',
+    model: 'ai-model',
+  }],
+  activeAIConfig: 'ai-config' as string | null,
+});
+
+let storeState = createStoreState();
+const mockUseAppStore = vi.mocked(mocks.useAppStore);
+mockUseAppStore.mockImplementation((selector?: (state: typeof storeState) => unknown) =>
+  selector ? selector(storeState) : storeState);
+(mockUseAppStore as unknown as { getState: () => typeof storeState }).getState = () => storeState;
+
+const release: Release = {
+  id: 100,
+  tag_name: 'v1.0.0',
+  name: 'Version 1.0.0',
+  body: 'Notes body',
+  published_at: '2026-01-02T00:00:00.000Z',
+  html_url: 'https://github.com/owner/repo/releases/tag/v1.0.0',
+  assets: [],
+  prerelease: false,
+  repository: { id: 9, full_name: 'owner/repo', name: 'repo' },
+};
+
+describe('computeRpcDownloadKey', () => {
+  it('versions the key with updatedAt', () => {
+    expect(computeRpcDownloadKey({ url: 'https://x/a.zip', updatedAt: '2026-01-01T00:00:00.000Z' }))
+      .toBe('https://x/a.zip@2026-01-01T00:00:00.000Z');
+    expect(computeRpcDownloadKey({ url: 'https://x/a.zip' })).toBe('https://x/a.zip@');
+    expect(computeRpcDownloadKey({ url: 'https://x/a.zip', updatedAt: undefined })).toBe('https://x/a.zip@');
+  });
+});
+
+describe('useReleaseArtifactActions.sendRpcDownload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeState = createStoreState();
+  });
+
+  it('passes url, name and the backend secret through and records the sent state', async () => {
+    mocks.sendToRpcDownload.mockResolvedValue({ success: true });
+    const { result } = renderHook(() => useReleaseArtifactActions());
+    await act(async () => {
+      await result.current.sendRpcDownload({ url: 'https://x/a.zip', name: 'a.zip', updatedAt: '2026-01-01T00:00:00.000Z' });
+    });
+    expect(mocks.sendToRpcDownload).toHaveBeenCalledWith('https://x/a.zip', 'a.zip', 'secret-1');
+    expect(result.current.rpcDownloadStates['https://x/a.zip@2026-01-01T00:00:00.000Z']).toBe('sent');
+    expect(mocks.toast).toHaveBeenCalledWith('已发送到远程下载器', 'success');
+  });
+
+  it('omits the secret when the store has none', async () => {
+    storeState.backendApiSecret = null;
+    mocks.sendToRpcDownload.mockResolvedValue({ success: true });
+    const { result } = renderHook(() => useReleaseArtifactActions());
+    await act(async () => {
+      await result.current.sendRpcDownload({ url: 'https://x/a.zip', name: 'a.zip' });
+    });
+    expect(mocks.sendToRpcDownload).toHaveBeenCalledWith('https://x/a.zip', 'a.zip', undefined);
+  });
+
+  it('shows the dedicated toast when the RPC service is not running and resets the state', async () => {
+    mocks.sendToRpcDownload.mockResolvedValue({ success: false, error: 'RPC service not running' });
+    const { result } = renderHook(() => useReleaseArtifactActions());
+    await act(async () => {
+      await result.current.sendRpcDownload({ url: 'https://x/a.zip', name: 'a.zip' });
+    });
+    expect(mocks.toast).toHaveBeenCalledWith('远程下载服务未运行，请检查配置', 'error');
+    expect(result.current.rpcDownloadStates['https://x/a.zip@']).toBe('idle');
+  });
+
+  it('falls back to the raw error or a generic message on other failures', async () => {
+    mocks.sendToRpcDownload.mockResolvedValue({ success: false, error: 'quota exceeded' });
+    const { result } = renderHook(() => useReleaseArtifactActions());
+    await act(async () => {
+      await result.current.sendRpcDownload({ url: 'https://x/a.zip', name: 'a.zip' });
+    });
+    expect(mocks.toast).toHaveBeenCalledWith('quota exceeded', 'error');
+
+    mocks.sendToRpcDownload.mockResolvedValue({ success: false });
+    await act(async () => {
+      await result.current.sendRpcDownload({ url: 'https://x/b.zip', name: 'b.zip' });
+    });
+    expect(mocks.toast).toHaveBeenLastCalledWith('发送失败', 'error');
+  });
+
+  it('toasts the not-running message on a thrown error', async () => {
+    mocks.sendToRpcDownload.mockRejectedValue(new Error('socket hang up'));
+    const { result } = renderHook(() => useReleaseArtifactActions());
+    await act(async () => {
+      await result.current.sendRpcDownload({ url: 'https://x/a.zip', name: 'a.zip' });
+    });
+    expect(mocks.toast).toHaveBeenCalledWith('远程下载服务未运行，请检查配置', 'error');
+    expect(result.current.rpcDownloadStates['https://x/a.zip@']).toBe('idle');
+  });
+
+  it('short-circuits while sending and clears the sent state on retry', async () => {
+    let resolveSend!: (value: { success: boolean }) => void;
+    mocks.sendToRpcDownload.mockImplementation(() => new Promise<{ success: boolean }>((resolve) => {
+      resolveSend = resolve;
+    }));
+
+    const { result } = renderHook(() => useReleaseArtifactActions());
+    const link = { url: 'https://x/a.zip', name: 'a.zip' };
+    let first!: Promise<void>;
+    act(() => {
+      first = result.current.sendRpcDownload(link);
+    });
+    expect(result.current.rpcDownloadStates['https://x/a.zip@']).toBe('sending');
+
+    // 发送中重复点击被短路：第二次调用不会发起新请求
+    await act(async () => {
+      await result.current.sendRpcDownload(link);
+    });
+    expect(mocks.sendToRpcDownload).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveSend({ success: true });
+      await first;
+    });
+    expect(result.current.rpcDownloadStates['https://x/a.zip@']).toBe('sent');
+
+    // 重试：清除旧的成功态再发送
+    mocks.sendToRpcDownload.mockResolvedValue({ success: true });
+    await act(async () => {
+      await result.current.sendRpcDownload(link);
+    });
+    expect(mocks.sendToRpcDownload).toHaveBeenCalledTimes(2);
+    expect(result.current.rpcDownloadStates['https://x/a.zip@']).toBe('sent');
+  });
+});
+
+describe('useReleaseArtifactActions.generateSummary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeState = createStoreState();
+  });
+
+  it('toasts without writing state when no AI config is active', async () => {
+    storeState.aiConfigs = [];
+    const { result } = renderHook(() => useReleaseArtifactActions());
+    await act(async () => { await result.current.generateSummary(release); });
+    expect(mocks.toast).toHaveBeenCalledWith('请先在设置中配置 AI 服务。', 'error');
+    expect(result.current.summaries[100]).toBeUndefined();
+    expect(mocks.analyzeReleaseSummary).not.toHaveBeenCalled();
+  });
+
+  it('stores loading → done with the generated content', async () => {
+    mocks.analyzeReleaseSummary.mockResolvedValue('# Summary');
+    const { result } = renderHook(() => useReleaseArtifactActions());
+    await act(async () => { await result.current.generateSummary(release); });
+    expect(mocks.analyzeReleaseSummary).toHaveBeenCalledWith(
+      'Notes body',
+      { repoName: 'owner/repo', tagName: 'v1.0.0', releaseName: 'Version 1.0.0' },
+      expect.any(AbortSignal),
+    );
+    expect(result.current.summaries[100]).toEqual({ status: 'done', content: '# Summary' });
+  });
+
+  it('skips regeneration while loading or when a done summary exists', async () => {
+    mocks.analyzeReleaseSummary.mockResolvedValue('# Summary');
+    const { result } = renderHook(() => useReleaseArtifactActions());
+    await act(async () => { await result.current.generateSummary(release); });
+
+    await act(async () => { await result.current.generateSummary(release); });
+    expect(mocks.analyzeReleaseSummary).toHaveBeenCalledTimes(1);
+
+    // loading 态同样短路
+    let resolveSummary!: (value: string) => void;
+    mocks.analyzeReleaseSummary.mockImplementation(() => new Promise<string>((resolve) => {
+      resolveSummary = resolve;
+    }));
+    const second: Release = { ...release, id: 101 };
+    let pending!: Promise<void>;
+    act(() => {
+      pending = result.current.generateSummary(second);
+    });
+    await act(async () => { await result.current.generateSummary(second); });
+    expect(result.current.summaries[101]?.status).toBe('loading');
+    resolveSummary('# late');
+    await act(async () => { await pending; });
+  });
+
+  it('stores the error state and toasts on failure', async () => {
+    mocks.analyzeReleaseSummary.mockRejectedValue(new Error('model offline'));
+    const { result } = renderHook(() => useReleaseArtifactActions());
+    await act(async () => { await result.current.generateSummary(release); });
+    expect(result.current.summaries[100]).toEqual({ status: 'error', error: 'model offline' });
+    expect(mocks.toast).toHaveBeenCalledWith('总结生成失败：model offline', 'error');
+  });
+
+  it('stays silent on AbortError', async () => {
+    const abortError = new Error('The operation was aborted');
+    abortError.name = 'AbortError';
+    mocks.analyzeReleaseSummary.mockRejectedValue(abortError);
+    const { result } = renderHook(() => useReleaseArtifactActions());
+    await act(async () => { await result.current.generateSummary(release); });
+    expect(mocks.toast).not.toHaveBeenCalled();
+    expect(result.current.summaries[100]).toEqual({ status: 'loading' });
+  });
+
+  it('aborts all in-flight summary requests on unmount', async () => {
+    const signals: AbortSignal[] = [];
+    mocks.analyzeReleaseSummary.mockImplementation((_body: string, _meta: unknown, signal: AbortSignal) => {
+      signals.push(signal);
+      return new Promise<string>(() => undefined);
+    });
+    const { result, unmount } = renderHook(() => useReleaseArtifactActions());
+    act(() => {
+      void result.current.generateSummary(release);
+    });
+    expect(signals[0].aborted).toBe(false);
+    unmount();
+    expect(signals[0].aborted).toBe(true);
+  });
+
+  it('cancelSummaryRequests aborts in-flight requests without unmounting', async () => {
+    const signals: AbortSignal[] = [];
+    mocks.analyzeReleaseSummary.mockImplementation((_body: string, _meta: unknown, signal: AbortSignal) => {
+      signals.push(signal);
+      return new Promise<string>(() => undefined);
+    });
+    const { result } = renderHook(() => useReleaseArtifactActions());
+    act(() => {
+      void result.current.generateSummary(release);
+    });
+    act(() => {
+      result.current.cancelSummaryRequests();
+    });
+    expect(signals[0].aborted).toBe(true);
+  });
+
+  it('reset clears summaries and rpc download states', async () => {
+    mocks.sendToRpcDownload.mockResolvedValue({ success: true });
+    mocks.analyzeReleaseSummary.mockResolvedValue('# Summary');
+    const { result } = renderHook(() => useReleaseArtifactActions());
+    await act(async () => {
+      await result.current.sendRpcDownload({ url: 'https://x/a.zip', name: 'a.zip' });
+      await result.current.generateSummary(release);
+    });
+    expect(result.current.summaries[100]).toEqual({ status: 'done', content: '# Summary' });
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.summaries).toEqual({});
+    expect(result.current.rpcDownloadStates).toEqual({});
+  });
+});

--- a/src/hooks/useReleaseArtifactActions.test.tsx
+++ b/src/hooks/useReleaseArtifactActions.test.tsx
@@ -217,6 +217,19 @@ describe('useReleaseArtifactActions.generateSummary', () => {
     await act(async () => { await pending; });
   });
 
+  it('collapses same-tick consecutive generateSummary calls into a single request', async () => {
+    // loading 守卫读渲染快照：同一事件循环内（同步双调用）第二次仍看到旧快照，
+    // 依赖 summaryAbortRefs 的同步门卫去重。
+    mocks.analyzeReleaseSummary.mockImplementation(() => new Promise<string>(() => undefined));
+    const { result } = renderHook(() => useReleaseArtifactActions());
+    act(() => {
+      void result.current.generateSummary(release);
+      void result.current.generateSummary(release);
+    });
+    expect(mocks.analyzeReleaseSummary).toHaveBeenCalledTimes(1);
+    expect(result.current.summaries[100]?.status).toBe('loading');
+  });
+
   it('stores the error state and toasts on failure', async () => {
     mocks.analyzeReleaseSummary.mockRejectedValue(new Error('model offline'));
     const { result } = renderHook(() => useReleaseArtifactActions());

--- a/src/hooks/useReleaseArtifactActions.test.tsx
+++ b/src/hooks/useReleaseArtifactActions.test.tsx
@@ -300,6 +300,31 @@ describe('useReleaseArtifactActions.generateSummary', () => {
     expect(mocks.toast).not.toHaveBeenCalled();
   });
 
+  it('reset discards late results even when the service ignores the abort signal', async () => {
+    // H1 回归：resolve 型 mock（忽略 signal，不抛 AbortError）——修复前会把迟到
+    // 的 done 回写进刚清空的状态；修复后由 post-await aborted 守卫丢弃。
+    let resolveSummary!: (value: string) => void;
+    mocks.analyzeReleaseSummary.mockImplementation(() => new Promise<string>((resolve) => {
+      resolveSummary = resolve;
+    }));
+    const { result } = renderHook(() => useReleaseArtifactActions());
+
+    act(() => {
+      void result.current.generateSummary(release);
+    });
+    expect(result.current.summaries[100]?.status).toBe('loading');
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.summaries).toEqual({});
+
+    resolveSummary('# stale');
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+    expect(result.current.summaries).toEqual({});
+    expect(mocks.toast).not.toHaveBeenCalled();
+  });
+
   it('reset clears summaries and rpc download states', async () => {
     mocks.sendToRpcDownload.mockResolvedValue({ success: true });
     mocks.analyzeReleaseSummary.mockResolvedValue('# Summary');

--- a/src/hooks/useReleaseArtifactActions.ts
+++ b/src/hooks/useReleaseArtifactActions.ts
@@ -70,10 +70,13 @@ export const useReleaseArtifactActions = (): ReleaseArtifactActions => {
   useEffect(() => cancelSummaryRequests, [cancelSummaryRequests]);
 
   const reset = useCallback(() => {
+    // 先取消进行中的总结请求再清空：否则刷新（sheet 的 loadReleases）后，
+    // 迟到的完成会回写旧结果到刚清空的状态里。
+    cancelSummaryRequests();
     setSummaries({});
     rpcDownloadStatesRef.current = {};
     setRpcDownloadStates({});
-  }, []);
+  }, [cancelSummaryRequests]);
 
   const sendRpcDownload = useCallback(async (link: RpcDownloadLink) => {
     const key = computeRpcDownloadKey(link);

--- a/src/hooks/useReleaseArtifactActions.ts
+++ b/src/hooks/useReleaseArtifactActions.ts
@@ -121,8 +121,13 @@ export const useReleaseArtifactActions = (): ReleaseArtifactActions => {
       return;
     }
 
-    // 请求取消仅经由 cancelSummaryRequests（unmount / reset）；loading 守卫使同 id
-    // 并发不可达，无需"取消上一请求"。
+    // 同步门卫：loading 守卫读的是渲染快照，同一事件循环内的连续调用（双击/重复
+    // 触发）拿到的还是旧快照、会双双通过；summaryAbortRefs 同步更新，可挡住并发
+    // 双请求。
+    if (summaryAbortRefs.current[release.id]) return;
+
+    // 请求取消仅经由 cancelSummaryRequests（unmount / reset）；同步门卫 + loading
+    // 守卫使同 id 并发不可达，无需"取消上一请求"。
     const controller = new AbortController();
     summaryAbortRefs.current[release.id] = controller;
 

--- a/src/hooks/useReleaseArtifactActions.ts
+++ b/src/hooks/useReleaseArtifactActions.ts
@@ -108,8 +108,8 @@ export const useReleaseArtifactActions = (): ReleaseArtifactActions => {
 
   const generateSummary = useCallback(async (release: Release) => {
     const existing = summaries[release.id];
-    // 前置守卫：ReleaseCard 侧由 View 的展开短路保证不重复触发，这里同时兼容
-    // useRepositoryReleaseSheet 的委托调用（loading 中或已有结论时不重跑）。
+    // 前置守卫：loading 中或已有结论时不重跑。ReleaseCard 按钮在 loading 期间本就
+    // disabled（原实现的"取消上一请求"由此不可达，此处守卫化并兼容 sheet 委托）。
     if (existing?.status === 'loading' || (existing?.status === 'done' && existing.content)) return;
 
     const activeConfig = aiConfigs.find((config) => config.id === activeAIConfig);
@@ -121,8 +121,8 @@ export const useReleaseArtifactActions = (): ReleaseArtifactActions => {
       return;
     }
 
-    // 取消上一次未完成的请求
-    summaryAbortRefs.current[release.id]?.abort();
+    // 请求取消仅经由 cancelSummaryRequests（unmount / reset）；loading 守卫使同 id
+    // 并发不可达，无需"取消上一请求"。
     const controller = new AbortController();
     summaryAbortRefs.current[release.id] = controller;
 
@@ -139,10 +139,13 @@ export const useReleaseArtifactActions = (): ReleaseArtifactActions => {
         },
         controller.signal
       );
+      // 对齐原 sheet 的 post-await 守卫：服务不响应 signal 而迟到 resolve 时
+      // （如 reset()/unmount 之后），丢弃过期结果，不得回写刚清空的状态。
+      if (controller.signal.aborted) return;
       setSummaries((previous) => ({ ...previous, [release.id]: { status: 'done', content } }));
     } catch (error) {
-      // 主动取消（卸载/重新发起）时静默处理，不更新状态、不弹错误
-      if (error instanceof Error && error.name === 'AbortError') {
+      // 主动取消（卸载/重置）时静默处理，不更新状态、不弹错误
+      if ((error instanceof Error && error.name === 'AbortError') || controller.signal.aborted) {
         return;
       }
       const message = error instanceof Error ? error.message : String(error);

--- a/src/hooks/useReleaseArtifactActions.ts
+++ b/src/hooks/useReleaseArtifactActions.ts
@@ -1,0 +1,166 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import type { Release } from '../types';
+import { sendToRpcDownload } from '../services/rpcDownloadService';
+import { AIService } from '../services/aiService';
+import { useAppStore } from '../store/useAppStore';
+import { useDialog } from '../hooks/useDialog';
+
+export type ReleaseArtifactSummaryState = {
+  status: 'idle' | 'loading' | 'done' | 'error';
+  content?: string;
+  error?: string;
+};
+
+export type RpcDownloadState = 'idle' | 'sending' | 'sent';
+
+export interface RpcDownloadLink {
+  url: string;
+  name: string;
+  updatedAt?: string;
+}
+
+// 同一资产更新后 URL 不变但 updatedAt 会变，key 带上版本，
+// 否则旧版本的"已发送 ✓"会错误地残留在新版本上。
+export const computeRpcDownloadKey = (link: { url: string; updatedAt?: string }): string =>
+  `${link.url}@${link.updatedAt ?? ''}`;
+
+export interface ReleaseArtifactActions {
+  summaries: Record<number, ReleaseArtifactSummaryState>;
+  rpcDownloadStates: Record<string, RpcDownloadState>;
+  sendRpcDownload: (link: RpcDownloadLink) => Promise<void>;
+  generateSummary: (release: Release) => Promise<void>;
+  cancelSummaryRequests: () => void;
+  /** 清空 summaries 与 RPC 发送状态（sheet 在 loadReleases 时重置，原为其本地 state 置空）。 */
+  reset: () => void;
+}
+
+/**
+ * Release 资产动作（RPC 发送 + AI 总结），规范语义取自 ReleaseCard 版本；
+ * useRepositoryReleaseSheet 委托本 hook（ADR 0001：同一逻辑不允许第三份拷贝）。
+ */
+export const useReleaseArtifactActions = (): ReleaseArtifactActions => {
+  const { language, backendApiSecret, aiConfigs, activeAIConfig } = useAppStore(useShallow((state) => ({
+    language: state.language,
+    backendApiSecret: state.backendApiSecret,
+    aiConfigs: state.aiConfigs,
+    activeAIConfig: state.activeAIConfig,
+  })));
+  const { toast } = useDialog();
+  const t = useCallback((zh: string, en: string) => language === 'zh' ? zh : en, [language]);
+
+  const [summaries, setSummaries] = useState<Record<number, ReleaseArtifactSummaryState>>({});
+  // 渲染态用 useState Record 取代原 ReleaseCard 的 refs + forceUpdate（渲染等价）；
+  // 同步镜像 ref 保留原 ref 的同步短路语义：同一事件循环内的快速连点不会被
+  // setState 的异步批处理放过，避免重复发送。
+  const rpcDownloadStatesRef = useRef<Record<string, RpcDownloadState>>({});
+  const [rpcDownloadStates, setRpcDownloadStates] = useState<Record<string, RpcDownloadState>>({});
+  const applyRpcDownloadState = useCallback((key: string, state: RpcDownloadState) => {
+    rpcDownloadStatesRef.current = { ...rpcDownloadStatesRef.current, [key]: state };
+    setRpcDownloadStates(rpcDownloadStatesRef.current);
+  }, []);
+
+  const summaryAbortRefs = useRef<Record<number, AbortController | undefined>>({});
+
+  const cancelSummaryRequests = useCallback(() => {
+    Object.values(summaryAbortRefs.current).forEach((controller) => controller?.abort());
+    summaryAbortRefs.current = {};
+  }, []);
+
+  useEffect(() => cancelSummaryRequests, [cancelSummaryRequests]);
+
+  const reset = useCallback(() => {
+    setSummaries({});
+    rpcDownloadStatesRef.current = {};
+    setRpcDownloadStates({});
+  }, []);
+
+  const sendRpcDownload = useCallback(async (link: RpcDownloadLink) => {
+    const key = computeRpcDownloadKey(link);
+    // 仅在发送进行中时短路，允许发送完成后再次点击重新发送
+    if (rpcDownloadStatesRef.current[key] === 'sending') return;
+
+    // 重试开始即清除旧的成功态：若本次失败/异常，行内不得残留 ✓，
+    // 否则卡片会把失败的重试报告成成功。
+    applyRpcDownloadState(key, 'sending');
+    try {
+      const result = await sendToRpcDownload(link.url, link.name, backendApiSecret || undefined);
+      if (result.success) {
+        applyRpcDownloadState(key, 'sent');
+        toast(t('已发送到远程下载器', 'Sent to remote downloader'), 'success');
+      } else {
+        applyRpcDownloadState(key, 'idle');
+        toast(
+          result.error === 'RPC service not running'
+            ? t('远程下载服务未运行，请检查配置', 'Remote download service not running, please check config')
+            : result.error || t('发送失败', 'Send failed'),
+          'error'
+        );
+      }
+    } catch {
+      applyRpcDownloadState(key, 'idle');
+      toast(t('远程下载服务未运行，请检查配置', 'Remote download service not running, please check config'), 'error');
+    }
+  }, [applyRpcDownloadState, backendApiSecret, t, toast]);
+
+  const generateSummary = useCallback(async (release: Release) => {
+    const existing = summaries[release.id];
+    // 前置守卫：ReleaseCard 侧由 View 的展开短路保证不重复触发，这里同时兼容
+    // useRepositoryReleaseSheet 的委托调用（loading 中或已有结论时不重跑）。
+    if (existing?.status === 'loading' || (existing?.status === 'done' && existing.content)) return;
+
+    const activeConfig = aiConfigs.find((config) => config.id === activeAIConfig);
+    if (!activeConfig) {
+      toast(
+        language === 'zh' ? '请先在设置中配置 AI 服务。' : 'Please configure AI service in settings first.',
+        'error'
+      );
+      return;
+    }
+
+    // 取消上一次未完成的请求
+    summaryAbortRefs.current[release.id]?.abort();
+    const controller = new AbortController();
+    summaryAbortRefs.current[release.id] = controller;
+
+    const config = activeConfig;
+    setSummaries((previous) => ({ ...previous, [release.id]: { status: 'loading' } }));
+    try {
+      const aiService = new AIService(config, language);
+      const content = await aiService.analyzeReleaseSummary(
+        release.body || '',
+        {
+          repoName: release.repository.full_name,
+          tagName: release.tag_name,
+          releaseName: release.name && release.name !== release.tag_name ? release.name : undefined,
+        },
+        controller.signal
+      );
+      setSummaries((previous) => ({ ...previous, [release.id]: { status: 'done', content } }));
+    } catch (error) {
+      // 主动取消（卸载/重新发起）时静默处理，不更新状态、不弹错误
+      if (error instanceof Error && error.name === 'AbortError') {
+        return;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      setSummaries((previous) => ({ ...previous, [release.id]: { status: 'error', error: message } }));
+      toast(
+        language === 'zh' ? `总结生成失败：${message}` : `Summary failed: ${message}`,
+        'error'
+      );
+    } finally {
+      if (summaryAbortRefs.current[release.id] === controller) {
+        delete summaryAbortRefs.current[release.id];
+      }
+    }
+  }, [activeAIConfig, aiConfigs, language, summaries, toast]);
+
+  return useMemo(() => ({
+    summaries,
+    rpcDownloadStates,
+    sendRpcDownload,
+    generateSummary,
+    cancelSummaryRequests,
+    reset,
+  }), [summaries, rpcDownloadStates, sendRpcDownload, generateSummary, cancelSummaryRequests, reset]);
+};


### PR DESCRIPTION
## 概述

按 `docs/plans/allowlist-migration-plan.md`（ADR 0001 · B 方案：搬运 + 顺手提纯 · 单 PR）完成 allowlist 清零迁移：10 个 View 组件的远程调用与 Store 写入全部收敛进 hook，最后整体删除 `eslint.config.js` 与 `scripts/check-boundaries.cjs` 的 allowlist 机制（非置空）。行为零变更，例外见下文"已声明的行为微差异"。

## Commit 切分（19 commits，每 commit 门禁可过）

1. `refactor(gists)` GistEditorModal 类型改从 useGistActions 重导出引（§5，规则零改动）
2. `feat(gists)` useGistActions 扩展 analyzeOne/unstarGist/deleteGist/fetchGistFileRaw + patch 纯函数 + 单测
3. `feat(discovery)` 新建 useDiscoveryRepoActions + discoveryRepoPatches + 单测
4. `feat(readme)` 新建 src/hooks/useReadmeFetch + pickReadmeCandidate + 单测
5. `feat(release)` 新建 useReleaseArtifactActions + 单测；useRepositoryReleaseSheet 改委托（同 commit，避免第三份拷贝）
6. `feat(releases)` useReleaseTimelineActions 新增 syncWatchedSources + 单测
7. `feat(settings)` 新建 useBackendAvailability
8. `feat(repositories)` 新建 useSearchActions + 4 个纯函数 + 单测
9. 逐 View 切换（9a–9i：GistCard → GistDetailModal → SettingsPanel → RepositoryEditModal → ReleaseSourceSettingsModal → SubscriptionRepoCard → ReleaseCard → ReadmeModal → SearchBar）
10. `chore(boundaries)` 删除 allowlist 机制（常量 + 镜像 Set + ignores 接线 + 早返 + 相关注释，整体删除）
11. `fix(review)` 审计修复（见下文）

## 已声明的行为微差异（零行为变更的唯一例外）

按规格 §2.5 的 3 处（useRepositoryReleaseSheet 委托，规范语义 = ReleaseCard 版本）：

1. **dedup key**：sheet 的 RPC 下载状态 key 由 `url` 变为 `url@updatedAt`（与 ReleaseCard 一致，修同病灶）；`RepositoryReleaseSheet.tsx` UI 及其测试同步换 key。
2. **AI 配置缺失**：由"静默置 error 态"变"toast 不置态"——Sheet 内不再出现行内错误卡片，仅有 toast 提示。
3. **RPC 失败文案**：统一为 ReleaseCard 版（'远程下载服务未运行，请检查配置' 等）。

审计后补充声明的 3 处（行为等价或不可达）：

4. **sheet 的 `sendAssetToRpc` 不再阻断"已发送后重发"**（共享 hook 语义允许重试）——sheet UI 的 `disabled={isSending || isSent}` 仍阻止实际点击，无可见变化；仅 hook 层面守卫差异。
5. **GistView 的 `onDeleted` 改从 store 直接订阅 `deleteGist`**：useGistActions 新增的卡片级 `deleteGist(gist, onDeleted?)` 有意遮蔽经 `...state` 展开的同名 store action（签名不同、内置确认），GistView 只需原始 store action 按 id 移除记录，行为不变。
6. **SubscriptionRepoCard 的 `pendingUnstarAction` 残留 state 移除**：确认按钮直调 hook 的稳定 `executeUnstar`，原"暂存动作再调用"模式已无必要，可见行为等价。
7. **`syncWatchedSources` 的 `hiddenByRepo` 读取时机**：由"调用时的快照"改为"await 完成后从最新 store 读取"（`12c59bc`）——同步期间在设置面板切换 `release_hidden` 不再被旧快照覆盖，属正确性提升。
8. **AI 总结的 loading 守卫语义**：同 id 请求进行中再次触发由"abort 旧请求重发起"变为"静默忽略"——原 ReleaseCard 按钮 loading 期间本就 disabled，重发起路径在原 UI 中不可达；守卫化同时是 sheet 委托防重复触发的必要条件。

## 计划外但必要的实现决策

- **`useReadmeFetch` 在自身 controller 被 abort 时以 `AbortError` 命名的错误 reject**：原 View 在 await 后用 `signal.aborted` 丢弃过期结果并跳过 `setLoading(false)`；abort 实体移交 hook 后 View 拿不到 signal，由 hook 抛 AbortError、View 用既有 `isAbortError` 判定，保持"静默丢弃 + 不动 loading"的语义（否则会出现新请求把 loading 误关的闪烁回归）。
- **`useReleaseArtifactActions` 增加稳定 ref 镜像**：`sendRpcDownload` 的 sending 短路读 ref（同步语义，防同 tick 连点双发），渲染态走 `useState` Record（替换原 refs+forceUpdate，渲染等价）；另按 sheet 的 `loadReleases` 原有置空行为补了 `reset()`（规格未列及，缺了会丢"刷新后清空总结/下载状态"的行为）。
- **审计修复**（`fix(review)` commit）：sheet 的 unmount-cancel effect 曾依赖整个 `artifactActions` 对象（随状态更新换引用），会在每次状态更新时触发 cleanup 自我中止进行中的 AI 总结并卡死 loading——已改为只依赖共享 hook 内零依赖的稳定 `cancelSummaryRequests`，并补 abort 感知回归测试；`fetchGistFileRaw` 依赖只含 token（语言改 `getState()` 读取），避免 GistDetailModal 因语言切换重拉大文件。

## 测试

- 新增 8 个测试文件（useSearchActions 23 例、useGistActions 16 例、useDiscoveryRepoActions + patches 14 例、useReadmeFetch 17 例、useReleaseArtifactActions 18 例、useReleaseTimelineActions 4 例、useBackendAvailability 2 例），并为存量 `useRepositoryReleaseSheet.test.tsx` 扩展 1 个委托回归用例（同步门卫/状态回写）。
- 存量测试零预防性重写：`useRepositoryCardActions`、`SearchBar`、`RepositoryEditModal`、`ReadmeModal`、`ReleaseCard`、`ReleaseTimeline`、`ForkTimeline`、`BackendPanel` 全部按原样通过；`useAppStore.modularization.test` 零改动通过（Store 未动的证明，`git diff main -- src/store` 为空）。

## 验收（全绿）

```
npm run lint                        # eslint . 全仓
node scripts/check-boundaries.cjs   # 边界扫描（allowlist 已删）
npm run test:run                    # vitest run：76 文件 / 724 用例
npm run typecheck                   # tsc -b --noEmit
rg 四项口径（静态/动态/export-from/死接线）均为空
```

## Follow-up（本 PR 不做，见规格 §10）

ADR 勘误（ban list 10→12、allowlist 已清零）、application DOM/JSX 禁令机制化、search/gists/releases 提纯函数下沉评估、routeMode 文档化、useVectorSearchActions 校验补齐等。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 统一 Gist、发现页仓库、Release 和 README 的操作流程，提升分析、收藏、删除、下载及内容获取的一致性。
  - README 获取支持后端优先、GitHub 备用，并改善取消、重复请求及过期结果处理。
  - 优化搜索、星标同步、分类同步及失败回退流程。
  - 优化 Release 资源下载、AI 摘要处理、Watch 仓库同步和后端可用性判断。
- **测试**
  - 扩充搜索、README、Release、Gist 和发现页操作的自动化测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

