### PR TITLE
fix(categories): prevent partial keyword false positives

### DIFF
--- a/src/utils/categoryUtils.test.ts
+++ b/src/utils/categoryUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Category, Repository } from '../types';
-import { getEffectiveTags, matchesCategory, resolveCategoryAssignment, buildCategoryHints } from './categoryUtils';
+import { getAICategory, getEffectiveTags, matchesCategory, resolveCategoryAssignment, buildCategoryHints } from './categoryUtils';
 
 const aiCategory: Category = {
   id: 'ai',
@@ -586,5 +586,39 @@ describe('resolveCategoryAssignment summary-only metadata match', () => {
       custom_category: undefined,
     };
     expect(resolveCategoryAssignment(repository, ['开发工具'], [customSkills, aiCategory])).toBe(undefined);
+  });
+});
+
+describe('category keyword direction', () => {
+  const gameCategory: Category = {
+    id: 'game', name: '游戏', icon: '🎮',
+    keywords: ['游戏', 'game', 'gaming', 'unity', 'unreal', 'godot'],
+  };
+
+  it.each(['legacy', 'effective'] as const)('does not classify Go tags as Godot in %s mode', (mode) => {
+    const repository = { ...baseRepository, ai_tags: ['Go'] };
+    expect(matchesCategory(repository, gameCategory, mode)).toBe(false);
+    expect(getAICategory(repository, [gameCategory])).toBe('');
+  });
+
+  it('does not classify Go topics as Godot', () => {
+    const repository = { ...baseRepository, ai_tags: [], topics: ['go', 'docker'] };
+    expect(matchesCategory(repository, gameCategory, 'effective')).toBe(false);
+  });
+
+  it.each(['godot', 'godot-engine', 'gaming', '游戏开发'])('keeps matching relevant tag %s', (tag) => {
+    const repository = { ...baseRepository, ai_tags: [tag] };
+    expect(matchesCategory(repository, gameCategory, 'effective')).toBe(true);
+    expect(getAICategory(repository, [gameCategory])).toBe('游戏');
+  });
+
+  it('does not assign a custom Godot category to Go tags', () => {
+    const category = { ...gameCategory, isCustom: true };
+    expect(resolveCategoryAssignment(baseRepository, ['Go'], [category])).toBeUndefined();
+  });
+
+  it('preserves a locked manual game category', () => {
+    const repository = { ...baseRepository, ai_tags: ['Go'], custom_category: '游戏', category_locked: true };
+    expect(matchesCategory(repository, gameCategory, 'effective')).toBe(true);
   });
 });

--- a/src/utils/categoryUtils.ts
+++ b/src/utils/categoryUtils.ts
@@ -65,8 +65,7 @@ export const getAICategory = (repo: Repository, allCategories: Category[]): stri
 
     const hasMatch = repo.ai_tags.some(tag =>
       category.keywords.some(keyword =>
-        tag.toLowerCase().includes(keyword.toLowerCase()) ||
-        keyword.toLowerCase().includes(tag.toLowerCase())
+        tag.toLowerCase().includes(keyword.toLowerCase())
       )
     );
 
@@ -151,8 +150,7 @@ const tagMatchesCategory = (
 ): boolean => {
   const tagLower = tag.toLowerCase();
   const keywordMatch = getCategoryKeywords(category).some(keyword =>
-    tagLower.includes(keyword.toLowerCase()) ||
-    keyword.toLowerCase().includes(tagLower)
+    tagLower.includes(keyword.toLowerCase())
   );
   if (keywordMatch) return true;
 
@@ -293,8 +291,7 @@ export const resolveCategoryAssignment = (
       category.name.toLowerCase().includes(tag.toLowerCase()) ||
       tag.toLowerCase().includes(category.name.toLowerCase()) ||
       keywords.some(keyword =>
-        tag.toLowerCase().includes(keyword.toLowerCase()) ||
-        keyword.toLowerCase().includes(tag.toLowerCase())
+        tag.toLowerCase().includes(keyword.toLowerCase())
       )
     );
   });
@@ -304,8 +301,7 @@ export const resolveCategoryAssignment = (
     return normalizedTags.some(tag =>
       category.name.toLowerCase() === tag.toLowerCase() ||
       keywords.some(keyword =>
-        tag.toLowerCase().includes(keyword.toLowerCase()) ||
-        keyword.toLowerCase().includes(tag.toLowerCase())
+        tag.toLowerCase().includes(keyword.toLowerCase())
       )
     );
   });


### PR DESCRIPTION
## Summary

Fix category false positives caused by bidirectional substring matching. A short tag such as `Go` previously matched the game keyword `godot`, incorrectly placing Traefik, Portmaster, HypoMux, and mydocker in the Game category.

Category matching now requires the repository tag to contain the configured keyword. Relevant values such as `godot`, `godot-engine`, `gaming`, and `游戏开发` continue to match, and locked manual categories remain unchanged.

## Verification

- `npx vitest run src/utils/categoryUtils.test.ts` — 54 tests passed
- `npm run typecheck` — passed
- `git diff --check` — passed
- Verified in the local UI: the Game category decreased from 6 repositories to 2.

## Scope checklist

- [x] Runtime category-filter behavior described; no persisted data or migration changes.
- [x] No new component business-service imports.
- [x] No new application-layer React, Store, or service imports.
- [x] No inline boundary-rule disables.

### Runtime / persistence / UI changes (if any)

Category filters no longer treat a short repository tag as matching a longer keyword that merely contains it. Existing stored data is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 优化分类关键词匹配规则，避免短关键词因匹配更长单词片段而产生错误分类。
  * 保留相关游戏关键词、自定义分类及手动锁定分类的正常匹配行为。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->