### PR TITLE
feat(search): 无向量 AI 搜索降级链改为「词法召回 + LLM 精选排序」

### DIFF
--- a/src/features/repositories/hooks/useSearchActions.test.tsx
+++ b/src/features/repositories/hooks/useSearchActions.test.tsx
@@ -479,6 +479,37 @@ describe('useSearchActions.keywordSearch', () => {
     expect(result.current.skipNextTextSearchRef.current).toBe(true);
   });
 
+  it('toasts the fallback reason when AI selection reports a failure', async () => {
+    storeState.vectorSearchConfig = {
+      enabled: true,
+      workerUrl: 'https://worker.example',
+      authToken: 'worker-token',
+      embeddingConfigId: 'emb',
+      indexMode: 'description',
+      readmeMaxChars: 6000,
+      enableHyDE: false,
+    };
+    storeState.repositories = [
+      baseRepo({ id: 1, full_name: 'owner/foo-repo' }),
+      baseRepo({ id: 2, full_name: 'owner/bar-repo' }),
+    ];
+    mocks.embed.mockResolvedValue([[0.1]]);
+    mocks.vectorQuery.mockResolvedValue([]);
+    // 端点抖动/配置问题：service 回调 ai_failed，词法命中照常返回
+    mocks.searchRepositoriesWithSelection.mockImplementation(
+      (_repos: Repository[], _query: string, opts?: { onFallback?: (reason: string) => void }) => {
+        opts?.onFallback?.('ai_failed');
+        return Promise.resolve([storeState.repositories[0]]);
+      },
+    );
+
+    const { result } = renderHook(() => useSearchActions());
+    await act(async () => { await result.current.aiSearch('foo', identity); });
+
+    expect(mocks.toast).toHaveBeenCalledWith('AI 请求失败，已回退本地词法搜索', 'warning');
+    expect(storeState.setSearchResults).toHaveBeenCalledWith([storeState.repositories[0]]);
+  });
+
   it('uses basic text search directly when no AI config exists', async () => {
     storeState.aiConfigs = [];
     storeState.repositories = [

--- a/src/features/repositories/hooks/useSearchActions.test.tsx
+++ b/src/features/repositories/hooks/useSearchActions.test.tsx
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
   vectorQuery: vi.fn(),
   generateHyDEQuery: vi.fn(),
   searchRepositoriesWithSemanticReranking: vi.fn(),
-  searchRepositoriesWithReranking: vi.fn(),
+  searchRepositoriesWithSelection: vi.fn(),
   getAllStarredRepositories: vi.fn(),
   getUserLists: vi.fn(),
   forceSyncToBackend: vi.fn(),
@@ -48,7 +48,7 @@ vi.mock('../../../services/aiService', () => ({
   AIService: class {
     generateHyDEQuery = mocks.generateHyDEQuery;
     searchRepositoriesWithSemanticReranking = mocks.searchRepositoriesWithSemanticReranking;
-    searchRepositoriesWithReranking = mocks.searchRepositoriesWithReranking;
+    searchRepositoriesWithSelection = mocks.searchRepositoriesWithSelection;
   },
 }));
 
@@ -245,7 +245,7 @@ describe('useSearchActions.aiSearch (vector hit)', () => {
       });
       mocks.embed.mockResolvedValue([[0.1]]);
       mocks.vectorQuery.mockResolvedValue([]);
-      mocks.searchRepositoriesWithReranking.mockResolvedValue([]);
+      mocks.searchRepositoriesWithSelection.mockResolvedValue([]);
 
       const { result } = renderHook(() => useSearchActions());
       let promise!: Promise<void>;
@@ -265,7 +265,7 @@ describe('useSearchActions.aiSearch (vector hit)', () => {
     const { result } = renderHook(() => useSearchActions());
     await act(async () => { await result.current.aiSearch('   ', identity); });
     expect(mocks.embed).not.toHaveBeenCalled();
-    expect(mocks.searchRepositoriesWithReranking).not.toHaveBeenCalled();
+    expect(mocks.searchRepositoriesWithSelection).not.toHaveBeenCalled();
     expect(storeState.setSearchResults).not.toHaveBeenCalled();
     expect(storeState.setSearchFilters).not.toHaveBeenCalled();
     expect(result.current.isSearching).toBe(false);
@@ -288,7 +288,7 @@ describe('useSearchActions.aiSearch (vector hit)', () => {
       baseRepo({ id: 2, full_name: 'owner/bar-repo' }),
     ];
     mocks.embed.mockResolvedValue([]);
-    mocks.searchRepositoriesWithReranking.mockResolvedValue([storeState.repositories[0]]);
+    mocks.searchRepositoriesWithSelection.mockResolvedValue([storeState.repositories[0]]);
 
     const { result } = renderHook(() => useSearchActions());
     await act(async () => { await result.current.aiSearch('foo', identity); });
@@ -317,7 +317,7 @@ describe('useSearchActions.aiSearch (vector hit)', () => {
     mocks.vectorQuery.mockResolvedValue([
       { id: '99', score: 0.9, metadata: { full_name: '', description: '', tags: [] } },
     ]);
-    mocks.searchRepositoriesWithReranking.mockResolvedValue([storeState.repositories[0]]);
+    mocks.searchRepositoriesWithSelection.mockResolvedValue([storeState.repositories[0]]);
 
     const { result } = renderHook(() => useSearchActions());
     await act(async () => { await result.current.aiSearch('foo', identity); });
@@ -343,7 +343,7 @@ describe('useSearchActions.aiSearch (vector hit)', () => {
       baseRepo({ id: 2, full_name: 'owner/bar-repo' }),
     ];
     mocks.embed.mockRejectedValue(new Error('embed down'));
-    mocks.searchRepositoriesWithReranking.mockResolvedValue([storeState.repositories[0]]);
+    mocks.searchRepositoriesWithSelection.mockResolvedValue([storeState.repositories[0]]);
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     const { result } = renderHook(() => useSearchActions());
@@ -369,7 +369,7 @@ describe('useSearchActions.aiSearch (vector hit)', () => {
     mocks.generateHyDEQuery.mockResolvedValue('an ideal description of foo');
     mocks.embed.mockResolvedValue([[0.1]]);
     mocks.vectorQuery.mockResolvedValue([]);
-    mocks.searchRepositoriesWithReranking.mockResolvedValue([]);
+    mocks.searchRepositoriesWithSelection.mockResolvedValue([]);
 
     const { result } = renderHook(() => useSearchActions());
     await act(async () => { await result.current.aiSearch('foo', identity); });
@@ -383,7 +383,7 @@ describe('useSearchActions.keywordSearch', () => {
     setupStoreMocks();
   });
 
-  it('falls back to basic text search when AI reranking fails and vector search found nothing', async () => {
+  it('falls back to basic text search when AI selection fails and vector search found nothing', async () => {
     storeState.vectorSearchConfig = {
       enabled: true,
       workerUrl: 'https://worker.example',
@@ -399,16 +399,76 @@ describe('useSearchActions.keywordSearch', () => {
     ];
     mocks.embed.mockResolvedValue([[0.1]]);
     mocks.vectorQuery.mockResolvedValue([]);
-    mocks.searchRepositoriesWithReranking.mockRejectedValue(new Error('ai down'));
+    mocks.searchRepositoriesWithSelection.mockRejectedValue(new Error('ai down'));
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     const { result } = renderHook(() => useSearchActions());
     await act(async () => { await result.current.aiSearch('foo', identity); });
     warnSpy.mockRestore();
 
-    expect(mocks.searchRepositoriesWithReranking).toHaveBeenCalledTimes(1);
+    expect(mocks.searchRepositoriesWithSelection).toHaveBeenCalledTimes(1);
     expect(storeState.setSearchResults).toHaveBeenCalledWith([storeState.repositories[0]]);
     expect(storeState.setSearchFilters).toHaveBeenCalledWith({ query: 'foo' });
+  });
+
+  it('presents an empty result when AI selection explicitly returns no relevant repositories', async () => {
+    storeState.vectorSearchConfig = {
+      enabled: true,
+      workerUrl: 'https://worker.example',
+      authToken: 'worker-token',
+      embeddingConfigId: 'emb',
+      indexMode: 'description',
+      readmeMaxChars: 6000,
+      enableHyDE: false,
+    };
+    storeState.repositories = [
+      baseRepo({ id: 1, full_name: 'owner/foo-repo' }),
+      baseRepo({ id: 2, full_name: 'owner/bar-repo' }),
+    ];
+    mocks.embed.mockResolvedValue([[0.1]]);
+    mocks.vectorQuery.mockResolvedValue([]);
+    // 模型明确判断"没有相关仓库"：返回 [] 是合法结果，UI 应呈现空态而非全库噪声
+    mocks.searchRepositoriesWithSelection.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useSearchActions());
+    await act(async () => { await result.current.aiSearch('完全不相关的东西', identity); });
+
+    expect(storeState.setSearchResults).toHaveBeenCalledWith([]);
+    expect(storeState.setSearchFilters).toHaveBeenCalledWith({ query: '完全不相关的东西' });
+  });
+
+  it('keeps the AI-provided ordering instead of the default star ordering', async () => {
+    storeState.vectorSearchConfig = {
+      enabled: true,
+      workerUrl: 'https://worker.example',
+      authToken: 'worker-token',
+      embeddingConfigId: 'emb',
+      indexMode: 'description',
+      readmeMaxChars: 6000,
+      enableHyDE: false,
+    };
+    storeState.repositories = [
+      baseRepo({ id: 1, full_name: 'owner/high-star', stargazers_count: 1000 }),
+      baseRepo({ id: 2, full_name: 'owner/low-star', stargazers_count: 3 }),
+    ];
+    mocks.embed.mockResolvedValue([[0.1]]);
+    mocks.vectorQuery.mockResolvedValue([]);
+    // LLM 精选把低 star 的排在前面：applyFilters 的 star 降序不能覆盖该顺序
+    mocks.searchRepositoriesWithSelection.mockResolvedValue([
+      storeState.repositories[1],
+      storeState.repositories[0],
+    ]);
+    // 模拟 SearchBar 真实的 applyFilters：按 star 降序排序
+    const starSort = (repos: Repository[]) =>
+      [...repos].sort((a, b) => (b.stargazers_count || 0) - (a.stargazers_count || 0));
+
+    const { result } = renderHook(() => useSearchActions());
+    await act(async () => { await result.current.aiSearch('foo', starSort); });
+
+    expect(storeState.setSearchResults).toHaveBeenCalledWith([
+      storeState.repositories[1],
+      storeState.repositories[0],
+    ]);
   });
 
   it('uses basic text search directly when no AI config exists', async () => {
@@ -420,7 +480,7 @@ describe('useSearchActions.keywordSearch', () => {
     const { result } = renderHook(() => useSearchActions());
     await act(async () => { await result.current.keywordSearch('foo', identity); });
 
-    expect(mocks.searchRepositoriesWithReranking).not.toHaveBeenCalled();
+    expect(mocks.searchRepositoriesWithSelection).not.toHaveBeenCalled();
     expect(storeState.setSearchResults).toHaveBeenCalledWith([storeState.repositories[0]]);
   });
 });

--- a/src/features/repositories/hooks/useSearchActions.test.tsx
+++ b/src/features/repositories/hooks/useSearchActions.test.tsx
@@ -544,6 +544,39 @@ describe('useSearchActions.keywordSearch', () => {
     expect(result.current.isSearching).toBe(false);
   });
 
+  it('supersedes an in-flight AI search: the previous signal aborts and writes nothing', async () => {
+    storeState.repositories = [
+      baseRepo({ id: 1, full_name: 'owner/foo-repo' }),
+      baseRepo({ id: 2, full_name: 'owner/bar-repo' }),
+    ];
+    const signals: Array<AbortSignal | undefined> = [];
+    mocks.searchRepositoriesWithSelection.mockImplementation(
+      (_repos: Repository[], _query: string, opts?: { signal?: AbortSignal }) => {
+        signals.push(opts?.signal);
+        // 模拟真实在途请求：signal abort 时以 AbortError 拒绝
+        return new Promise<Repository[]>((_resolve, reject) => {
+          opts?.signal?.addEventListener('abort', () => {
+            reject(Object.assign(new Error('The operation was aborted.'), { name: 'AbortError' }));
+          });
+        });
+      },
+    );
+
+    const { result } = renderHook(() => useSearchActions());
+    let first!: Promise<void>;
+    await act(async () => { first = result.current.aiSearch('first', identity); });
+    // 第二次搜索（不 await：模拟仍在途）启动时中止第一次
+    await act(async () => { result.current.aiSearch('second', identity); });
+    // 第二次搜索的启动即中止第一次的在途 controller
+    expect(signals[0]?.aborted).toBe(true);
+    expect(signals[1]?.aborted).toBe(false);
+    await act(async () => { await first; });
+
+    // 被取代的搜索不得写入结果，也不复位第二次搜索的 isSearching
+    expect(storeState.setSearchResults).not.toHaveBeenCalled();
+    expect(result.current.isSearching).toBe(true);
+  });
+
   it('uses basic text search directly when no AI config exists', async () => {
     storeState.aiConfigs = [];
     storeState.repositories = [

--- a/src/features/repositories/hooks/useSearchActions.test.tsx
+++ b/src/features/repositories/hooks/useSearchActions.test.tsx
@@ -509,6 +509,9 @@ describe('useSearchActions.keywordSearch', () => {
 
     expect(mocks.toast).toHaveBeenCalledWith('AI 请求失败，已回退本地词法搜索', 'warning');
     expect(storeState.setSearchResults).toHaveBeenCalledWith([storeState.repositories[0]]);
+    // 兜底结果（加权词法 + CJK bigram 召回）优于过滤 effect 的 AND 整串匹配，
+    // 必须置位 skipNextTextSearchRef 防止被其重设（CJK 查询会被重设为空）
+    expect(result.current.skipNextTextSearchRef.current).toBe(true);
   });
 
   it('stops quietly without fallback results when the search is cancelled', async () => {

--- a/src/features/repositories/hooks/useSearchActions.test.tsx
+++ b/src/features/repositories/hooks/useSearchActions.test.tsx
@@ -322,7 +322,8 @@ describe('useSearchActions.aiSearch (vector hit)', () => {
     const { result } = renderHook(() => useSearchActions());
     await act(async () => { await result.current.aiSearch('foo', identity); });
 
-    expect(result.current.skipNextTextSearchRef.current).toBe(false);
+    // 落入 keywordSearch 后 AI 精选成功：结果须像向量路径一样挡住过滤 effect 的覆盖
+    expect(result.current.skipNextTextSearchRef.current).toBe(true);
     expect(storeState.setSearchResults).toHaveBeenCalledWith([storeState.repositories[0]]);
     expect(storeState.setSearchFilters).toHaveBeenCalledWith({ query: 'foo' });
   });
@@ -409,6 +410,8 @@ describe('useSearchActions.keywordSearch', () => {
     expect(mocks.searchRepositoriesWithSelection).toHaveBeenCalledTimes(1);
     expect(storeState.setSearchResults).toHaveBeenCalledWith([storeState.repositories[0]]);
     expect(storeState.setSearchFilters).toHaveBeenCalledWith({ query: 'foo' });
+    // AI 失败走基础文本搜索兜底：顺序非 AI 产物，无需挡 SearchBar 的过滤 effect
+    expect(result.current.skipNextTextSearchRef.current).toBe(false);
   });
 
   it('presents an empty result when AI selection explicitly returns no relevant repositories', async () => {
@@ -435,6 +438,8 @@ describe('useSearchActions.keywordSearch', () => {
 
     expect(storeState.setSearchResults).toHaveBeenCalledWith([]);
     expect(storeState.setSearchFilters).toHaveBeenCalledWith({ query: '完全不相关的东西' });
+    // 空态是模型的明确判断，同样必须挡住 SearchBar 过滤 effect 的回填
+    expect(result.current.skipNextTextSearchRef.current).toBe(true);
   });
 
   it('keeps the AI-provided ordering instead of the default star ordering', async () => {
@@ -469,6 +474,9 @@ describe('useSearchActions.keywordSearch', () => {
       storeState.repositories[1],
       storeState.repositories[0],
     ]);
+    // AI 结果的顺序/子集/空态不能被 SearchBar 的过滤 effect 用基础文本搜索覆盖：
+    // keywordSearch 需像向量路径一样置位 skipNextTextSearchRef
+    expect(result.current.skipNextTextSearchRef.current).toBe(true);
   });
 
   it('uses basic text search directly when no AI config exists', async () => {

--- a/src/features/repositories/hooks/useSearchActions.test.tsx
+++ b/src/features/repositories/hooks/useSearchActions.test.tsx
@@ -50,6 +50,7 @@ vi.mock('../../../services/aiService', () => ({
     searchRepositoriesWithSemanticReranking = mocks.searchRepositoriesWithSemanticReranking;
     searchRepositoriesWithSelection = mocks.searchRepositoriesWithSelection;
   },
+  isAbortError: (error: unknown) => error instanceof Error && error.name === 'AbortError',
 }));
 
 vi.mock('../../../services/githubApi', () => ({
@@ -508,6 +509,36 @@ describe('useSearchActions.keywordSearch', () => {
 
     expect(mocks.toast).toHaveBeenCalledWith('AI 请求失败，已回退本地词法搜索', 'warning');
     expect(storeState.setSearchResults).toHaveBeenCalledWith([storeState.repositories[0]]);
+  });
+
+  it('stops quietly without fallback results when the search is cancelled', async () => {
+    storeState.vectorSearchConfig = {
+      enabled: true,
+      workerUrl: 'https://worker.example',
+      authToken: 'worker-token',
+      embeddingConfigId: 'emb',
+      indexMode: 'description',
+      readmeMaxChars: 6000,
+      enableHyDE: false,
+    };
+    storeState.repositories = [
+      baseRepo({ id: 1, full_name: 'owner/foo-repo' }),
+      baseRepo({ id: 2, full_name: 'owner/bar-repo' }),
+    ];
+    mocks.embed.mockResolvedValue([[0.1]]);
+    mocks.vectorQuery.mockResolvedValue([]);
+    // service 按契约把 AbortError 向上重抛：取消不是失败，hook 不做基础文本兜底
+    mocks.searchRepositoriesWithSelection.mockRejectedValue(
+      Object.assign(new Error('The operation was aborted.'), { name: 'AbortError' }),
+    );
+
+    const { result } = renderHook(() => useSearchActions());
+    await act(async () => { await result.current.aiSearch('foo', identity); });
+
+    expect(mocks.toast).not.toHaveBeenCalled();
+    expect(storeState.setSearchResults).not.toHaveBeenCalled();
+    expect(storeState.setSearchFilters).not.toHaveBeenCalled();
+    expect(result.current.isSearching).toBe(false);
   });
 
   it('uses basic text search directly when no AI config exists', async () => {

--- a/src/features/repositories/hooks/useSearchActions.ts
+++ b/src/features/repositories/hooks/useSearchActions.ts
@@ -283,6 +283,10 @@ export const useSearchActions = (): SearchActions => {
       finalFiltered.sort((a, b) =>
         (aiOrder.get(String(a.id)) ?? Number.MAX_SAFE_INTEGER)
         - (aiOrder.get(String(b.id)) ?? Number.MAX_SAFE_INTEGER));
+      // 下面 setSearchFilters({ query }) 会触发 SearchBar 的过滤 effect，用基础
+      // 文本搜索+star 排序重设结果——LLM 精选的顺序、子集与显式空态都会被覆盖。
+      // 与向量路径同用 skipNextTextSearchRef 挡掉这次 effect（含空结果场景）。
+      skipNextTextSearchRef.current = true;
     }
     setSearchResults(finalFiltered);
 

--- a/src/features/repositories/hooks/useSearchActions.ts
+++ b/src/features/repositories/hooks/useSearchActions.ts
@@ -259,12 +259,19 @@ export const useSearchActions = (): SearchActions => {
               ? t('AI 精选相关仓库...', 'AI selecting relevant repositories...')
               : t('AI 语义分析...', 'AI semantic analysis...'));
           },
+          onFallback: (reason) => {
+            // 端点抖动/配置问题时用户看到的不能只是"空结果"：明确告知已降级
+            if (reason === 'ai_failed') {
+              toast(t('AI 请求失败，已回退本地词法搜索', 'AI request failed, fell back to local lexical search'), 'warning');
+            }
+          },
         });
         console.log('✅ AI selection search completed, results:', aiResults.length);
         filtered = aiResults;
         aiOrdered = true;
       } catch (error) {
         console.warn('❌ AI search failed, falling back to basic search:', error);
+        toast(t('AI 请求失败，已回退本地词法搜索', 'AI request failed, fell back to local lexical search'), 'warning');
         filtered = performBasicTextSearch(repositories, query);
       }
     } else {
@@ -292,7 +299,7 @@ export const useSearchActions = (): SearchActions => {
 
     // Update search filters to mark that AI search was performed
     setSearchFilters({ query });
-  }, [repositories, aiConfigs, activeAIConfig, language, setSearchResults, setSearchFilters, t]);
+  }, [repositories, aiConfigs, activeAIConfig, language, setSearchResults, setSearchFilters, toast, t]);
 
   const aiSearch = useCallback(async (
     query: string,

--- a/src/features/repositories/hooks/useSearchActions.ts
+++ b/src/features/repositories/hooks/useSearchActions.ts
@@ -245,38 +245,45 @@ export const useSearchActions = (): SearchActions => {
     applyFilters: (repos: Repository[]) => Repository[],
   ): Promise<void> => {
     const activeConfig = aiConfigs.find(config => config.id === activeAIConfig);
-    console.log('🤖 AI Config found:', !!activeConfig, 'Active AI Config ID:', activeAIConfig);
-    console.log('📋 Available AI Configs:', aiConfigs.length);
-    console.log('🔧 AI Configs:', aiConfigs.map(c => ({ id: c.id, name: c.name, hasApiKey: !!c.apiKey })));
 
     let filtered = repositories;
+    let aiOrdered = false;
     if (activeConfig) {
       try {
-        console.log('🚀 Calling AI service...');
+        // 无向量降级链：查询扩展+意图复述 → 词法候选召回 → LLM 精选排序
         setSearchPhase(t('AI 语义分析...', 'AI semantic analysis...'));
         const aiService = new AIService(activeConfig, language);
-
-        // 先尝试AI搜索
-        const aiResults = await aiService.searchRepositoriesWithReranking(repositories, query);
-        console.log('✅ AI search completed, results:', aiResults.length);
-
+        const aiResults = await aiService.searchRepositoriesWithSelection(repositories, query, {
+          onPhase: (phase) => {
+            setSearchPhase(phase === 'selecting'
+              ? t('AI 精选相关仓库...', 'AI selecting relevant repositories...')
+              : t('AI 语义分析...', 'AI semantic analysis...'));
+          },
+        });
+        console.log('✅ AI selection search completed, results:', aiResults.length);
         filtered = aiResults;
+        aiOrdered = true;
       } catch (error) {
         console.warn('❌ AI search failed, falling back to basic search:', error);
         filtered = performBasicTextSearch(repositories, query);
-        console.log('🔄 Basic search fallback results:', filtered.length);
       }
     } else {
       console.log('⚠️ No AI config found, using basic text search');
       // Basic text search if no AI config
       filtered = performBasicTextSearch(repositories, query);
-      console.log('📝 Basic search results:', filtered.length);
     }
 
     // Apply other filters and update results
     const finalFiltered = applyFilters(filtered);
-    console.log('🎯 Final filtered results:', finalFiltered.length);
-    console.log('📋 Final filtered repositories:', finalFiltered.map(r => r.name));
+    if (aiOrdered) {
+      // AI 返回的顺序（LLM 精选序或词法兜底序）就是相关性顺序；applyFilters 会按
+      // 排序控件重排（默认 star 降序），这里恢复 AI 顺序——与向量路径的
+      // rerankOrder 恢复逻辑同构。
+      const aiOrder = new Map(filtered.map((repo, index) => [String(repo.id), index]));
+      finalFiltered.sort((a, b) =>
+        (aiOrder.get(String(a.id)) ?? Number.MAX_SAFE_INTEGER)
+        - (aiOrder.get(String(b.id)) ?? Number.MAX_SAFE_INTEGER));
+    }
     setSearchResults(finalFiltered);
 
     // Update search filters to mark that AI search was performed

--- a/src/features/repositories/hooks/useSearchActions.ts
+++ b/src/features/repositories/hooks/useSearchActions.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState, type MutableRefObject, useRef } from 'r
 import { useShallow } from 'zustand/react/shallow';
 import type { Category, Repository } from '../../../types';
 import { useAppStore, getAllCategories } from '../../../store/useAppStore';
-import { AIService } from '../../../services/aiService';
+import { AIService, isAbortError } from '../../../services/aiService';
 import { EmbeddingClient, VectorSearchService } from '../../../services/vectorSearchService';
 import { GitHubApiService } from '../../../services/githubApi';
 import { createGitHubListsApiService } from '../../../services/githubApiFactory';
@@ -270,6 +270,8 @@ export const useSearchActions = (): SearchActions => {
         filtered = aiResults;
         aiOrdered = true;
       } catch (error) {
+        // 取消不是失败：向上传播交给 aiSearch 静默结束，不产出兜底结果
+        if (isAbortError(error)) throw error;
         console.warn('❌ AI search failed, falling back to basic search:', error);
         toast(t('AI 请求失败，已回退本地词法搜索', 'AI request failed, fell back to local lexical search'), 'warning');
         filtered = performBasicTextSearch(repositories, query);
@@ -428,6 +430,11 @@ export const useSearchActions = (): SearchActions => {
 
       await keywordSearch(query, applyFilters);
     } catch (error) {
+      // 取消不是失败：静默结束当前搜索（finally 会复位搜索状态），不产出结果
+      if (isAbortError(error)) {
+        console.log('🚫 AI search cancelled');
+        return;
+      }
       console.error('💥 Search failed:', error);
     } finally {
       setIsSearching(false);

--- a/src/features/repositories/hooks/useSearchActions.ts
+++ b/src/features/repositories/hooks/useSearchActions.ts
@@ -192,7 +192,11 @@ export interface SearchActions {
   vectorScoreMapRef: MutableRefObject<{ query: string; scores: Map<string, number> } | null>;
   skipNextTextSearchRef: MutableRefObject<boolean>;
   aiSearch: (query: string, applyFilters: (repos: Repository[]) => Repository[]) => Promise<void>;
-  keywordSearch: (query: string, applyFilters: (repos: Repository[]) => Repository[]) => Promise<void>;
+  keywordSearch: (
+    query: string,
+    applyFilters: (repos: Repository[]) => Repository[],
+    options?: { signal?: AbortSignal },
+  ) => Promise<void>;
   syncStars: (mode?: 'auto' | 'stars-only' | 'stars-and-lists') => Promise<void>;
 }
 
@@ -238,11 +242,14 @@ export const useSearchActions = (): SearchActions => {
   const [searchPhase, setSearchPhase] = useState<string | null>(null);
   const vectorScoreMapRef = useRef<{ query: string; scores: Map<string, number> } | null>(null);
   const skipNextTextSearchRef = useRef(false);
+  // 当前在途 AI 搜索的控制器：新搜索启动时中止旧请求（超代语义）
+  const aiSearchAbortRef = useRef<AbortController | null>(null);
   const t = useCallback((zh: string, en: string) => language === 'zh' ? zh : en, [language]);
 
   const keywordSearch = useCallback(async (
     query: string,
     applyFilters: (repos: Repository[]) => Repository[],
+    options?: { signal?: AbortSignal },
   ): Promise<void> => {
     const activeConfig = aiConfigs.find(config => config.id === activeAIConfig);
 
@@ -254,6 +261,7 @@ export const useSearchActions = (): SearchActions => {
         setSearchPhase(t('AI 语义分析...', 'AI semantic analysis...'));
         const aiService = new AIService(activeConfig, language);
         const aiResults = await aiService.searchRepositoriesWithSelection(repositories, query, {
+          signal: options?.signal,
           onPhase: (phase) => {
             setSearchPhase(phase === 'selecting'
               ? t('AI 精选相关仓库...', 'AI selecting relevant repositories...')
@@ -308,6 +316,12 @@ export const useSearchActions = (): SearchActions => {
     applyFilters: (repos: Repository[]) => Repository[],
   ): Promise<void> => {
     if (!query.trim()) return;
+
+    // 新搜索接管：中止上一次仍在途的 AI 请求（搜索进行中按 Enter 可再次触发），
+    // 防止过期结果落盘覆盖新结果。被取代的搜索在 finally 里不复位搜索状态。
+    aiSearchAbortRef.current?.abort();
+    const controller = new AbortController();
+    aiSearchAbortRef.current = controller;
 
     setIsSearching(true);
     setSearchPhase(null);
@@ -428,17 +442,22 @@ export const useSearchActions = (): SearchActions => {
       }
       // ====== 向量搜索分支结束 ======
 
-      await keywordSearch(query, applyFilters);
+      await keywordSearch(query, applyFilters, { signal: controller.signal });
     } catch (error) {
-      // 取消不是失败：静默结束当前搜索（finally 会复位搜索状态），不产出结果
+      // 取消不是失败：静默结束当前搜索（不产出结果），不当作可恢复的 AI 失败
       if (isAbortError(error)) {
         console.log('🚫 AI search cancelled');
         return;
       }
       console.error('💥 Search failed:', error);
     } finally {
-      setIsSearching(false);
-      setSearchPhase(null);
+      // 仅当本次搜索仍是"当前搜索"时才复位状态：被新搜索取代的旧搜索
+      // 不把新搜索的 isSearching/searchPhase 状态清掉
+      if (aiSearchAbortRef.current === controller) {
+        aiSearchAbortRef.current = null;
+        setIsSearching(false);
+        setSearchPhase(null);
+      }
     }
   }, [repositories, aiConfigs, activeAIConfig, language, setSearchResults, setSearchFilters, keywordSearch, t]);
 

--- a/src/services/aiService.test.ts
+++ b/src/services/aiService.test.ts
@@ -39,7 +39,7 @@ function makeRepo(partial: Partial<Repository> & Pick<Repository, 'id' | 'name' 
   };
 }
 
-describe('AIService.searchRepositoriesWithReranking — enhanced basic search fallback', () => {
+describe('AIService.searchRepositoriesWithSelection — 词法兜底', () => {
   beforeEach(() => {
     // Force the AI request path to fail so we fall back to performEnhancedBasicSearch.
     (window.fetch as ReturnType<typeof vi.fn>).mockImplementation(() => {
@@ -66,7 +66,7 @@ describe('AIService.searchRepositoriesWithReranking — enhanced basic search fa
     });
 
     const service = new AIService(makeConfig() as never, 'en');
-    const results = await service.searchRepositoriesWithReranking([repoA, repoB], 'react mit');
+    const results = await service.searchRepositoriesWithSelection([repoA, repoB], 'react mit');
 
     const ids = results.map((r) => r.id);
     // With the license weight, A's license match outweighs B's popularity edge.
@@ -89,7 +89,7 @@ describe('AIService.searchRepositoriesWithReranking — enhanced basic search fa
 
     const service = new AIService(makeConfig() as never, 'en');
     // Should resolve the license object to 'MIT' and rank the repo — not throw.
-    const results = await service.searchRepositoriesWithReranking([repoA], 'mit');
+    const results = await service.searchRepositoriesWithSelection([repoA], 'mit');
     expect(results.map((r) => r.id)).toEqual([3]);
   });
 
@@ -107,21 +107,6 @@ describe('AIService.searchRepositoriesWithReranking — enhanced basic search fa
     expect(results.map((r) => r.id)).toEqual([4]);
   });
 
-  it('finds a repo by its custom tag via basic search', async () => {
-    const repo = makeRepo({
-      id: 5,
-      name: 'skill-pack',
-      full_name: 'acme/skill-pack',
-      description: 'A collection of prompts',
-      ai_tags: ['效率工具'],
-      custom_tags: ['技能'],
-    });
-
-    const service = new AIService(makeConfig() as never, 'zh');
-    const results = service['performBasicSearch']([repo], '技能');
-    expect(results.map((r) => r.id)).toEqual([5]);
-  });
-
   it('finds a repo matching only through custom_tags via enhanced search', async () => {
     const repo = makeRepo({
       id: 6,
@@ -133,8 +118,134 @@ describe('AIService.searchRepositoriesWithReranking — enhanced basic search fa
     });
 
     const service = new AIService(makeConfig() as never, 'zh');
-    const results = service['performEnhancedSearch']([repo], '技能', ['技能']);
+    const results = service['performEnhancedBasicSearch']([repo], '技能', ['技能']);
     expect(results.map((r) => r.id)).toEqual([6]);
+  });
+});
+
+describe('AIService.searchRepositoriesWithSelection — LLM 精选', () => {
+  const fetchJson = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+  const chatResponse = (content: string) => fetchJson({ choices: [{ message: { content } }] });
+  const mockFetch = () => {
+    const fetchMock = window.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockReset();
+    return fetchMock;
+  };
+  const captureBody = async (init?: RequestInit) => JSON.parse(String(init?.body)) as Record<string, unknown>;
+
+  it('扩展查询后把候选摘要交给 LLM 精选，并按模型排序返回（携带意图说明）', async () => {
+    const fetchMock = mockFetch();
+    const requests: Array<Record<string, unknown>> = [];
+    fetchMock.mockImplementationOnce(async (_url, init) => {
+      requests.push(await captureBody(init));
+      return chatResponse('{"intent":"找 markdown 编辑器","keywords":["markdown","editor"],"synonyms":[]}');
+    });
+    fetchMock.mockImplementationOnce(async (_url, init) => {
+      requests.push(await captureBody(init));
+      return chatResponse('[880000002, 880000001]');
+    });
+
+    const repoA = makeRepo({ id: 880000001, name: 'quick-md', full_name: 'acme/quick-md', description: 'a markdown editor', stargazers_count: 900 });
+    const repoB = makeRepo({ id: 880000002, name: 'random-tool', full_name: 'acme/random-tool', description: 'unrelated', stargazers_count: 5000 });
+
+    const service = new AIService(makeConfig() as never, 'zh');
+    const results = await service.searchRepositoriesWithSelection([repoA, repoB], 'markdown 编辑器');
+
+    expect(results.map((r) => r.id)).toEqual([880000002, 880000001]);
+    // 扩展请求要求模型复述意图；精选请求携带意图说明与候选摘要
+    expect(String((requests[0].messages as Array<{ content: string }>)[1].content)).toContain('"intent"');
+    const selectionPrompt = String((requests[1].messages as Array<{ content: string }>)[1].content);
+    expect(selectionPrompt).toContain('用户意图说明：找 markdown 编辑器');
+    expect(selectionPrompt).toContain('共 2 个');
+    expect(selectionPrompt).toContain('acme/quick-md');
+  });
+
+  it('模型把候选行号当作 ID 返回时按行号解析，重排结果不被静默丢弃', async () => {
+    const fetchMock = mockFetch();
+    fetchMock.mockImplementationOnce(async () => chatResponse('{"intent":"","keywords":[],"synonyms":[]}'));
+    fetchMock.mockImplementationOnce(async () => chatResponse('[2, 1]'));
+
+    const repoA = makeRepo({ id: 730000001, name: 'alpha', full_name: 'acme/alpha' });
+    const repoB = makeRepo({ id: 730000002, name: 'beta', full_name: 'acme/beta' });
+
+    const service = new AIService(makeConfig() as never, 'zh');
+    const results = await service.searchRepositoriesWithSelection([repoA, repoB], 'anything');
+
+    expect(results.map((r) => r.id)).toEqual([730000002, 730000001]);
+  });
+
+  it('模型明确返回空数组时呈现空结果，而不是回退到词法噪声', async () => {
+    const fetchMock = mockFetch();
+    fetchMock.mockImplementationOnce(async () => chatResponse('{"intent":"","keywords":["foo"],"synonyms":[]}'));
+    fetchMock.mockImplementationOnce(async () => chatResponse('[]'));
+
+    const repoA = makeRepo({ id: 740000001, name: 'foo-tool', full_name: 'acme/foo-tool' });
+
+    const service = new AIService(makeConfig() as never, 'zh');
+    const results = await service.searchRepositoriesWithSelection([repoA], '不存在的东西');
+
+    expect(results).toEqual([]);
+  });
+
+  it('大库先词法召回：候选按上限截断注入精选提示词', async () => {
+    const fetchMock = mockFetch();
+    const requests: Array<Record<string, unknown>> = [];
+    fetchMock.mockImplementationOnce(async (_url, init) => {
+      requests.push(await captureBody(init));
+      return chatResponse('{"intent":"","keywords":["thing"],"synonyms":[]}');
+    });
+    fetchMock.mockImplementationOnce(async (_url, init) => {
+      requests.push(await captureBody(init));
+      return chatResponse('[900001]');
+    });
+
+    const target = makeRepo({ id: 900001, name: 'target-thing', full_name: 'acme/target-thing', description: 'the thing you want', stargazers_count: 10 });
+    const pads = Array.from({ length: 159 }, (_, i) =>
+      makeRepo({ id: 900002 + i, name: `junk-${i}`, full_name: `acme/junk-${i}`, stargazers_count: i }));
+
+    const service = new AIService(makeConfig() as never, 'zh');
+    const results = await service.searchRepositoriesWithSelection([target, ...pads], 'thing');
+
+    const selectionPrompt = String((requests[1].messages as Array<{ content: string }>)[1].content);
+    expect(selectionPrompt).toContain('共 100 个');
+    expect(results.map((r) => r.id)).toEqual([900001]);
+  });
+});
+
+describe('AIService.searchRepositoriesWithSemanticReranking — 行号兜底', () => {
+  const fetchJson = (body: unknown, status = 200) => new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+
+  beforeEach(() => {
+    (window.fetch as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  it('模型把候选行号当作 ID 返回时按行号解析，重排结果不再被静默丢弃', async () => {
+    // 回归：旧的 repoById.get(id) 解析会把行号响应整份丢弃，重排静默失效
+    const repoA = makeRepo({ id: 730000001, name: 'alpha', full_name: 'acme/alpha', stargazers_count: 10 });
+    const repoB = makeRepo({ id: 730000002, name: 'beta', full_name: 'acme/beta', stargazers_count: 5 });
+    (window.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      fetchJson({ choices: [{ message: { content: '[2, 1]' } }] }),
+    );
+
+    const service = new AIService(makeConfig() as never, 'zh');
+    const results = await service.searchRepositoriesWithSemanticReranking([repoA, repoB], 'anything');
+
+    expect(results.map((r) => r.id)).toEqual([730000002, 730000001]);
+  });
+
+  it('真实 ID 优先于行号解析，未被排到的仓库追加在末尾', async () => {
+    const repoA = makeRepo({ id: 730000001, name: 'alpha', full_name: 'acme/alpha' });
+    const repoB = makeRepo({ id: 730000002, name: 'beta', full_name: 'acme/beta' });
+    const repoC = makeRepo({ id: 730000003, name: 'gamma', full_name: 'acme/gamma' });
+    (window.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      fetchJson({ choices: [{ message: { content: '[730000003, 1]' } }] }),
+    );
+
+    const service = new AIService(makeConfig() as never, 'zh');
+    const results = await service.searchRepositoriesWithSemanticReranking([repoA, repoB, repoC], 'anything');
+
+    // 730000003 按真实 ID 命中；1 在候选范围内按行号解析为 repoA；repoB 未被排到，追加在末尾
+    expect(results.map((r) => r.id)).toEqual([730000003, 730000001, 730000002]);
   });
 });
 

--- a/src/services/aiService.test.ts
+++ b/src/services/aiService.test.ts
@@ -121,6 +121,18 @@ describe('AIService.searchRepositoriesWithSelection — 词法兜底', () => {
     const results = service['performEnhancedBasicSearch']([repo], '技能', ['技能']);
     expect(results.map((r) => r.id)).toEqual([6]);
   });
+
+  it('扩展词与查询词相同时不重复计分（词级剔除）', async () => {
+    const repo = makeRepo({ id: 20, name: 'markdown', full_name: 'acme/markdown' });
+
+    const service = new AIService(makeConfig() as never, 'zh');
+    const scored = service['scoreRepositoriesByKeywords']([repo], 'markdown editor', ['Markdown', 'acme']);
+
+    // 'Markdown' 等于查询词 'markdown'，剔除后不再对 name/fullName 重复计分；
+    // 'acme'（fullName 命中）仍正常计分：name 0.4 + fullName 0.35 + 扩展词 0.2 = 0.95
+    //（若词级剔除失效则为 1.4）
+    expect(scored[0].score).toBeCloseTo(0.95, 10);
+  });
 });
 
 describe('AIService.searchRepositoriesWithSelection — LLM 精选', () => {
@@ -158,6 +170,8 @@ describe('AIService.searchRepositoriesWithSelection — LLM 精选', () => {
     expect(selectionPrompt).toContain('用户意图说明：找 markdown 编辑器');
     expect(selectionPrompt).toContain('共 2 个');
     expect(selectionPrompt).toContain('acme/quick-md');
+    // 普通模型的精选请求维持紧凑预算
+    expect(requests[1].max_tokens).toBe(800);
   });
 
   it('模型把候选行号当作 ID 返回时按行号解析，重排结果不被静默丢弃', async () => {
@@ -209,6 +223,43 @@ describe('AIService.searchRepositoriesWithSelection — LLM 精选', () => {
     const selectionPrompt = String((requests[1].messages as Array<{ content: string }>)[1].content);
     expect(selectionPrompt).toContain('共 100 个');
     expect(results.map((r) => r.id)).toEqual([900001]);
+  });
+
+  it('调用方取消（abort）时不做词法兜底，取消异常向上传播', async () => {
+    const fetchMock = mockFetch();
+    fetchMock.mockImplementationOnce(async () => {
+      throw Object.assign(new Error('The operation was aborted.'), { name: 'AbortError' });
+    });
+    const controller = new AbortController();
+
+    const repoA = makeRepo({ id: 750000001, name: 'foo-tool', full_name: 'acme/foo-tool' });
+
+    const service = new AIService(makeConfig() as never, 'zh');
+    // 取消 ≠ AI 失败：不能把词法兜底结果当作搜索结果返回
+    await expect(
+      service.searchRepositoriesWithSelection([repoA], 'foo', { signal: controller.signal }),
+    ).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('推理模型的精选调用复用更大的 token 预算，避免推理耗尽预算后静默退化', async () => {
+    const fetchMock = mockFetch();
+    const requests: Array<Record<string, unknown>> = [];
+    fetchMock.mockImplementationOnce(async (_url, init) => {
+      requests.push(await captureBody(init));
+      return chatResponse('{"intent":"","keywords":[],"synonyms":[]}');
+    });
+    fetchMock.mockImplementationOnce(async (_url, init) => {
+      requests.push(await captureBody(init));
+      return chatResponse('[]');
+    });
+
+    const repo = makeRepo({ id: 760000001, name: 'foo-tool', full_name: 'acme/foo-tool' });
+    const service = new AIService({ ...makeConfig(), reasoningEffort: 'high' } as never, 'zh');
+    await service.searchRepositoriesWithSelection([repo], 'foo');
+
+    // 扩展请求维持 300；精选请求复用重排序的 4096 预算（推理 token 共享预算）
+    expect(requests[0].max_tokens).toBe(300);
+    expect(requests[1].max_tokens).toBe(4096);
   });
 });
 

--- a/src/services/aiService.test.ts
+++ b/src/services/aiService.test.ts
@@ -308,6 +308,22 @@ describe('AIService.searchRepositoriesWithSelection — LLM 精选', () => {
     expect(onFallback).toHaveBeenCalledWith('ai_empty');
     expect(results).toEqual([]);
   });
+
+  it('模型返回的 ID 全部无法落位时按响应无效处理，回退词法而非空态', async () => {
+    const fetchMock = mockFetch();
+    fetchMock.mockImplementationOnce(async () => chatResponse('{"intent":"","keywords":["foo"],"synonyms":[]}'));
+    fetchMock.mockImplementationOnce(async () => chatResponse('[999999999, 888888888]'));
+    const onFallback = vi.fn();
+
+    const repo = makeRepo({ id: 790000001, name: 'foo-tool', full_name: 'acme/foo-tool' });
+
+    const service = new AIService(makeConfig() as never, 'zh');
+    const results = await service.searchRepositoriesWithSelection([repo], 'foo', { onFallback });
+
+    // 幻觉 ID ≠ 模型判空：不能把无效响应当成"无相关结果"呈现空态
+    expect(onFallback).toHaveBeenCalledWith('unparseable');
+    expect(results.map((r) => r.id)).toEqual([790000001]);
+  });
 });
 
 describe('AIService.searchRepositoriesWithSemanticReranking — 行号兜底', () => {

--- a/src/services/aiService.test.ts
+++ b/src/services/aiService.test.ts
@@ -133,6 +133,21 @@ describe('AIService.searchRepositoriesWithSelection — 词法兜底', () => {
     //（若词级剔除失效则为 1.4）
     expect(scored[0].score).toBeCloseTo(0.95, 10);
   });
+
+  it('中文查询无 AI 扩展词时按 CJK bigram 召回，兜底不再整串零命中', async () => {
+    const repo = makeRepo({
+      id: 30,
+      name: 'stars-manager',
+      full_name: 'acme/stars-manager',
+      description: '管理 GitHub 星标仓库的工具',
+    });
+
+    const service = new AIService(makeConfig() as never, 'zh');
+    // "星标仓库"无空格切不出词，整串也不在描述里；bigram "星标"/"仓库" 命中描述
+    const scored = service['scoreRepositoriesByKeywords']([repo], '星标仓库', []);
+    expect(scored).toHaveLength(1);
+    expect(scored[0].score).toBeGreaterThan(0);
+  });
 });
 
 describe('AIService.searchRepositoriesWithSelection — LLM 精选', () => {
@@ -257,9 +272,41 @@ describe('AIService.searchRepositoriesWithSelection — LLM 精选', () => {
     const service = new AIService({ ...makeConfig(), reasoningEffort: 'high' } as never, 'zh');
     await service.searchRepositoriesWithSelection([repo], 'foo');
 
-    // 扩展请求维持 300；精选请求复用重排序的 4096 预算（推理 token 共享预算）
-    expect(requests[0].max_tokens).toBe(300);
+    // 扩展请求给思考模型留足余量；精选请求复用重排序的 4096 预算（推理 token 共享预算）
+    expect(requests[0].max_tokens).toBe(2000);
     expect(requests[1].max_tokens).toBe(4096);
+  });
+
+  it('AI 请求失败时通过 onFallback 通知调用方，并回退词法得分序', async () => {
+    const fetchMock = mockFetch();
+    fetchMock.mockImplementationOnce(async () => {
+      throw new TypeError('Failed to fetch');
+    });
+    const onFallback = vi.fn();
+
+    const repoA = makeRepo({ id: 770000001, name: 'foo-tool', full_name: 'acme/foo-tool' });
+
+    const service = new AIService(makeConfig() as never, 'zh');
+    const results = await service.searchRepositoriesWithSelection([repoA], 'foo', { onFallback });
+
+    // 端点抖动/配置问题时：回调说明原因，结果退到词法命中而非空
+    expect(onFallback).toHaveBeenCalledWith('ai_failed');
+    expect(results.map((r) => r.id)).toEqual([770000001]);
+  });
+
+  it('模型判定无相关仓库时保留空结果，并通过 onFallback 说明原因', async () => {
+    const fetchMock = mockFetch();
+    fetchMock.mockImplementationOnce(async () => chatResponse('{"intent":"","keywords":[],"synonyms":[]}'));
+    fetchMock.mockImplementationOnce(async () => chatResponse('[]'));
+    const onFallback = vi.fn();
+
+    const repo = makeRepo({ id: 780000001, name: 'foo-tool', full_name: 'acme/foo-tool' });
+
+    const service = new AIService(makeConfig() as never, 'zh');
+    const results = await service.searchRepositoriesWithSelection([repo], '完全无关的查询', { onFallback });
+
+    expect(onFallback).toHaveBeenCalledWith('ai_empty');
+    expect(results).toEqual([]);
   });
 });
 

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -2080,18 +2080,23 @@ ${repoInfo}
       signal?: AbortSignal;
       /** 搜索阶段回调，供 UI 展示进度（扩展查询 → 精选排序）。 */
       onPhase?: (phase: 'expanding' | 'selecting') => void;
+      /** AI 精选未能产出结果时回调，供 UI 提示原因：ai_failed=请求/配置失败，
+       *  unparseable=响应无法解析，ai_empty=模型判定无相关仓库。 */
+      onFallback?: (reason: 'ai_failed' | 'unparseable' | 'ai_empty') => void;
     } = {}
   ): Promise<Repository[]> {
     const startTime = Date.now();
     if (!query.trim()) return repositories;
-    const { signal, onPhase } = options;
+    const { signal, onPhase, onFallback } = options;
     let aiTerms: string[] = [];
     let intent = '';
 
     try {
       logger.info('ai', 'Starting AI selection search', { apiType: this.getApiType(), model: this.config.model, configId: this.config.id, query });
 
-      // ① 查询扩展 + 意图复述
+      // ① 查询扩展 + 意图复述。思考类模型的思考 token 与输出共享预算，
+      //    预算太小会把 JSON 截断在半截（实测 glm 思考模型 300 token 不够），
+      //    给足余量；非思考模型只按实际用量计费，无额外成本。
       onPhase?.('expanding');
       const system = this.language === 'zh'
         ? '你是一个智能搜索助手。请分析用户的搜索意图，提取关键词并提供多语言翻译。'
@@ -2100,7 +2105,7 @@ ${repoInfo}
         system,
         user: this.createSearchPrompt(query),
         temperature: 0.1,
-        maxTokens: 300,
+        maxTokens: 2000,
         signal,
       });
       if (content) {
@@ -2133,9 +2138,16 @@ ${repoInfo}
       const ranked = await this.selectRelevantRepositories(candidates, query, intent, signal);
       if (ranked === null) {
         // 响应缺失或格式非法：按词法得分序兜底
+        onFallback?.('unparseable');
         logger.warn('ai', 'AI selection returned unparseable result, falling back to lexical ranking', { configId: this.config.id, durationMs: Date.now() - startTime });
         return this.performEnhancedBasicSearch(repositories, query, aiTerms)
           .slice(0, AIService.SELECTION_CANDIDATE_LIMIT);
+      }
+      if (ranked.length === 0) {
+        // 模型明确判定无相关仓库：尊重该判断返回空态，但让调用方知道原因
+        onFallback?.('ai_empty');
+        logger.info('ai', 'AI selection found no relevant repositories', { configId: this.config.id, durationMs: Date.now() - startTime });
+        return [];
       }
       logger.info('ai', 'AI selection completed', {
         apiType: this.getApiType(),
@@ -2149,6 +2161,7 @@ ${repoInfo}
     } catch (error) {
       // 用户主动取消：不产出兜底结果，向上传播交由调用方处理
       if (signal?.aborted || (error instanceof Error && error.name === 'AbortError')) throw error;
+      onFallback?.('ai_failed');
       logger.warn('ai', 'AI selection failed, falling back to lexical ranking', {
         apiType: this.getApiType(),
         model: this.config.model,
@@ -2215,7 +2228,16 @@ ${repoInfo}
     // 去重并剔除与任一查询词相同的扩展词：避免同一命中被查询词与扩展词
     // 重复计分（按词级剔除，而非仅完整查询串）
     const querySet = new Set([normalizedQuery, ...queryWords]);
-    const terms = [...new Set(aiTerms.map(term => term.toLowerCase()).filter(term => term && !querySet.has(term)))];
+    // 中文查询没有空格分词，整串子串在英文元数据上几乎必然零命中（AI 失败
+    // 兜底时会得到空结果）：把 CJK 连续段切成 bigram 作为弱信号词参与召回
+    // 与计分。仅用于 AI 搜索的词法路径；输入框的 performBasicTextSearch 不受影响。
+    const cjkTerms = AIService.extractCjkBigrams(normalizedQuery).filter(bigram => !querySet.has(bigram));
+    const terms = [
+      ...new Set([
+        ...aiTerms.map(term => term.toLowerCase()).filter(term => term && !querySet.has(term)),
+        ...cjkTerms,
+      ]),
+    ];
 
     const scoredRepos: Array<{ repo: Repository; score: number }> = [];
     for (const repo of repositories) {
@@ -2309,6 +2331,26 @@ ${repoInfo}
     return this.scoreRepositoriesByKeywords(repositories, query, aiTerms)
       .filter(item => item.score > 0)
       .map(item => item.repo);
+  }
+
+  /**
+   * 把文本里的 CJK 连续段切成 bigram（"星标仓库" → 星标 / 标仓 / 仓库），
+   * 去重并限量。中文没有空格分词，整串子串匹配对英文元数据几乎必然失效，
+   * bigram 是无依赖词典时的最低成本召回手段。
+   */
+  private static extractCjkBigrams(text: string): string[] {
+    const cjkRuns = text.match(/[\u3400-\u4dbf\u4e00-\u9fff]+/g) || [];
+    const bigrams: string[] = [];
+    for (const run of cjkRuns) {
+      if (run.length === 1) {
+        bigrams.push(run);
+        continue;
+      }
+      for (let i = 0; i < run.length - 1; i++) {
+        bigrams.push(run.slice(i, i + 2));
+      }
+    }
+    return [...new Set(bigrams)].slice(0, 12);
   }
 
   private createSearchPrompt(query: string): string {

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -2194,7 +2194,7 @@ ${repoInfo}
       // 推理 token 与输出共享预算（openai reasoning 模型、gemini 2.5 思考模型）：
       // 小预算被推理耗尽时 content 为空、精选会静默退化，故复用重排序的 4096
       // 预算；普通模型 800 足够容纳 ≤20 个 ID 的 JSON 数组。
-      maxTokens: this.config.reasoningEffort || this.getApiType() === 'gemini'
+      maxTokens: (this.config.reasoningEffort || this.getApiType() === 'gemini')
         ? AIService.RERANKING_MAX_TOKENS
         : AIService.SELECTION_MAX_TOKENS,
       signal,

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -327,6 +327,15 @@ export class AIService {
   private static readonly ANALYSIS_MAX_ATTEMPTS = 3;
   private static readonly ANALYSIS_MAX_TOKENS = 4096;
   private static readonly RERANKING_MAX_TOKENS = 4096;
+  /** 库容不超过该数量时跳过词法召回，直接把全库交给 LLM 精选。 */
+  private static readonly SELECTION_FULL_LIBRARY_LIMIT = 150;
+  /** 大库时送入 LLM 的候选上限：token 成本与库容解耦的关键。 */
+  private static readonly SELECTION_CANDIDATE_LIMIT = 100;
+  /** 词法候选不足该数量时用 star 排序补足，保证 LLM 始终有足够候选。 */
+  private static readonly SELECTION_MIN_CANDIDATES = 15;
+  /** LLM 精选最多返回的相关仓库数。 */
+  private static readonly SELECTION_MAX_RESULTS = 20;
+  private static readonly SELECTION_MAX_TOKENS = 800;
 
   constructor(config: AIConfig, language: string = 'zh') {
     this.config = config;
@@ -1516,7 +1525,34 @@ AI Summary: ${gist.ai_summary || 'None'}`;
     // 注意：searchTopK 配置与此上限独立；若 searchTopK > 50，超出部分不会被重排序
     const candidates = repositories.slice(0, 50);
 
-    const repoSummaries = candidates.map((repo, index) => {
+    const system = this.language === 'zh'
+      ? '你是 GitHub 仓库搜索排序助手。根据用户查询，从候选仓库中选出最相关的，按相关性从高到低返回 ID 数组 JSON。只输出 JSON 数组，不要输出额外文字。'
+      : 'You are a GitHub repository search reranking assistant. Given a user query and candidate repositories, return a JSON array of repository IDs ordered from most to least relevant. Output only the JSON array, no extra text.';
+
+    const content = await this.requestText({
+      system,
+      user: `Query: ${query}\n\nRepositories:\n${this.sanitizeForPrompt(this.buildCandidateSummaries(candidates))}`,
+      temperature: 0.1,
+      maxTokens: AIService.RERANKING_MAX_TOKENS,
+      signal,
+    });
+
+    const ranked = this.resolveRankedRepositories(content, candidates);
+    if (ranked === null) {
+      logger.warn('ai', 'Failed to parse semantic reranking result');
+      return repositories;
+    }
+    const rankedIds = new Set(ranked.map(r => r.id));
+    // 未被 LLM 排到的仓库追加到末尾（保留原始顺序）
+    return [...ranked, ...repositories.filter(r => !rankedIds.has(r.id))];
+  }
+
+  /**
+   * 构造候选仓库的紧凑摘要（序号. ID | 全名 / 简介 / 语言 | ★ | License | Tags）。
+   * 语义重排序与无向量精选共用同一格式。
+   */
+  private buildCandidateSummaries(candidates: Repository[]): string {
+    return candidates.map((repo, index) => {
       const stars = repo.stargazers_count >= 1000
         ? `${(repo.stargazers_count / 1000).toFixed(0)}k`
         : String(repo.stargazers_count || 0);
@@ -1526,50 +1562,53 @@ AI Summary: ${gist.ai_summary || 'None'}`;
       if (desc) parts.push(`   ${desc}`);
       const meta = [repo.language, `★${stars}`];
       // 与 embedding 一致：归一化后、非哨兵才写入，避免 raw 对象变成 "[object Object]"
-      {
-        const lic = normalizeLicense(repo.license);
-        if (lic !== NO_LICENSE_SENTINEL) meta.push(`License: ${lic}`);
-      }
+      const lic = normalizeLicense(repo.license);
+      if (lic !== NO_LICENSE_SENTINEL) meta.push(`License: ${lic}`);
       if (tags) meta.push(`Tags: ${tags}`);
       parts.push(`   ${meta.join(' | ')}`);
       return parts.join('\n');
     }).join('\n\n');
+  }
 
-    const system = this.language === 'zh'
-      ? '你是 GitHub 仓库搜索排序助手。根据用户查询，从候选仓库中选出最相关的，按相关性从高到低返回 ID 数组 JSON。只输出 JSON 数组，不要输出额外文字。'
-      : 'You are a GitHub repository search reranking assistant. Given a user query and candidate repositories, return a JSON array of repository IDs ordered from most to least relevant. Output only the JSON array, no extra text.';
-
-    const content = await this.requestText({
-      system,
-      user: `Query: ${query}\n\nRepositories:\n${this.sanitizeForPrompt(repoSummaries)}`,
-      temperature: 0.1,
-      maxTokens: AIService.RERANKING_MAX_TOKENS,
-      signal,
-    });
-
+  /**
+   * 从模型输出解析排序后的仓库列表。ID 优先匹配；模型偶尔会把候选行号
+   * （1..N）当作 ID 返回，此时在候选范围内按行号解析——否则整份重排结果会被
+   * 静默丢弃。返回 null 表示输出里没有可解析的 JSON 数组。
+   */
+  private resolveRankedRepositories(content: string, candidates: Repository[]): Repository[] | null {
+    const jsonMatch = content.match(/\[[\s\S]*?\]/);
+    if (!jsonMatch) return null;
+    let ids: unknown[];
     try {
-      const jsonMatch = content.match(/\[[\s\S]*?\]/);
-      const ids = JSON.parse(jsonMatch ? jsonMatch[0] : content);
-      if (!Array.isArray(ids)) return repositories;
-
-      const repoById = new Map(repositories.map(r => [String(r.id), r]));
-      const seen = new Set<string>();
-      const ranked = ids
-        .map((id: unknown) => String(id))
-        .filter(id => {
-          if (seen.has(id)) return false;
-          seen.add(id);
-          return true;
-        })
-        .map(id => repoById.get(id))
-        .filter((r): r is Repository => !!r);
-      const rankedIds = new Set(ranked.map(r => r.id));
-      // 未被 LLM 排到的仓库追加到末尾（保留原始顺序）
-      return [...ranked, ...repositories.filter(r => !rankedIds.has(r.id))];
-    } catch (error) {
-      logger.warn('ai', 'Failed to parse semantic reranking result', error);
-      return repositories;
+      const parsed = JSON.parse(jsonMatch[0]) as unknown;
+      if (!Array.isArray(parsed)) return null;
+      ids = parsed;
+    } catch {
+      return null;
     }
+    const byId = new Map(candidates.map(repo => [String(repo.id), repo]));
+    const seen = new Set<string>();
+    const ranked: Repository[] = [];
+    for (const raw of ids) {
+      const key = String(raw).trim();
+      let repo = byId.get(key);
+      if (!repo) {
+        // 真实 GitHub ID 都是大整数，与 1..N 行号不会冲突；先按 ID 匹配失败
+        // 再尝试行号，两种引用风格都能正确落位。
+        const ordinal = Number(key);
+        if (Number.isInteger(ordinal) && ordinal >= 1 && ordinal <= candidates.length) {
+          repo = candidates[ordinal - 1];
+        }
+      }
+      if (repo) {
+        const idKey = String(repo.id);
+        if (!seen.has(idKey)) {
+          seen.add(idKey);
+          ranked.push(repo);
+        }
+      }
+    }
+    return ranked;
   }
 
   private createAnalysisRetryPrompt(originalPrompt: string, previousContent: string, invalidReason: string): string {
@@ -1999,37 +2038,6 @@ ${repoInfo}
     }
   }
 
-  async searchRepositories(repositories: Repository[], query: string): Promise<Repository[]> {
-    const startTime = Date.now();
-    if (!query.trim()) return repositories;
-
-    try {
-      // Use AI to understand and translate the search query
-      const searchPrompt = this.createSearchPrompt(query);
-
-      const system = this.language === 'zh'
-        ? '你是一个智能搜索助手。请分析用户的搜索意图，提取关键词并提供多语言翻译。'
-        : 'You are an intelligent search assistant. Please analyze user search intent, extract keywords and provide multilingual translations.';
-
-      const content = await this.requestText({
-        system,
-        user: searchPrompt,
-        temperature: 0.1,
-        maxTokens: 200,
-      });
-
-      if (content) {
-        const searchTerms = this.parseSearchResponse(content);
-        return this.performEnhancedSearch(repositories, query, searchTerms);
-      }
-    } catch {
-      logger.warn('ai', 'AI search failed, falling back to basic search', { configId: this.config.id, durationMs: Date.now() - startTime });
-    }
-
-    // Fallback to basic search
-    return this.performBasicSearch(repositories, query);
-  }
-
   /**
    * HyDE (Hypothetical Document Embedding) 查询预处理
    * 根据用户查询生成一个"理想仓库描述"，用该描述生成向量而非原始查询
@@ -2056,60 +2064,154 @@ ${repoInfo}
   }
 
   /**
-   * Search repositories using AI semantic search with fallback to enhanced basic search.
-   * Attempts to call the configured AI service to parse search intent and extract
-   * multilingual keywords, then delegates to performEnhancedSearch. Falls back to
-   * performEnhancedBasicSearch with intelligent ranking if AI is unavailable or fails.
-   *
-   * @param repositories - The full list of repositories to search
-   * @param query - The user's search query string
-   * @returns Filtered and ranked repositories matching the query
+   * 无向量路径的 AI 语义搜索（向量搜索不可用时的降级链）。
+   * 三段式：
+   * ① 查询扩展 + 意图复述（一次 chat 调用）；
+   * ② 本地词法打分召回候选（小库直接全量；大库取 top-K，token 成本与库容解耦）；
+   * ③ LLM 精选排序（只返回真正相关的仓库，最多 20 个）。
+   * 与旧实现（LLM 只做关键词扩展、本地 OR 子串过滤）的本质区别：LLM 能看到
+   * 仓库摘要并直接决定结果与顺序。LLM 调用/解析失败时按词法得分序兜底；
+   * 模型明确表示"无相关结果"时返回空数组（UI 呈现空态而非噪声）。
    */
-  async searchRepositoriesWithReranking(repositories: Repository[], query: string): Promise<Repository[]> {
+  async searchRepositoriesWithSelection(
+    repositories: Repository[],
+    query: string,
+    options: {
+      signal?: AbortSignal;
+      /** 搜索阶段回调，供 UI 展示进度（扩展查询 → 精选排序）。 */
+      onPhase?: (phase: 'expanding' | 'selecting') => void;
+    } = {}
+  ): Promise<Repository[]> {
     const startTime = Date.now();
-    logger.info('ai', 'Starting enhanced search', { query });
     if (!query.trim()) return repositories;
+    const { signal, onPhase } = options;
+    let aiTerms: string[] = [];
+    let intent = '';
 
     try {
-      logger.info('ai', 'Calling configured AI service for semantic search', { apiType: this.getApiType(), model: this.config.model, configId: this.config.id });
-      const searchPrompt = this.createSearchPrompt(query);
+      logger.info('ai', 'Starting AI selection search', { apiType: this.getApiType(), model: this.config.model, configId: this.config.id, query });
+
+      // ① 查询扩展 + 意图复述
+      onPhase?.('expanding');
       const system = this.language === 'zh'
         ? '你是一个智能搜索助手。请分析用户的搜索意图，提取关键词并提供多语言翻译。'
         : 'You are an intelligent search assistant. Please analyze user search intent, extract keywords and provide multilingual translations.';
-
       const content = await this.requestText({
         system,
-        user: searchPrompt,
+        user: this.createSearchPrompt(query),
         temperature: 0.1,
-        maxTokens: 200,
+        maxTokens: 300,
+        signal,
       });
-
       if (content) {
-        const searchTerms = this.parseSearchResponse(content);
-        const results = this.performEnhancedSearch(repositories, query, searchTerms);
-        logger.info('ai', 'AI semantic search completed', { resultCount: results.length, apiType: this.getApiType(), model: this.config.model, durationMs: Date.now() - startTime });
-        return results;
+        const parsed = this.parseSearchResponse(content);
+        aiTerms = parsed.terms;
+        intent = parsed.intent;
       }
-    } catch {
-      logger.warn('ai', 'AI semantic search failed, falling back to enhanced basic search', { apiType: this.getApiType(), model: this.config.model, configId: this.config.id, durationMs: Date.now() - startTime });
+
+      // ② 候选召回
+      let candidates: Repository[];
+      if (repositories.length <= AIService.SELECTION_FULL_LIBRARY_LIMIT) {
+        // 小库：全量直送（LLM 上下文足够，召回阶段没有信息增益）
+        candidates = [...repositories].sort((a, b) => (b.stargazers_count || 0) - (a.stargazers_count || 0));
+      } else {
+        const scored = this.scoreRepositoriesByKeywords(repositories, query, aiTerms);
+        candidates = scored.slice(0, AIService.SELECTION_CANDIDATE_LIMIT).map(item => item.repo);
+        if (candidates.length < AIService.SELECTION_MIN_CANDIDATES) {
+          // 词法命中过少（如纯语义查询）：用 star 排序补足，保证 LLM 有足够候选
+          const have = new Set(candidates.map(repo => repo.id));
+          const pad = [...repositories]
+            .sort((a, b) => (b.stargazers_count || 0) - (a.stargazers_count || 0))
+            .filter(repo => !have.has(repo.id));
+          candidates = candidates.concat(pad.slice(0, AIService.SELECTION_CANDIDATE_LIMIT - candidates.length));
+        }
+      }
+      if (candidates.length === 0) return [];
+
+      // ③ LLM 精选排序
+      onPhase?.('selecting');
+      const ranked = await this.selectRelevantRepositories(candidates, query, intent, signal);
+      if (ranked === null) {
+        // 响应缺失或格式非法：按词法得分序兜底
+        logger.warn('ai', 'AI selection returned unparseable result, falling back to lexical ranking', { configId: this.config.id, durationMs: Date.now() - startTime });
+        return this.performEnhancedBasicSearch(repositories, query, aiTerms)
+          .slice(0, AIService.SELECTION_CANDIDATE_LIMIT);
+      }
+      logger.info('ai', 'AI selection completed', {
+        apiType: this.getApiType(),
+        model: this.config.model,
+        configId: this.config.id,
+        candidates: candidates.length,
+        resultCount: ranked.length,
+        durationMs: Date.now() - startTime,
+      });
+      return ranked;
+    } catch (error) {
+      logger.warn('ai', 'AI selection failed, falling back to lexical ranking', {
+        apiType: this.getApiType(),
+        model: this.config.model,
+        configId: this.config.id,
+        durationMs: Date.now() - startTime,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return this.performEnhancedBasicSearch(repositories, query, aiTerms)
+        .slice(0, AIService.SELECTION_CANDIDATE_LIMIT);
     }
-
-    logger.info('ai', 'Using enhanced basic search with intelligent ranking');
-    const fallbackResults = this.performEnhancedBasicSearch(repositories, query);
-    logger.info('ai', 'Enhanced search completed', { resultCount: fallbackResults.length });
-
-    return fallbackResults;
   }
 
-  // Enhanced basic search with intelligent ranking (fallback when AI fails)
-  private performEnhancedBasicSearch(repositories: Repository[], query: string): Repository[] {
+  /**
+   * 把候选仓库摘要交给 LLM，选出与查询真正相关的仓库并按相关性排序。
+   * 返回 null 表示响应缺失/无法解析（调用方走词法兜底）；空数组是合法结果
+   * （模型判断没有仓库能满足查询意图）。
+   */
+  private async selectRelevantRepositories(
+    candidates: Repository[],
+    query: string,
+    intent: string,
+    signal?: AbortSignal
+  ): Promise<Repository[] | null> {
+    const summaries = this.sanitizeForPrompt(this.buildCandidateSummaries(candidates));
+    const intentLine = intent
+      ? (this.language === 'zh'
+        ? `\n\n用户意图说明：${this.sanitizeForPrompt(intent)}`
+        : `\n\nQuery intent: ${this.sanitizeForPrompt(intent)}`)
+      : '';
+
+    const system = this.language === 'zh'
+      ? '你是 GitHub 仓库搜索排序助手。根据用户查询，从候选仓库中选出真正相关的仓库，按相关性从高到低返回其 ID 的 JSON 数组。注意：ID 是候选列表中给出的真实仓库 ID（一长串数字），严禁使用序号、行号或自行编号。只输出 JSON 数组，不要输出任何额外文字。若没有仓库能满足查询意图，返回空数组 []。'
+      : 'You are a GitHub repository search reranking assistant. Select the repositories that truly match the user query and return their IDs as a JSON array ordered from most to least relevant. The ID is the real repository ID (a long number) from the candidate list; never use ordinals or line numbers. Output only the JSON array, no extra text. If no repository satisfies the query intent, return an empty array [].';
+
+    const user = this.language === 'zh'
+      ? `用户查询：「${this.sanitizeForPrompt(query)}」${intentLine}\n\n候选仓库（共 ${candidates.length} 个）：\n${summaries}\n\n要求：\n- 只保留能满足查询意图的仓库；若没有仓库能真正满足意图，返回 []，不要用仅部分沾边的仓库凑数。\n- 相关性相近时，star 数更高、更活跃的优先。\n- 最多返回 ${AIService.SELECTION_MAX_RESULTS} 个 ID。`
+      : `User query: "${this.sanitizeForPrompt(query)}"${intentLine}\n\nCandidate repositories (${candidates.length} total):\n${summaries}\n\nRequirements:\n- Keep only repositories that satisfy the query intent; if none truly do, return [] instead of padding with loosely related ones.\n- When relevance is similar, prefer higher stars and more active projects.\n- Return at most ${AIService.SELECTION_MAX_RESULTS} IDs.`;
+
+    const content = await this.requestText({
+      system,
+      user,
+      temperature: 0.1,
+      maxTokens: AIService.SELECTION_MAX_TOKENS,
+      signal,
+    });
+
+    const ranked = this.resolveRankedRepositories(content, candidates);
+    if (ranked === null) return null;
+    return ranked.slice(0, AIService.SELECTION_MAX_RESULTS);
+  }
+
+  /**
+   * 词法加权打分（候选召回与失败兜底共用）。查询词用高权重；AI 扩展词是弱
+   * 信号，只用于召回与加分，权重约为查询词的六成。
+   */
+  private scoreRepositoriesByKeywords(repositories: Repository[], query: string, aiTerms: string[]): Array<{ repo: Repository; score: number }> {
     const normalizedQuery = query.toLowerCase();
     const queryWords = normalizedQuery.split(/\s+/).filter(word => word.length > 0);
-    
-    // Score repositories based on relevance
-    const scoredRepos = repositories.map(repo => {
+    // 去重并剔除与原查询相同的扩展词，避免重复计分
+    const terms = [...new Set(aiTerms.map(term => term.toLowerCase()).filter(term => term && term !== normalizedQuery))];
+
+    const scoredRepos: Array<{ repo: Repository; score: number }> = [];
+    for (const repo of repositories) {
       let score = 0;
-      
+
       const searchableFields = {
         name: repo.name.toLowerCase(),
         fullName: repo.full_name.toLowerCase(),
@@ -2124,33 +2226,37 @@ ${repoInfo}
         license: normalizeLicense(repo.license).toLowerCase(),
       };
 
-      // Check if any query word matches any field
+      // 完全无命中（查询词与扩展词均未命中）的仓库不进入候选
       const hasMatch = queryWords.some(word => {
         return Object.values(searchableFields).some(fieldValue => {
           return fieldValue.includes(word);
         });
+      }) || terms.some(term => {
+        return Object.values(searchableFields).some(fieldValue => {
+          return fieldValue.includes(term);
+        });
       });
 
-      if (!hasMatch) return { repo, score: 0 };
+      if (!hasMatch) continue;
 
       // Calculate relevance score
       queryWords.forEach(word => {
         // Name matches (highest weight)
         if (searchableFields.name.includes(word)) score += 0.4;
         if (searchableFields.fullName.includes(word)) score += 0.35;
-        
+
         // Description matches
         if (searchableFields.description.includes(word)) score += 0.3;
         if (searchableFields.customDescription.includes(word)) score += 0.32;
-        
+
         // Tags and topics matches
         if (searchableFields.topics.includes(word)) score += 0.25;
         if (searchableFields.aiTags.includes(word)) score += 0.22;
         if (searchableFields.customTags.includes(word)) score += 0.24;
-        
+
         // AI summary matches
         if (searchableFields.aiSummary.includes(word)) score += 0.15;
-        
+
         // Platform and language matches
         if (searchableFields.aiPlatforms.includes(word)) score += 0.18;
         if (searchableFields.language.includes(word)) score += 0.12;
@@ -2159,21 +2265,40 @@ ${repoInfo}
         if (searchableFields.license.includes(word)) score += 0.2;
       });
 
+      // AI 扩展词：较弱权重的同类命中
+      terms.forEach(term => {
+        if (searchableFields.name.includes(term)) score += 0.25;
+        if (searchableFields.fullName.includes(term)) score += 0.2;
+        if (searchableFields.customDescription.includes(term)) score += 0.2;
+        if (searchableFields.description.includes(term)) score += 0.18;
+        if (searchableFields.topics.includes(term)) score += 0.15;
+        if (searchableFields.aiTags.includes(term)) score += 0.13;
+        if (searchableFields.customTags.includes(term)) score += 0.14;
+        if (searchableFields.aiPlatforms.includes(term)) score += 0.1;
+        if (searchableFields.aiSummary.includes(term)) score += 0.1;
+        if (searchableFields.license.includes(term)) score += 0.12;
+        if (searchableFields.language.includes(term)) score += 0.08;
+      });
+
       // Boost for exact matches
       if (searchableFields.name === normalizedQuery) score += 0.5;
       if (searchableFields.name.includes(normalizedQuery)) score += 0.3;
-      
+
       // Popularity boost (logarithmic to avoid overwhelming other factors)
       const popularityScore = Math.log10(repo.stargazers_count + 1) * 0.05;
       score += popularityScore;
 
-      return { repo, score };
-    });
+      scoredRepos.push({ repo, score });
+    }
 
-    // Filter out repositories with no matches and sort by relevance
-    return scoredRepos
+    scoredRepos.sort((a, b) => b.score - a.score);
+    return scoredRepos;
+  }
+
+  /** 词法得分排序兜底：只保留得分 > 0 的仓库，按得分从高到低。 */
+  private performEnhancedBasicSearch(repositories: Repository[], query: string, aiTerms: string[] = []): Repository[] {
+    return this.scoreRepositoriesByKeywords(repositories, query, aiTerms)
       .filter(item => item.score > 0)
-      .sort((a, b) => b.score - a.score)
       .map(item => item.repo);
   }
 
@@ -2183,12 +2308,14 @@ ${repoInfo}
 用户搜索查询: "${query}"
 
 请分析这个搜索查询并提供：
-1. 主要关键词（中英文）
-2. 相关的技术术语和同义词
-3. 可能的应用类型或分类
+1. 一句话复述用户的真实搜索意图（不超过30字）
+2. 主要关键词（中英文）
+3. 相关的技术术语和同义词
+4. 可能的应用类型或分类
 
 以JSON格式回复：
 {
+  "intent": "一句话复述用户的真实搜索意图",
   "keywords": ["关键词1", "keyword1", "关键词2", "keyword2"],
   "categories": ["分类1", "category1"],
   "synonyms": ["同义词1", "synonym1"]
@@ -2199,12 +2326,14 @@ ${repoInfo}
 User search query: "${query}"
 
 Please analyze this search query and provide:
-1. Main keywords (in English and Chinese)
-2. Related technical terms and synonyms
-3. Possible application types or categories
+1. One sentence restating the user's true search intent (max 30 words)
+2. Main keywords (in English and Chinese)
+3. Related technical terms and synonyms
+4. Possible application types or categories
 
 Reply in JSON format:
 {
+  "intent": "One sentence restating the user's true search intent",
   "keywords": ["keyword1", "关键词1", "keyword2", "关键词2"],
   "categories": ["category1", "分类1"],
   "synonyms": ["synonym1", "同义词1"]
@@ -2213,71 +2342,24 @@ Reply in JSON format:
     }
   }
 
-  private parseSearchResponse(content: string): string[] {
+  private parseSearchResponse(content: string): { terms: string[]; intent: string } {
     try {
       const parsed = this.extractAndParseAIJson(content);
       if (parsed) {
-        const allTerms = [
+        const terms = [
           ...(Array.isArray(parsed.keywords) ? parsed.keywords : []),
           ...(Array.isArray(parsed.categories) ? parsed.categories : []),
           ...(Array.isArray(parsed.synonyms) ? parsed.synonyms : []),
-        ];
-        return allTerms.filter(term => typeof term === 'string' && term.length > 0);
+        ]
+          .filter((term): term is string => typeof term === 'string' && term.trim().length > 0)
+          .map(term => term.trim());
+        const intent = typeof parsed.intent === 'string' ? parsed.intent.trim() : '';
+        return { terms: [...new Set(terms)], intent: intent.slice(0, 100) };
       }
     } catch (error) {
       logger.warn('ai', 'Failed to parse AI search response', { error: String(error) });
     }
-    return [];
-  }
-
-  private performEnhancedSearch(repositories: Repository[], originalQuery: string, aiTerms: string[]): Repository[] {
-    const allSearchTerms = [originalQuery, ...aiTerms];
-
-    return repositories.filter(repo => {
-      const searchableText = [
-        repo.name,
-        repo.full_name,
-        repo.description || '',
-        repo.language || '',
-        ...(repo.topics || []),
-        repo.ai_summary || '',
-        ...(repo.custom_tags || []),
-        ...(repo.ai_tags || []),
-        ...(repo.ai_platforms || []),
-        normalizeLicense(repo.license),
-      ].join(' ').toLowerCase();
-
-      // Check if any of the AI-enhanced terms match
-      return allSearchTerms.some(term => {
-        const normalizedTerm = term.toLowerCase();
-        return searchableText.includes(normalizedTerm) ||
-               // Fuzzy matching for partial matches
-               normalizedTerm.split(/\s+/).every(word => searchableText.includes(word));
-      });
-    });
-  }
-
-  private performBasicSearch(repositories: Repository[], query: string): Repository[] {
-    const normalizedQuery = query.toLowerCase();
-    
-    return repositories.filter(repo => {
-      const searchableText = [
-        repo.name,
-        repo.full_name,
-        repo.description || '',
-        repo.language || '',
-        ...(repo.topics || []),
-        repo.ai_summary || '',
-        ...(repo.custom_tags || []),
-        ...(repo.ai_tags || []),
-        ...(repo.ai_platforms || []),
-        normalizeLicense(repo.license),
-      ].join(' ').toLowerCase();
-
-      // Split query into words and check if all words are present
-      const queryWords = normalizedQuery.split(/\s+/);
-      return queryWords.every(word => searchableText.includes(word));
-    });
+    return { terms: [], intent: '' };
   }
 
   static async searchRepositories(repositories: Repository[], query: string): Promise<Repository[]> {

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -1578,7 +1578,8 @@ AI Summary: ${gist.ai_summary || 'None'}`;
   /**
    * 从模型输出解析排序后的仓库列表。ID 优先匹配；模型偶尔会把候选行号
    * （1..N）当作 ID 返回，此时在候选范围内按行号解析——否则整份重排结果会被
-   * 静默丢弃。返回 null 表示输出里没有可解析的 JSON 数组。
+   * 静默丢弃。返回 null 表示响应无效（没有可解析的 JSON 数组，或非空数组的
+   * ID 全部无法落位）；空数组是合法结果（模型明确判定无相关仓库）。
    */
   private resolveRankedRepositories(content: string, candidates: Repository[]): Repository[] | null {
     const jsonMatch = content.match(/\[[\s\S]*?\]/);
@@ -1613,6 +1614,9 @@ AI Summary: ${gist.ai_summary || 'None'}`;
         }
       }
     }
+    // 非空响应却一个 ID 都没落位：是幻觉 ID / 响应无效，不是模型判空。
+    // 返回 null 让调用方走词法兜底，避免把无效响应当成"无相关结果"呈现空态。
+    if (ids.length > 0 && ranked.length === 0) return null;
     return ranked;
   }
 

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -2147,6 +2147,8 @@ ${repoInfo}
       });
       return ranked;
     } catch (error) {
+      // 用户主动取消：不产出兜底结果，向上传播交由调用方处理
+      if (signal?.aborted || (error instanceof Error && error.name === 'AbortError')) throw error;
       logger.warn('ai', 'AI selection failed, falling back to lexical ranking', {
         apiType: this.getApiType(),
         model: this.config.model,
@@ -2189,7 +2191,12 @@ ${repoInfo}
       system,
       user,
       temperature: 0.1,
-      maxTokens: AIService.SELECTION_MAX_TOKENS,
+      // 推理 token 与输出共享预算（openai reasoning 模型、gemini 2.5 思考模型）：
+      // 小预算被推理耗尽时 content 为空、精选会静默退化，故复用重排序的 4096
+      // 预算；普通模型 800 足够容纳 ≤20 个 ID 的 JSON 数组。
+      maxTokens: this.config.reasoningEffort || this.getApiType() === 'gemini'
+        ? AIService.RERANKING_MAX_TOKENS
+        : AIService.SELECTION_MAX_TOKENS,
       signal,
     });
 
@@ -2205,8 +2212,10 @@ ${repoInfo}
   private scoreRepositoriesByKeywords(repositories: Repository[], query: string, aiTerms: string[]): Array<{ repo: Repository; score: number }> {
     const normalizedQuery = query.toLowerCase();
     const queryWords = normalizedQuery.split(/\s+/).filter(word => word.length > 0);
-    // 去重并剔除与原查询相同的扩展词，避免重复计分
-    const terms = [...new Set(aiTerms.map(term => term.toLowerCase()).filter(term => term && term !== normalizedQuery))];
+    // 去重并剔除与任一查询词相同的扩展词：避免同一命中被查询词与扩展词
+    // 重复计分（按词级剔除，而非仅完整查询串）
+    const querySet = new Set([normalizedQuery, ...queryWords]);
+    const terms = [...new Set(aiTerms.map(term => term.toLowerCase()).filter(term => term && !querySet.has(term)))];
 
     const scoredRepos: Array<{ repo: Repository; score: number }> = [];
     for (const repo of repositories) {

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -117,6 +117,11 @@ export function isAIStreamUnsupportedError(error: unknown): boolean {
   return error instanceof AIStreamUnsupportedError;
 }
 
+/** 判断错误是否为请求取消（AbortError）。取消不是失败：调用方应停止流程而非兜底。 */
+export function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
 /** 当前 AI 配置/端点不支持模型原生工具调用（function calling）。调用方应降级到编排式循环。 */
 export class AIToolCallUnsupportedError extends Error {
   constructor(message = 'Tool calling is not supported on this AI configuration') {
@@ -2160,7 +2165,7 @@ ${repoInfo}
       return ranked;
     } catch (error) {
       // 用户主动取消：不产出兜底结果，向上传播交由调用方处理
-      if (signal?.aborted || (error instanceof Error && error.name === 'AbortError')) throw error;
+      if (signal?.aborted || isAbortError(error)) throw error;
       onFallback?.('ai_failed');
       logger.warn('ai', 'AI selection failed, falling back to lexical ranking', {
         apiType: this.getApiType(),


### PR DESCRIPTION
## Summary

向量搜索未配置或不可用时，AI 搜索的实际效果很差。根因是旧降级链（`searchRepositoriesWithReranking`）里 **LLM 只做关键词扩展，从不见仓库数据**：扩展出的关键词在本地做 OR 子串过滤，泛化同义词导致噪声爆炸（实测"AI 代码审查工具"命中 951 个仓库中的 510 个），结果再按 star 排序，AI 对排序零贡献。

本 PR 将无向量降级链改为三段式 **retrieve-then-select**（检索-精选），全程只用普通 chat 调用、不依赖向量：

1. **查询扩展 + 意图复述**（1 次 chat 调用）：提取中英文关键词/同义词，新增 `intent` 字段一句话复述用户真实意图；
2. **本地词法召回**（零成本）：库容 ≤150 全量直送；大库按加权词法打分取 top-100（token 成本与库容解耦），词法命中不足时按 star 补足；
3. **LLM 精选排序**（1 次 chat 调用）：LLM 阅读候选摘要（名称/简介/语言/★/标签），只返回真正相关的仓库（最多 20 个），提示词带加固约束（"ID 是真实仓库 ID 长数字，严禁序号"、"无相关返回 []，不要凑数"）。

配套修复与增强：

- `resolveRankedRepositories` 容错解析：**真实 ID 优先、候选行号兜底**。实验中发现模型会混用两种引用风格，旧的 `repoById.get(id)` 会把行号响应整份静默丢弃——向量路径 `searchRepositoriesWithSemanticReranking` 存在同样的既有缺陷，本 PR 一并加固（补回归测试）。
- `keywordSearch` 恢复 AI 相关性顺序，避免被 `applyFilters` 的排序控件（默认 star 降序）覆盖（与向量路径 `rerankOrder` 恢复逻辑同构）。
- AI 明确返回空数组时呈现空结果（走既有空态提示），而非词法噪声；LLM 失败时按词法得分序 top-100 兜底。
- 移除随之失去调用方的死代码：`searchRepositoriesWithReranking`、`performEnhancedSearch`、实例版 `searchRepositories`、`performBasicSearch`。

## 实验跑分数据（旧版 vs 新版）

**实验设置**：仓库作者的 951 个真实星标仓库；模型 `agnes-2.5-flash`（OpenAI 兼容 chat 端点）；两轮共 22 条真实风格的中英文查询。相关性标注采用 pooling 方法（新旧方案召回并集 + 全库定向排查），逐条人工判读。旧版（S0）为忠实复刻的线上行为（扩展 → OR 子串过滤 → star 排序）。

### 第一轮：12 条混合风格查询

| 方案 | P@5 ↑ | R@10 ↑ | 输入 token/次 | LLM 调用 |
|---|---|---|---|---|
| 旧版（扩展 + OR 过滤 + star 排序） | 0.21 | 0.31 | ~0.3k | 1 |
| **新版（本 PR：词法召回 + LLM 精选）** | **0.67** | **0.52** | ~7.6k | 2 |
| 全量直送 LLM（否决方案） | 0.58 | 0.46 | ~65.5k | 2 |

> 否决"全量直送"的原因：951 库容即出现注意力稀释（"截图贴图工具"查询 P@5=0），且 token 随库容线性膨胀（5000 星标 ≈ 34 万 token/次）。

**噪声纪律**（星标库中不存在相关项的查询，理想返回 ≈ 0）：

| 查询 | 旧版返回 | 新版返回 |
|---|---|---|
| AI 代码审查工具 | **510 条**（全部噪声） | 1 条 |
| 浏览器里写代码的环境 | 33 条（全部噪声） | 1 条 |
| 终端文件管理器 | 26 条（全部噪声） | 2 条 |

### 第二轮：按输入风格分组（各 6 条纯关键词 + 4 条简单描述句）

| 查询风格 | 指标 | 旧版 | 新版 |
|---|---|---|---|
| 纯关键词（录屏 / 剪贴板 / webdav / 音乐播放器 / PDF转markdown / 笔记） | P@5 | 0.30 | **0.77** |
| | R@10 | 0.58 | **0.70** |
| 简单描述句（"把网页文章转成 markdown 的工具"等） | P@5 | 0.05 | **0.40** |
| | R@10 | 0.19 | **0.54** |

**典型样例**（新版 top 结果）：

- "markdown 编辑器"：MiaoYan、MarkEdit、doocs/md、marktext、note-gen（旧版前几名：markitdown、Stirling-PDF、mermaid 等无关热门仓库）
- "数据库管理客户端"：dbeaver、Chat2DB、TablePro、sqlchat、conar（旧版首位：hoppscotch）
- "录屏"：OBS、QuickRecorder、screenity（旧版 P@5=0.4，中文关键词对英文描述的跨语言匹配靠扩展词桥接）

**成本与延迟**：每次 AI 搜索新增 1 次约 7.6k input token 的调用，端到端延迟增加约 1~2.5s；候选数固定 100，成本不随库容增长。

## Runtime / persistence / UI changes

- **运行时行为**：无向量 AI 搜索的降级链替换（本 PR 主体）；AI 搜索完成时结果按 AI 相关性排序；AI 判定"无相关仓库"时展示既有空态（"未找到与...相关的仓库"）而非旧版的噪声全集；AI 失败时兜底结果从"全量匹配集"变为"词法得分 top-100"。
- **持久化**：无变更（不涉及 Store keys / version / migrate）。
- **UI**：搜索阶段提示新增"AI 精选相关仓库..."一档（复用现有 `searchPhase` 机制）；输入框实时关键词匹配与向量路径行为均未改动。

## Verification

按模板顺序本地全量执行：

```bash
npm run check:boundaries   # ✓ no frontend layering violations
npm run lint               # ✓
npm run typecheck          # ✓
npm run test:run           # ✓ 778 passed (80 files)
npm run build              # ✓ bundle 998.58 KiB / limit 3000 KiB
git diff --check           # ✓
```

## Notes for reviewers / CodeRabbit

- `searchRepositoriesWithSelection` 的常量（候选上限 100、小库阈值 150、精选上限 20）来自实验调参与行业惯例（retrieve-then-rerank / RankGPT listwise 范式），欢迎讨论取值。
- `searchGistsWithReranking` 存在同款"行号静默丢弃"问题，但需要泛型化解析 helper 才能复用，为控制本 PR 范围未动，建议单独跟进。
- 实验脚本与标注数据未纳入仓库（一次性验证产物）；如需要可以整理成 `docs/` 下的实验记录。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - AI 搜索结合查询意图扩展、候选召回与智能精选，提供更相关的仓库结果。
  - 搜索过程中支持展示查询扩展和结果精选等阶段的进度反馈。
  - 改进中文关键词召回，提升相关仓库的搜索覆盖率。
- **改进**
  - AI 精选结果保留智能排序，不再强制按 Star 数降序排列。
  - AI 搜索失败时自动回退到基础文本搜索，并通过提示告知用户。
  - AI 明确返回空结果时，正确展示空结果状态。
  - 取消搜索时静默停止，避免显示错误提示或写入过期结果。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->