### PR TITLE
fix(ui): 修复"资产已更新"徽标挤压时间列导致两者换行

### DIFF
--- a/src/components/ReleaseCard.tsx
+++ b/src/components/ReleaseCard.tsx
@@ -164,9 +164,12 @@ const ReleaseCard: React.FC<ReleaseCardProps> = memo(({
             </div>
           </div>
 
-          <div className="flex items-center gap-3 flex-shrink-0 self-center md:w-[496px] md:justify-end">
-            <div className="hidden md:flex w-[140px] shrink-0 flex-col justify-center gap-1.5 text-xs text-muted-foreground dark:text-muted-foreground">
-              <div className="flex items-center gap-1.5">
+          {/* 元信息列不设固定上限：出现“资产已更新”徽标时整行向左扩展（min-w 保证
+              无徽标时仍维持 140px 栏宽对齐），否则 140px 内放不下徽标会把时间和
+              徽标文字都挤到换行；按钮区仍固定 344px 靠右，位置不受影响。 */}
+          <div className="flex items-center gap-3 flex-shrink-0 self-center md:justify-end">
+            <div className="hidden md:flex md:min-w-[140px] shrink-0 flex-col justify-center gap-1.5 text-xs text-muted-foreground dark:text-muted-foreground">
+              <div className="flex items-center gap-1.5 whitespace-nowrap">
                 <Calendar className="w-3.5 h-3.5" />
                 <span>
                   {formatDistanceToNow(new Date(effectiveTime), {


### PR DESCRIPTION
## Summary

ReleaseCard 头部右侧元信息列被外层容器固定宽度（`md:w-[496px]` = 时间列 140 + 间距 12 + 按钮区 344）钉死为 `w-[140px]`，一旦出现"资产已更新"徽标，该行超出列宽，时间和徽标文字被同时挤到换行（如"大约 2 小时/前"、"资产已更/新"）。

修复方式：

- 外层容器去掉 `md:w-[496px]` 固定宽度，改为随内容自适应；
- 时间列 `w-[140px]` → `md:min-w-[140px]`：无徽标时栏宽与对齐完全不变，有徽标时整列向左自然扩展腾出空间；
- 时间行加 `whitespace-nowrap`，时间和徽标文字不再换行；
- 右侧按钮区仍固定 344px 靠右，位置不受影响。

与仓库分组头部的同类徽标（ReleaseTimeline，本就是 `whitespace-nowrap` 自动向左伸展）行为对齐，也与 ForkCard 元信息列既有的 `min-w-[140px]` 模式一致。

## Verification

按模板顺序本地全部通过：

- [x] `npm run check:boundaries`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:run`（76 个测试文件 / 741 个测试全部通过）
- [x] `npm run build`（legacy bundle 998.58 KiB ≤ 3000 KiB）
- [x] `git diff --check`

## Scope checklist

- [x] **Runtime/persistence/UI changes described.** 仅 UI 样式类名调整，无运行时逻辑、持久化数据改动（Store keys / `version` / `partialize` / `migrate` / `merge` 均未触及），无迁移影响。
- [x] No new `import` of a business service directly into `src/components/**`
- [x] No new `import` of React/JSX/the Store/any service into `src/features/*/application/**`
- [x] No inline `eslint-disable` to bypass the boundary rules

### Runtime / persistence / UI changes (if any)

UI：ReleaseCard 头部元信息列布局调整——"资产已更新"徽标出现时，时间行整体向左扩展而不是换行。纯 className 变更，无 DOM 结构变化，无逻辑改动。

## Notes for reviewers / CodeRabbit

纯样式类名改动，预期无行为回归。jsdom 无法断言 CSS 换行行为，故未新增测试；现有 ReleaseCard / ReleaseTimeline 测试全部通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **样式**
  * 优化发布卡片头部元信息布局。
  * “资产已更新”徽标显示时，时间信息保持单行展示，避免换行。
  * 无徽标时继续保持元信息列的对齐效果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->