### PR TITLE
fix: auto-rename GitHub Lists on language switch (Mandarin -> English)

### DIFF
--- a/src/services/githubListsApi.test.ts
+++ b/src/services/githubListsApi.test.ts
@@ -31,6 +31,10 @@ const UPDATE_ITEM_DATA = {
   data: { updateUserListsForItem: { clientMutationId: 'c1' } },
 };
 
+const UPDATE_LIST_DATA = {
+  data: { updateUserList: { list: { id: 'L_1', name: 'renamed' } } },
+};
+
 const VIEWER_LISTS_DATA = {
   data: {
     viewer: {
@@ -223,6 +227,53 @@ describe('GitHubListsApiService 后端代理回退直连', () => {
     expect(calls).toHaveLength(2);
     expect(String(calls[0][0])).toBe(PROXY_URL);
     expect(String(calls[1][0])).toBe(DIRECT_URL);
+  });
+
+  describe('updateUserList', () => {
+    function lastVariables(): Record<string, unknown> {
+      const calls = vi.mocked(window.fetch).mock.calls;
+      return JSON.parse(String((calls[calls.length - 1][1] as RequestInit).body ?? '{}')).variables;
+    }
+
+    it('省略 description 时变量表不含 description 键（重命名保留已有描述，不被显式 null 清空）', async () => {
+      const api = makeService(null);
+      vi.mocked(window.fetch).mockResolvedValueOnce(makeJsonResponse(200, UPDATE_LIST_DATA));
+
+      await api.updateUserList('L_1', 'Development Tools');
+
+      const variables = lastVariables();
+      expect(variables).toEqual({ listId: 'L_1', name: 'Development Tools' });
+      // toEqual 会忽略值为 undefined 的键，这里显式断言键确实不存在
+      expect('description' in variables).toBe(false);
+    });
+
+    it('显式传 null 时发送 description: null（保留清空描述的能力）', async () => {
+      const api = makeService(null);
+      vi.mocked(window.fetch).mockResolvedValueOnce(makeJsonResponse(200, UPDATE_LIST_DATA));
+
+      await api.updateUserList('L_1', 'Development Tools', null);
+
+      expect(lastVariables()).toEqual({ listId: 'L_1', name: 'Development Tools', description: null });
+    });
+
+    it('显式传描述字符串时原样发送', async () => {
+      const api = makeService(null);
+      vi.mocked(window.fetch).mockResolvedValueOnce(makeJsonResponse(200, UPDATE_LIST_DATA));
+
+      await api.updateUserList('L_1', 'Development Tools', 'curated tools');
+
+      expect(lastVariables()).toEqual({ listId: 'L_1', name: 'Development Tools', description: 'curated tools' });
+    });
+
+    it('未知结果（内部超时）时抛错，不自动重放、不回退直连', async () => {
+      const api = makeService(BACKEND_URL);
+      vi.mocked(window.fetch).mockRejectedValueOnce(new DOMException('The operation was aborted.', 'AbortError'));
+
+      await expect(api.updateUserList('L_1', 'Development Tools')).rejects.toThrow(/请求超时/);
+      const calls = vi.mocked(window.fetch).mock.calls;
+      expect(calls).toHaveLength(1);
+      expect(String(calls[0][0])).toBe(PROXY_URL);
+    });
   });
 
   it('代理请求内部超时（AbortError）后回退直连并成功', async () => {

--- a/src/services/githubListsApi.ts
+++ b/src/services/githubListsApi.ts
@@ -740,6 +740,19 @@ export class GitHubListsApiService {
       { replayableMutation: true }
     );
   }
+  /** 重命名 List（用于语言切换时的自动迁移）。 */
+  async updateUserList(listId: string, name: string, description?: string): Promise<void> {
+    await this.request<{ updateUserList: { list: { id: string; name: string } } }>(
+      `mutation($listId: ID!, $name: String!, $description: String) {
+        updateUserList(input: { listId: $listId, name: $name, description: $description }) {
+          list { id name }
+        }
+      }`,
+      { listId, name, description: description ?? null },
+      { replayableMutation: true }
+    );
+  }
+
 
   /**
    * 将某仓库（itemId 为 GraphQL node id）加入指定 list 集合。

--- a/src/services/githubListsApi.ts
+++ b/src/services/githubListsApi.ts
@@ -740,7 +740,7 @@ export class GitHubListsApiService {
       { replayableMutation: true }
     );
   }
-  /** 重命名 List（用于语言切换时的自动迁移）。 */
+  /** 重命名 List（用于语言切换时的自动迁移）。幂等：重命名到同一目标名称可安全重放。 */
   async updateUserList(listId: string, name: string, description?: string): Promise<void> {
     await this.request<{ updateUserList: { list: { id: string; name: string } } }>(
       `mutation($listId: ID!, $name: String!, $description: String) {
@@ -749,7 +749,7 @@ export class GitHubListsApiService {
         }
       }`,
       { listId, name, description: description ?? null },
-      { replayableMutation: true }
+      { replayableMutation: false }
     );
   }
 

--- a/src/services/githubListsApi.ts
+++ b/src/services/githubListsApi.ts
@@ -740,19 +740,28 @@ export class GitHubListsApiService {
       { replayableMutation: true }
     );
   }
-  /** 重命名 List（用于语言切换时的自动迁移）。幂等：重命名到同一目标名称可安全重放。 */
-  async updateUserList(listId: string, name: string, description?: string): Promise<void> {
+  /**
+   * 重命名 List（用于语言切换时的自动迁移）。
+   * description 仅在显式传入时随请求发送：省略该参数时变量表中不含 description 键，
+   * GraphQL 视为"未提供该字段"，保留 list 已有描述；显式传 null 才表示清空描述。
+   * 未知结果（网络/超时）不自动重放：重命名虽幂等，但下一轮推送会因名称不匹配
+   * 自然重试，无需在请求层重放。
+   */
+  async updateUserList(listId: string, name: string, description?: string | null): Promise<void> {
+    const variables: { listId: string; name: string; description?: string | null } = { listId, name };
+    if (description !== undefined) {
+      variables.description = description;
+    }
     await this.request<{ updateUserList: { list: { id: string; name: string } } }>(
       `mutation($listId: ID!, $name: String!, $description: String) {
         updateUserList(input: { listId: $listId, name: $name, description: $description }) {
           list { id name }
         }
       }`,
-      { listId, name, description: description ?? null },
+      variables,
       { replayableMutation: false }
     );
   }
-
 
   /**
    * 将某仓库（itemId 为 GraphQL node id）加入指定 list 集合。

--- a/src/store/slices/repositorySlice.test.ts
+++ b/src/store/slices/repositorySlice.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from 'vitest';
+import { beforeEach } from 'vitest';
+import type { Repository } from '../../types';
+import { defaultCategories } from '../schema';
+import { createRepositorySlice } from './repositorySlice';
+import { logger } from '../../services/logger';
+
+vi.mock('../../services/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), errorFromError: vi.fn() },
+}));
+
+interface HarnessState {
+  listsPush: { isRunning: boolean; total: number; done: number; currentLabel: string | null; message: string | null; error: string | null };
+  categoryListIdMap: Record<string, string>;
+  [key: string]: unknown;
+}
+
+type MockListsApi = {
+  getUserLists: ReturnType<typeof vi.fn>;
+  createUserList: ReturnType<typeof vi.fn>;
+  updateUserList: ReturnType<typeof vi.fn>;
+  updateUserListsForItem: ReturnType<typeof vi.fn>;
+  resolveRepositoryNodeIds: ReturnType<typeof vi.fn>;
+};
+
+function makeRepo(overrides: Partial<Repository> = {}): Repository {
+  return {
+    id: 1,
+    name: 'my-cli-app',
+    full_name: 'owner/my-cli-app',
+    description: null,
+    html_url: 'https://github.com/owner/my-cli-app',
+    stargazers_count: 1,
+    forks_count: 0,
+    forks: 0,
+    language: null,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    pushed_at: '2024-01-01T00:00:00Z',
+    owner: { login: 'owner', avatar_url: '' },
+    topics: ['cli'],
+    ...overrides,
+  };
+}
+
+/**
+ * 最小化 slice 测试装置：仅提供 pushCategoriesToLists 读取/写入的状态字段。
+ * 仓库 my-cli-app（topics: ['cli']）经 devtools 分类关键词 'cli' 命中，
+ * 使推送流程完整走到最终 set()，从而可断言 categoryListIdMap 的持久化。
+ */
+function makeSliceHarness(options: {
+  currentLists: Array<{ id: string; name: string; items: string[] }>;
+  categoryListIdMap?: Record<string, string>;
+  repositories?: Repository[];
+}) {
+  const state: HarnessState = {
+    listsPush: { isRunning: false, total: 0, done: 0, currentLabel: null, message: null, error: null },
+    githubToken: 'token',
+    user: { login: 'octocat' },
+    repositories: options.repositories ?? [makeRepo()],
+    customCategories: [],
+    language: 'en',
+    hiddenDefaultCategoryIds: defaultCategories.filter(c => c.id !== 'devtools').map(c => c.id),
+    defaultCategoryOverrides: {},
+    categoryListIdMap: options.categoryListIdMap ?? {},
+  };
+  const set = (partial: unknown) => {
+    const next = typeof partial === 'function'
+      ? (partial as (s: HarnessState) => Partial<HarnessState>)(state)
+      : partial;
+    Object.assign(state, next);
+  };
+  const get = () => state;
+  const api: MockListsApi = {
+    getUserLists: vi.fn().mockResolvedValue(options.currentLists),
+    createUserList: vi.fn().mockResolvedValue('L_new'),
+    updateUserList: vi.fn().mockResolvedValue(undefined),
+    updateUserListsForItem: vi.fn().mockResolvedValue(undefined),
+    resolveRepositoryNodeIds: vi.fn().mockResolvedValue(new Map()),
+  };
+  const slice = createRepositorySlice(set as never, get as never);
+  const push = () => slice.pushCategoriesToLists(api as never);
+  return { push, api, state };
+}
+
+describe('pushCategoriesToLists 语言切换自动重命名', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('persistedId 映射的中文 list 在英文语言下被重命名为分类名，不新建 list', async () => {
+    const { push, api, state } = makeSliceHarness({
+      currentLists: [{ id: 'L_zh', name: '开发工具', items: [] }],
+      categoryListIdMap: { devtools: 'L_zh' },
+    });
+
+    await push();
+
+    expect(api.updateUserList).toHaveBeenCalledTimes(1);
+    expect(api.updateUserList).toHaveBeenCalledWith('L_zh', 'Development Tools');
+    expect(api.createUserList).not.toHaveBeenCalled();
+    expect(state.categoryListIdMap.devtools).toBe('L_zh');
+    expect(state.listsPush.error).toBeNull();
+  });
+
+  it('无映射时按名称变体匹配既有中文 list：重命名并写入映射', async () => {
+    const { push, api, state } = makeSliceHarness({
+      currentLists: [{ id: 'L_legacy', name: '开发工具', items: [] }],
+    });
+
+    await push();
+
+    expect(api.updateUserList).toHaveBeenCalledWith('L_legacy', 'Development Tools');
+    expect(api.createUserList).not.toHaveBeenCalled();
+    expect(state.categoryListIdMap.devtools).toBe('L_legacy');
+  });
+
+  it('list 名称已与分类名一致时不调用 updateUserList', async () => {
+    const { push, api } = makeSliceHarness({
+      currentLists: [{ id: 'L_en', name: 'Development Tools', items: [] }],
+      categoryListIdMap: { devtools: 'L_en' },
+    });
+
+    await push();
+
+    expect(api.updateUserList).not.toHaveBeenCalled();
+    expect(api.createUserList).not.toHaveBeenCalled();
+  });
+
+  it('重命名失败时保留映射并继续推送（best-effort，下轮重试）', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { push, api, state } = makeSliceHarness({
+      currentLists: [{ id: 'L_zh', name: '开发工具', items: [] }],
+      categoryListIdMap: { devtools: 'L_zh' },
+    });
+    api.updateUserList.mockRejectedValue(new Error('network down'));
+
+    await expect(push()).resolves.toBeUndefined();
+
+    expect(api.createUserList).not.toHaveBeenCalled();
+    expect(state.categoryListIdMap.devtools).toBe('L_zh');
+    expect(state.listsPush.error).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      'githubLists',
+      'Some lists failed to rename, will retry next push',
+      { failures: ['开发工具 -> Development Tools'] }
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('新建 list 使用当前语言的分类名（而非规范中文名）', async () => {
+    const { push, api, state } = makeSliceHarness({
+      currentLists: [],
+    });
+
+    await push();
+
+    expect(api.createUserList).toHaveBeenCalledWith('Development Tools', true);
+    expect(state.categoryListIdMap.devtools).toBe('L_new');
+  });
+});

--- a/src/store/slices/repositorySlice.ts
+++ b/src/store/slices/repositorySlice.ts
@@ -195,6 +195,11 @@ export const createRepositorySlice: AppStoreSlice<Pick<import('../types').AppAct
           for (const cat of allCategories) {
             const persistedId = categoryListIdMap[cat.id];
             if (persistedId && currentLists.some(l => l.id === persistedId)) {
+              const existing = currentLists.find(l => l.id === persistedId)!;
+              // auto-migrate name on language switch
+              if (existing.name !== cat.name) {
+                try { await api.updateUserList(persistedId, cat.name); } catch (e) { console.warn('rename list failed', persistedId, e); }
+              }
               listIdByCategoryId.set(cat.id, persistedId);
               managedListIds.add(persistedId);
               continue;
@@ -208,12 +213,16 @@ export const createRepositorySlice: AppStoreSlice<Pick<import('../types').AppAct
               nameVariants.some(v => v.toLowerCase() === l.name.toLowerCase())
             );
             if (matchedList) {
+              // rename if language changed (e.g. 开发工具 -> Development Tools)
+              if (matchedList.name !== cat.name) {
+                try { await api.updateUserList(matchedList.id, cat.name); } catch (e) { console.warn('rename list failed', matchedList.id, e); }
+              }
               listIdByCategoryId.set(cat.id, matchedList.id);
               nextCategoryListIdMap[cat.id] = matchedList.id;
               managedListIds.add(matchedList.id);
               continue;
             }
-            const id = await api.createUserList(canonicalName, true);
+            const id = await api.createUserList(cat.name, true);
             listIdByCategoryId.set(cat.id, id);
             nextCategoryListIdMap[cat.id] = id;
             managedListIds.add(id);

--- a/src/store/slices/repositorySlice.ts
+++ b/src/store/slices/repositorySlice.ts
@@ -1,5 +1,5 @@
-
 import type { Repository } from '../../types';
+import { logger } from '../../services/logger';
 import { matchesCategory } from '../../utils/categoryUtils';
 import type { AppStoreSlice } from '../types';
 import { defaultCategories, initialSearchFilters } from '../schema';
@@ -192,13 +192,14 @@ export const createRepositorySlice: AppStoreSlice<Pick<import('../types').AppAct
           const listIdByCategoryId = new Map<string, string>();
           const managedListIds = new Set<string>();
           const nextCategoryListIdMap = { ...categoryListIdMap };
+          const renameFailures: string[] = [];
           for (const cat of allCategories) {
             const persistedId = categoryListIdMap[cat.id];
             if (persistedId && currentLists.some(l => l.id === persistedId)) {
               const existing = currentLists.find(l => l.id === persistedId)!;
-              // auto-migrate name on language switch
+              // auto-migrate name on language switch — best-effort, keep mapping even if rename fails (retry next push)
               if (existing.name !== cat.name) {
-                try { await api.updateUserList(persistedId, cat.name); } catch (e) { console.warn('rename list failed', persistedId, e); }
+                try { await api.updateUserList(persistedId, cat.name); } catch (e) { console.warn('rename list failed', persistedId, existing.name, '->', cat.name, e); renameFailures.push(`${existing.name} -> ${cat.name}`); }
               }
               listIdByCategoryId.set(cat.id, persistedId);
               managedListIds.add(persistedId);
@@ -213,9 +214,9 @@ export const createRepositorySlice: AppStoreSlice<Pick<import('../types').AppAct
               nameVariants.some(v => v.toLowerCase() === l.name.toLowerCase())
             );
             if (matchedList) {
-              // rename if language changed (e.g. 开发工具 -> Development Tools)
+              // rename if language changed (e.g. 开发工具 -> Development Tools) — best-effort
               if (matchedList.name !== cat.name) {
-                try { await api.updateUserList(matchedList.id, cat.name); } catch (e) { console.warn('rename list failed', matchedList.id, e); }
+                try { await api.updateUserList(matchedList.id, cat.name); } catch (e) { console.warn('rename list failed', matchedList.id, matchedList.name, '->', cat.name, e); renameFailures.push(`${matchedList.name} -> ${cat.name}`); }
               }
               listIdByCategoryId.set(cat.id, matchedList.id);
               nextCategoryListIdMap[cat.id] = matchedList.id;
@@ -227,7 +228,9 @@ export const createRepositorySlice: AppStoreSlice<Pick<import('../types').AppAct
             nextCategoryListIdMap[cat.id] = id;
             managedListIds.add(id);
           }
-
+          if (renameFailures.length > 0) {
+            logger.warn('githubLists', 'Some lists failed to rename, will retry next push', { failures: renameFailures });
+          }
           // 3. 每仓库当前的 list 成员（小写 full_name → list id 集合）
           const repoCurrentListIds = new Map<string, Set<string>>();
           const lowerToOriginal = new Map<string, string>();

--- a/src/store/slices/repositorySlice.ts
+++ b/src/store/slices/repositorySlice.ts
@@ -195,11 +195,16 @@ export const createRepositorySlice: AppStoreSlice<Pick<import('../types').AppAct
           const renameFailures: string[] = [];
           for (const cat of allCategories) {
             const persistedId = categoryListIdMap[cat.id];
-            if (persistedId && currentLists.some(l => l.id === persistedId)) {
-              const existing = currentLists.find(l => l.id === persistedId)!;
+            const existing = persistedId ? currentLists.find(l => l.id === persistedId) : undefined;
+            if (persistedId && existing) {
               // auto-migrate name on language switch — best-effort, keep mapping even if rename fails (retry next push)
               if (existing.name !== cat.name) {
-                try { await api.updateUserList(persistedId, cat.name); } catch (e) { console.warn('rename list failed', persistedId, existing.name, '->', cat.name, e); renameFailures.push(`${existing.name} -> ${cat.name}`); }
+                try {
+                  await api.updateUserList(persistedId, cat.name);
+                } catch (e) {
+                  console.warn('rename list failed', persistedId, existing.name, '->', cat.name, e);
+                  renameFailures.push(`${existing.name} -> ${cat.name}`);
+                }
               }
               listIdByCategoryId.set(cat.id, persistedId);
               managedListIds.add(persistedId);
@@ -216,7 +221,12 @@ export const createRepositorySlice: AppStoreSlice<Pick<import('../types').AppAct
             if (matchedList) {
               // rename if language changed (e.g. 开发工具 -> Development Tools) — best-effort
               if (matchedList.name !== cat.name) {
-                try { await api.updateUserList(matchedList.id, cat.name); } catch (e) { console.warn('rename list failed', matchedList.id, matchedList.name, '->', cat.name, e); renameFailures.push(`${matchedList.name} -> ${cat.name}`); }
+                try {
+                  await api.updateUserList(matchedList.id, cat.name);
+                } catch (e) {
+                  console.warn('rename list failed', matchedList.id, matchedList.name, '->', cat.name, e);
+                  renameFailures.push(`${matchedList.name} -> ${cat.name}`);
+                }
               }
               listIdByCategoryId.set(cat.id, matchedList.id);
               nextCategoryListIdMap[cat.id] = matchedList.id;


### PR DESCRIPTION
## Problem
GitHub Lists were created with canonicalName (zh) regardless of current language, and existing lists were never renamed when language switched. Users who first synced in Mandarin (e.g. 开发工具) kept Mandarin list names on GitHub even after switching to English — reported on 0.7.9.

## Fix
- Add GitHubListsApiService.updateUserList (replayableMutation:false, idempotent rename)
- pushCategoriesToLists: create lists with cat.name (translated) instead of canonicalName
- Auto-rename on both persistedId and nameVariants match — best-effort, keep mapping even if rename fails (retry next push), collect renameFailures and logger.warn
- Re-entry guard already covers concurrent pushes

## Verified
- Manual gh graphql updateUserList renames 13 lists Mandarin→English and verified via viewer.lists
- tsc 0, eslint 0, 771 vitests + 8 electron tests pass
- Adversarial review (2 agents) addressed: replayable flag, mapping corruption, concurrency

Closes language-switch list migration gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 切换语言后，现有 GitHub 列表会尽力自动重命名，以匹配当前分类名称。
  * 新建 GitHub 列表时将使用当前分类名称。

* **改进**
  * 列表重命名失败时不会中断同步流程，系统会继续处理其他列表。
  * 更新列表时，省略描述将保留原描述；显式传入空值才会清空描述。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->