### PR TITLE
fix(ci): skip prebuild version sync in frontend Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,9 @@ RUN npm ci
 # Copy source code
 COPY . .
 
-# Build the application
-RUN npm run build
+# Build the application. --ignore-scripts skips the prebuild hook: sync-version
+# rewrites server/package.json, which is excluded from this frontend-only context.
+RUN npm run build --ignore-scripts
 
 # Production stage
 FROM nginx:alpine


### PR DESCRIPTION
## 问题

`Publish Frontend Docker Image to GHCR` 自 PR #333 合入后在 main 上持续失败（[run 33986885447](https://github.com/AmintaCCCP/GithubStarsManager/actions/runs/33986885447)）：

```
❌ 同步 package-lock.json 失败: ENOENT: no such file or directory, open '/app/server/package.json'
```

**根因**：PR #333 给 `npm run build` 增加了 `prebuild → sync-version` 钩子，且 `update-version.cjs --sync-lock` 现在强制同步 `server/package.json` / `server/package-lock.json`。而前端镜像的构建上下文通过根 `.dockerignore` 刻意排除了 `server/`（frontend-only 镜像不需要服务端代码），钩子在容器内必然 ENOENT。

`Dockerfile.fullstack` 未受影响：它使用 `Dockerfile.fullstack.dockerignore`（不排除 `server/`）；`server/Dockerfile` 无 prebuild 钩子。

## 修复

`Dockerfile` 改为 `npm run build --ignore-scripts`：跳过 prebuild 钩子（其产物是在仓库内改写版本文件，在一次性 Docker 层里本无意义），`vite build` 与 `check:bundle-size` 照常执行，与 PR #333 之前的 Docker 构建行为一致。

## 验证

- 本地 `npm run build --ignore-scripts`：无 prebuild 输出，vite 构建正常。
- 本地 `docker buildx build --platform linux/amd64 .`：构建成功。构建阶段锁定 `$BUILDPLATFORM`，多架构行为与之前绿色构建一致。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **构建**
  * 优化前端资源的 Docker 构建流程，避免构建过程中执行不必要的版本同步步骤。
  * 提升仅包含前端资源场景下的构建稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->