### PR TITLE
feat(repository-chat): 仓库页全局问答历史入口（S4）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ versions/.version-info.xml.*.tmp
 package-lock.json.*.tmp
 .omo/
 .zcode/
+
+# Local static demos for entry-point selection (never commit)
+.tmp-chat-entry-demos/

--- a/src/components/GlobalChatHistorySheet.test.tsx
+++ b/src/components/GlobalChatHistorySheet.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GlobalChatHistorySheet } from './GlobalChatHistorySheet';
+import { repositoryChatSessionRepository } from '../features/repository-chat/repositories/sessionRepository';
+import type { Repository } from '../types';
+import type { RepositoryChatSession } from '../types/repositoryChat';
+
+vi.mock('../store/useAppStore', () => ({
+  useAppStore: (selector: (state: { language: 'zh' }) => unknown) => selector({ language: 'zh' }),
+}));
+
+const createRepository = (id: number, fullName: string): Repository => ({
+  id,
+  name: fullName.split('/')[1],
+  full_name: fullName,
+  owner: { login: fullName.split('/')[0], avatar_url: 'https://example.com/avatar.png' },
+} as unknown as Repository);
+
+const createSession = (id: string, repoId: number, repoFullName: string, updatedAt: string): RepositoryChatSession => ({
+  id,
+  repoId,
+  repoFullName,
+  sourceRefSha: 'abcdef1234567890',
+  title: `title-${id}`,
+  createdAt: updatedAt,
+  updatedAt,
+});
+
+const repositories = [createRepository(1, 'owner/repo-one'), createRepository(2, 'owner/repo-two')];
+
+describe('GlobalChatHistorySheet', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    Object.defineProperty(window, 'indexedDB', { configurable: true, value: undefined });
+  });
+
+  it('按更新时间倒序列出跨仓会话', async () => {
+    await repositoryChatSessionRepository.saveSession(createSession('older', 1, 'owner/repo-one', '2026-08-24T00:00:00.000Z'));
+    await repositoryChatSessionRepository.saveSession(createSession('newer', 2, 'owner/repo-two', '2026-08-26T00:00:00.000Z'));
+
+    render(<GlobalChatHistorySheet isOpen repositories={repositories} onClose={() => {}} onSelectSession={() => {}} />);
+
+    const items = await screen.findAllByTitle(/进入 owner\//);
+    expect(items.map((item) => item.textContent)).toEqual([
+      expect.stringContaining('title-newer'),
+      expect.stringContaining('title-older'),
+    ]);
+  });
+
+  it('按标题或仓库名过滤并进入对应仓库会话', async () => {
+    await repositoryChatSessionRepository.saveSession(createSession('s1', 1, 'owner/repo-one', '2026-08-24T00:00:00.000Z'));
+    await repositoryChatSessionRepository.saveSession(createSession('s2', 2, 'owner/repo-two', '2026-08-26T00:00:00.000Z'));
+    const onSelectSession = vi.fn();
+
+    render(<GlobalChatHistorySheet isOpen repositories={repositories} onClose={() => {}} onSelectSession={onSelectSession} />);
+    await screen.findByTitle('进入 owner/repo-one 的会话');
+
+    fireEvent.change(screen.getByLabelText('搜索问答历史'), { target: { value: 'repo-two' } });
+    expect(screen.queryByTitle('进入 owner/repo-one 的会话')).toBeNull();
+
+    fireEvent.click(screen.getByTitle('进入 owner/repo-two 的会话'));
+    expect(onSelectSession).toHaveBeenCalledWith(repositories[1], 's2');
+  });
+
+  it('删除会话后从列表移除', async () => {
+    await repositoryChatSessionRepository.saveSession(createSession('doomed', 1, 'owner/repo-one', '2026-08-26T00:00:00.000Z'));
+
+    render(<GlobalChatHistorySheet isOpen repositories={repositories} onClose={() => {}} onSelectSession={() => {}} />);
+    await screen.findByTitle('进入 owner/repo-one 的会话');
+
+    const item = screen.getByTitle('进入 owner/repo-one 的会话').closest('li') as HTMLElement;
+    fireEvent.click(within(item).getByRole('button', { name: /删除会话/ }));
+    fireEvent.click(screen.getByRole('button', { name: '删除会话' }));
+
+    expect(await screen.findByText('还没有保存的问答会话。')).toBeTruthy();
+  });
+});

--- a/src/components/GlobalChatHistorySheet.test.tsx
+++ b/src/components/GlobalChatHistorySheet.test.tsx
@@ -62,8 +62,7 @@ describe('GlobalChatHistorySheet', () => {
     expect(onSelectSession).toHaveBeenCalledWith(repositories[1], 's2');
   });
 
-  it('删除会话后从列表移除', async () => {
-    await repositoryChatSessionRepository.saveSession(createSession('doomed', 1, 'owner/repo-one', '2026-08-26T00:00:00.000Z'));
+  it('删除会话后从列表移除', async () => {    await repositoryChatSessionRepository.saveSession(createSession('doomed', 1, 'owner/repo-one', '2026-08-26T00:00:00.000Z'));
 
     render(<GlobalChatHistorySheet isOpen repositories={repositories} onClose={() => {}} onSelectSession={() => {}} />);
     await screen.findByTitle('进入 owner/repo-one 的会话');
@@ -73,5 +72,20 @@ describe('GlobalChatHistorySheet', () => {
     fireEvent.click(screen.getByRole('button', { name: '删除会话' }));
 
     expect(await screen.findByText('还没有保存的问答会话。')).toBeTruthy();
+  });
+
+  it('读取失败时显示错误与重试，恢复后可重载', async () => {
+    const listSpy = vi.spyOn(repositoryChatSessionRepository, 'listRecentSessions');
+    listSpy.mockRejectedValueOnce(new Error('IndexedDB unavailable'));
+
+    render(<GlobalChatHistorySheet isOpen repositories={repositories} onClose={() => {}} onSelectSession={() => {}} />);
+    expect(await screen.findByText('历史加载失败，请重试。')).toBeTruthy();
+
+    listSpy.mockResolvedValueOnce([createSession('recovered', 1, 'owner/repo-one', '2026-08-26T00:00:00.000Z')]);
+    const retryButtons = await screen.findAllByRole('button', { name: '重试' });
+    fireEvent.click(retryButtons[0]);
+
+    expect(await screen.findByTitle('进入 owner/repo-one 的会话')).toBeTruthy();
+    listSpy.mockRestore();
   });
 });

--- a/src/components/GlobalChatHistorySheet.tsx
+++ b/src/components/GlobalChatHistorySheet.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { History, Search, Trash2 } from 'lucide-react';
 import type { Repository } from '../types';
 import type { RepositoryChatSession } from '../types/repositoryChat';
@@ -37,8 +37,11 @@ export const GlobalChatHistorySheet: React.FC<GlobalChatHistorySheetProps> = ({
   const t = (zh: string, en: string) => language === 'zh' ? zh : en;
   const [sessions, setSessions] = useState<RepositoryChatSession[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [query, setQuery] = useState('');
   const [pendingDeletion, setPendingDeletion] = useState<RepositoryChatSession | null>(null);
+  // 重叠刷新只允许最新请求提交，避免旧结果覆盖新状态。
+  const requestIdRef = useRef(0);
 
   const repositoryById = useMemo(() => {
     const map = new Map<number, Repository>();
@@ -47,13 +50,20 @@ export const GlobalChatHistorySheet: React.FC<GlobalChatHistorySheetProps> = ({
   }, [repositories]);
 
   const refresh = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
     setIsLoading(true);
+    setLoadError(null);
     try {
-      setSessions(await repositoryChatSessionRepository.listRecentSessions(50));
+      const nextSessions = await repositoryChatSessionRepository.listRecentSessions(50);
+      if (requestId !== requestIdRef.current) return;
+      setSessions(nextSessions);
+    } catch {
+      if (requestId !== requestIdRef.current) return;
+      setLoadError(language === 'zh' ? '历史加载失败，请重试。' : 'Failed to load history. Please retry.');
     } finally {
-      setIsLoading(false);
+      if (requestId === requestIdRef.current) setIsLoading(false);
     }
-  }, []);
+  }, [language]);
 
   useEffect(() => {
     if (isOpen) {
@@ -123,6 +133,13 @@ export const GlobalChatHistorySheet: React.FC<GlobalChatHistorySheetProps> = ({
         <section aria-label={t('问答历史列表', 'Chat history list')} className="min-h-0 flex-1 overflow-y-auto pr-1">
           {isLoading ? (
             <p className="py-10 text-center text-sm text-muted-foreground" role="status">{t('正在加载历史…', 'Loading history…')}</p>
+          ) : loadError && visibleSessions.length === 0 ? (
+            <div className="flex min-h-28 flex-col items-center justify-center gap-3 rounded-md border border-destructive/40 px-4 text-center text-sm" role="alert">
+              <p className="text-destructive">{loadError}</p>
+              <Button type="button" variant="secondary" size="sm" onClick={() => void refresh()}>
+                {t('重试', 'Retry')}
+              </Button>
+            </div>
           ) : visibleSessions.length === 0 ? (
             <div className="flex min-h-28 flex-col items-center justify-center gap-2 rounded-md border border-dashed border-border px-4 text-center text-xs text-muted-foreground">
               <History className="h-5 w-5" aria-hidden="true" />
@@ -131,7 +148,16 @@ export const GlobalChatHistorySheet: React.FC<GlobalChatHistorySheetProps> = ({
                 : t('没有匹配的会话。', 'No matching conversations found.')}</p>
             </div>
           ) : (
-            <ul className="space-y-1">
+            <>
+              {loadError && (
+                <div className="mb-2 flex items-center justify-between gap-2 rounded-md border border-destructive/40 px-3 py-2 text-xs text-destructive" role="alert">
+                  <span>{loadError}</span>
+                  <Button type="button" variant="secondary" size="sm" className="h-7" onClick={() => void refresh()}>
+                    {t('重试', 'Retry')}
+                  </Button>
+                </div>
+              )}
+              <ul className="space-y-1">
               {visibleSessions.map((session) => {
                 const repository = repositoryById.get(session.repoId);
                 return (
@@ -167,7 +193,8 @@ export const GlobalChatHistorySheet: React.FC<GlobalChatHistorySheetProps> = ({
                   </li>
                 );
               })}
-            </ul>
+              </ul>
+            </>
           )}
         </section>
 

--- a/src/components/GlobalChatHistorySheet.tsx
+++ b/src/components/GlobalChatHistorySheet.tsx
@@ -1,0 +1,202 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { History, Search, Trash2 } from 'lucide-react';
+import type { Repository } from '../types';
+import type { RepositoryChatSession } from '../types/repositoryChat';
+import { useAppStore } from '../store/useAppStore';
+import { repositoryChatSessionRepository } from '../features/repository-chat/repositories/sessionRepository';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from './ui/sheet';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from './ui/alert-dialog';
+
+interface GlobalChatHistorySheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  repositories: Repository[];
+  onSelectSession: (repository: Repository, sessionId: string) => void;
+}
+
+const HISTORY_CHANGE_EVENT = 'gsm:global-chat-history-changed';
+
+export const GlobalChatHistorySheet: React.FC<GlobalChatHistorySheetProps> = ({
+  isOpen,
+  onClose,
+  repositories,
+  onSelectSession,
+}) => {
+  const language = useAppStore((state) => state.language);
+  const t = (zh: string, en: string) => language === 'zh' ? zh : en;
+  const [sessions, setSessions] = useState<RepositoryChatSession[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [query, setQuery] = useState('');
+  const [pendingDeletion, setPendingDeletion] = useState<RepositoryChatSession | null>(null);
+
+  const repositoryById = useMemo(() => {
+    const map = new Map<number, Repository>();
+    repositories.forEach((repository) => map.set(repository.id, repository));
+    return map;
+  }, [repositories]);
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      setSessions(await repositoryChatSessionRepository.listRecentSessions(50));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      setQuery('');
+      void refresh();
+    }
+  }, [isOpen, refresh]);
+
+  const handleDelete = useCallback(async (sessionId: string) => {
+    await repositoryChatSessionRepository.permanentlyDeleteSession(sessionId);
+    setSessions((previous) => previous.filter((session) => session.id !== sessionId));
+    window.dispatchEvent(new CustomEvent(HISTORY_CHANGE_EVENT));
+  }, []);
+
+  const visibleSessions = useMemo(() => {
+    const normalizedQuery = query.trim().toLocaleLowerCase();
+    if (!normalizedQuery) return sessions;
+    return sessions.filter((session) =>
+      session.title.toLocaleLowerCase().includes(normalizedQuery) ||
+      session.repoFullName.toLocaleLowerCase().includes(normalizedQuery),
+    );
+  }, [query, sessions]);
+
+  const formatTime = useCallback((value: string) => {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return value;
+    return date.toLocaleString(language === 'zh' ? 'zh-CN' : 'en-US', {
+      month: 'numeric',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  }, [language]);
+
+  return (
+    <Sheet open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <SheetContent
+        side="right"
+        className="w-[min(100vw-1rem,32rem)] sm:max-w-none"
+        closeLabel={t('关闭问答历史', 'Close chat history')}
+        onPointerDownOutside={(event) => {
+          event.preventDefault();
+          window.setTimeout(onClose, 0);
+        }}
+      >
+        <SheetHeader>
+          <SheetTitle className="flex items-center gap-2 text-base">
+            <History className="h-4 w-4 shrink-0" aria-hidden="true" />
+            {t('问答历史', 'Chat history')}
+          </SheetTitle>
+          <SheetDescription>
+            {t('汇总各仓库的问答会话，点击进入对应仓库继续对话。', 'Conversations across repositories. Select one to continue in its repository.')}
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-2.5 top-2.5 h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            className="h-8 pl-8 text-xs"
+            placeholder={t('搜索标题或仓库名', 'Search title or repository')}
+            aria-label={t('搜索问答历史', 'Search chat history')}
+          />
+        </div>
+
+        <section aria-label={t('问答历史列表', 'Chat history list')} className="min-h-0 flex-1 overflow-y-auto pr-1">
+          {isLoading ? (
+            <p className="py-10 text-center text-sm text-muted-foreground" role="status">{t('正在加载历史…', 'Loading history…')}</p>
+          ) : visibleSessions.length === 0 ? (
+            <div className="flex min-h-28 flex-col items-center justify-center gap-2 rounded-md border border-dashed border-border px-4 text-center text-xs text-muted-foreground">
+              <History className="h-5 w-5" aria-hidden="true" />
+              <p>{sessions.length === 0
+                ? t('还没有保存的问答会话。', 'No saved conversations yet.')
+                : t('没有匹配的会话。', 'No matching conversations found.')}</p>
+            </div>
+          ) : (
+            <ul className="space-y-1">
+              {visibleSessions.map((session) => {
+                const repository = repositoryById.get(session.repoId);
+                return (
+                  <li key={session.id} className="flex items-center gap-1 rounded-md border border-transparent hover:border-border">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      className="h-auto min-w-0 flex-1 items-center justify-start gap-2.5 px-2 py-2 text-left"
+                      onClick={() => {
+                        if (repository) onSelectSession(repository, session.id);
+                      }}
+                      disabled={!repository}
+                      title={repository ? t(`进入 ${session.repoFullName} 的会话`, `Open conversation in ${session.repoFullName}`) : t('对应仓库已不在列表中', 'The repository is no longer in the list')}
+                    >
+                      {repository && (
+                        <img src={repository.owner.avatar_url} alt="" className="h-7 w-7 shrink-0 rounded-md border border-border" />
+                      )}
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-sm font-medium text-foreground">{session.title}</span>
+                        <span className="block truncate text-xs text-muted-foreground">{session.repoFullName} · {formatTime(session.updatedAt)}</span>
+                      </span>
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="h-7 w-7 shrink-0 text-muted-foreground hover:text-destructive"
+                      onClick={() => setPendingDeletion(session)}
+                      aria-label={t(`删除会话：${session.title}`, `Delete conversation: ${session.title}`)}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                    </Button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </section>
+
+        <AlertDialog open={Boolean(pendingDeletion)} onOpenChange={(open) => !open && setPendingDeletion(null)}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>{t('删除此会话？', 'Delete this conversation?')}</AlertDialogTitle>
+              <AlertDialogDescription>
+                {t(
+                  '仅删除此设备/账户保存的对话与工具轨迹，不会影响 GitHub 仓库、Star、README 或既有向量索引。',
+                  'This only deletes the conversation and tool trace saved for this device/account. It does not affect the GitHub repository, stars, README, or existing vector index.',
+                )}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>{t('取消', 'Cancel')}</AlertDialogCancel>
+              <AlertDialogAction
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                onClick={() => {
+                  if (pendingDeletion) void handleDelete(pendingDeletion.id);
+                  setPendingDeletion(null);
+                }}
+              >
+                {t('删除会话', 'Delete conversation')}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </SheetContent>
+    </Sheet>
+  );
+};

--- a/src/components/RepositoryChatSheet.tsx
+++ b/src/components/RepositoryChatSheet.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { AlertCircle, ArrowDown, CheckCircle2, ChevronDown, ChevronRight, CircleDot, Copy, ExternalLink, Gauge, History, Loader2, MessageSquareText, Plus, RotateCcw, Send, Square } from 'lucide-react';
+import { AlertCircle, ArrowDown, ArrowLeft, CheckCircle2, ChevronDown, ChevronRight, CircleDot, Copy, ExternalLink, Gauge, History, Loader2, MessageSquareText, Plus, RotateCcw, Send, Square } from 'lucide-react';
 import type { Repository } from '../types';
 import type { RepositoryChatMessage, RepositoryChatTaskDepth, RepositoryChatToolEvent, ToolEvidence } from '../types/repositoryChat';
 import { TASK_DEPTH_PRESETS } from '../types/repositoryChat';
@@ -24,6 +24,10 @@ interface RepositoryChatSheetProps {
   onClose: () => void;
   onCloseAutoFocus?: () => void;
   repository: Repository;
+  /** 从全局问答历史进入时，直接选中该会话。 */
+  initialSessionId?: string | null;
+  /** 从全局问答历史进入时，返回历史列表。 */
+  onBack?: () => void;
 }
 
 const shortSha = (sha: string) => sha.slice(0, 7);
@@ -155,6 +159,8 @@ const RepositoryChatSheet: React.FC<RepositoryChatSheetProps> = ({
   onClose,
   onCloseAutoFocus,
   repository,
+  initialSessionId,
+  onBack,
 }) => {
   const { language, setCurrentView, repositoryChatSettings, setRepositoryChatSettings } = useAppStore(useShallow((state) => ({
     language: state.language,
@@ -244,6 +250,22 @@ const RepositoryChatSheet: React.FC<RepositoryChatSheetProps> = ({
     setShowHistory(false);
   };
 
+  // 从全局问答历史进入：会话列表就绪后直接选中目标会话。
+  const initialSessionAppliedRef = useRef<string | null>(null);
+  useEffect(() => {
+    initialSessionAppliedRef.current = null;
+  }, [repository.id]);
+  useEffect(() => {
+    if (!initialSessionId || initialSessionAppliedRef.current === initialSessionId || isLoading) return;
+    if (!sessions.some((session) => session.id === initialSessionId)) return;
+    if (activeSession?.id === initialSessionId) {
+      initialSessionAppliedRef.current = initialSessionId;
+      return;
+    }
+    initialSessionAppliedRef.current = initialSessionId;
+    void selectSession(initialSessionId);
+  }, [initialSessionId, sessions, isLoading, activeSession?.id, selectSession]);
+
   const navigateToAiSettings = () => {
     if (repository) {
       sessionStorage.setItem('gsm:repository-chat-return', JSON.stringify({ repoId: repository.id, draft }));
@@ -300,6 +322,20 @@ const RepositoryChatSheet: React.FC<RepositoryChatSheetProps> = ({
         }}
       >
         <SheetHeader>
+          {onBack && (
+            <div className="-mb-1">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-xs text-muted-foreground"
+                onClick={onBack}
+              >
+                <ArrowLeft className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
+                {t('返回历史', 'Back to history')}
+              </Button>
+            </div>
+          )}
           <div className="flex min-w-0 items-start gap-3">
             <img src={repository.owner.avatar_url} alt="" className="h-9 w-9 shrink-0 rounded-md border border-border" />
             <div className="min-w-0 flex-1">

--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -4,6 +4,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { Bot, ChevronDown, LayoutGrid, List, Pause, Play, SearchX, X } from 'lucide-react';
 import { RepositoryCard } from './RepositoryCard';
 import { SimilarViewBanner } from './SimilarViewBanner';
+import { GlobalChatHistorySheet } from './GlobalChatHistorySheet';
 import { BulkActionToolbar } from './BulkActionToolbar';
 import { BulkCategorizeModal } from './BulkCategorizeModal';
 import { BulkRestoreModal, RestoreConfig } from './BulkRestoreModal';
@@ -111,6 +112,9 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
   const [isExitingSelection, setIsExitingSelection] = useState(false);
   const [activeChatRepository, setActiveChatRepository] = useState<Repository | null>(null);
   const activeChatTriggerRef = useRef<HTMLElement | null>(null);
+  // 全局问答历史（S4 入口）：抽屉 + 从历史进入单仓会话的目标会话。
+  const [globalHistoryOpen, setGlobalHistoryOpen] = useState(false);
+  const [globalChatSessionId, setGlobalChatSessionId] = useState<string | null>(null);
 
   const allCategories = useMemo(
     () => getAllCategories(customCategories, language, hiddenDefaultCategoryIds, defaultCategoryOverrides),
@@ -400,7 +404,34 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
   const handleAskRepository = useCallback((repository: Repository) => {
     const trigger = document.activeElement;
     activeChatTriggerRef.current = trigger instanceof HTMLElement ? trigger : null;
+    setGlobalChatSessionId(null);
     setActiveChatRepository(repository);
+  }, []);
+
+  // S4 全局入口（SearchBar「问答历史」按钮）经窗口事件打开历史抽屉。
+  useEffect(() => {
+    const handleOpenGlobalHistory = () => setGlobalHistoryOpen(true);
+    window.addEventListener('gsm:open-global-chat-history', handleOpenGlobalHistory);
+    return () => window.removeEventListener('gsm:open-global-chat-history', handleOpenGlobalHistory);
+  }, []);
+
+  const handleSelectGlobalSession = useCallback((repository: Repository, sessionId: string) => {
+    const trigger = document.activeElement;
+    activeChatTriggerRef.current = trigger instanceof HTMLElement ? trigger : null;
+    setGlobalChatSessionId(sessionId);
+    setActiveChatRepository(repository);
+    setGlobalHistoryOpen(false);
+  }, []);
+
+  const handleCloseChat = useCallback(() => {
+    setActiveChatRepository(null);
+    setGlobalChatSessionId(null);
+  }, []);
+
+  const handleBackToGlobalHistory = useCallback(() => {
+    setActiveChatRepository(null);
+    setGlobalChatSessionId(null);
+    setGlobalHistoryOpen(true);
   }, []);
 
   const handleBulkAction = async (action: string, selectedRepositories: Repository[]) => {
@@ -469,12 +500,23 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
         <LazyRepositoryChatSheet
           isOpen
           repository={activeChatRepository}
-          onClose={() => setActiveChatRepository(null)}
+          initialSessionId={globalChatSessionId}
+          onBack={globalChatSessionId ? handleBackToGlobalHistory : undefined}
+          onClose={handleCloseChat}
           onCloseAutoFocus={() => activeChatTriggerRef.current?.focus()}
         />
       </React.Suspense>
     </ErrorBoundary>,
     document.body,
+  );
+
+  const globalHistorySheet = (
+    <GlobalChatHistorySheet
+      isOpen={globalHistoryOpen}
+      onClose={() => setGlobalHistoryOpen(false)}
+      repositories={repositories}
+      onSelectSession={handleSelectGlobalSession}
+    />
   );
 
   if (filteredRepositories.length === 0) {
@@ -527,6 +569,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
         )}
         </div>
         {chatPortal}
+        {globalHistorySheet}
       </>
     );
   }
@@ -765,6 +808,7 @@ export const RepositoryList: React.FC<RepositoryListProps> = ({
       />
 
       {chatPortal}
+      {globalHistorySheet}
     </div>
   );
 };

--- a/src/components/SearchBar.test.tsx
+++ b/src/components/SearchBar.test.tsx
@@ -288,4 +288,19 @@ describe('SearchBar', () => {
       vi.useRealTimers();
     }
   });
+
+  it('dispatches the global history open event from the 问答历史 button', () => {
+    currentState = createStoreState({});
+    mockUseAppStore.mockReturnValue(currentState as ReturnType<typeof useAppStore>);
+    const dispatchSpy = vi.fn();
+    window.addEventListener('gsm:open-global-chat-history', dispatchSpy);
+
+    try {
+      render(<SearchBar />);
+      fireEvent.click(screen.getByRole('button', { name: '问答历史' }));
+      expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      window.removeEventListener('gsm:open-global-chat-history', dispatchSpy);
+    }
+  });
 });

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -117,15 +117,18 @@ export const SearchBar: React.FC = () => {
   const [isComposing, setIsComposing] = useState(false);
   // S4 全局问答历史入口：徽标显示已保存会话数。
   const [globalHistoryCount, setGlobalHistoryCount] = useState(0);
+  // 重叠刷新只允许最新请求提交，避免旧数量覆盖新状态。
+  const globalHistoryRequestRef = useRef(0);
 
   useEffect(() => {
     let cancelled = false;
     const refreshGlobalHistoryCount = async () => {
+      const requestId = ++globalHistoryRequestRef.current;
       try {
         const sessions = await repositoryChatSessionRepository.listRecentSessions(100);
-        if (!cancelled) setGlobalHistoryCount(sessions.length);
+        if (!cancelled && requestId === globalHistoryRequestRef.current) setGlobalHistoryCount(sessions.length);
       } catch {
-        if (!cancelled) setGlobalHistoryCount(0);
+        if (!cancelled && requestId === globalHistoryRequestRef.current) setGlobalHistoryCount(0);
       }
     };
     void refreshGlobalHistoryCount();

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,6 +1,6 @@
 import { Input } from './ui/input';
 import React, { useState, useEffect, useRef, useMemo } from 'react';
-import { Search, X, SlidersHorizontal, CheckCircle, Bell, BellOff, Bot, Edit3, Lock, Unlock, AlertCircle, ChevronDown, RefreshCw, Clock, ArrowDown, ArrowUp } from 'lucide-react';
+import { Search, X, SlidersHorizontal, CheckCircle, Bell, BellOff, Bot, Edit3, Lock, Unlock, AlertCircle, ChevronDown, RefreshCw, Clock, ArrowDown, ArrowUp, History } from 'lucide-react';
 import { getPlatformDisplayName, getPlatformIcon } from './platformMeta';
 import { useAppStore, getAllCategories } from '../store/useAppStore';
 import { useShallow } from 'zustand/react/shallow';
@@ -8,6 +8,7 @@ import { useSearchShortcuts } from '../hooks/useSearchShortcuts';
 import { useSearchActions } from '../features/repositories/hooks/useSearchActions';
 import { useDialog } from '../hooks/useDialog';
 import { isRepoCustomized } from '../utils/repoUtils';
+import { repositoryChatSessionRepository } from '../features/repository-chat/repositories/sessionRepository';
 import { applyRepoFilters, performBasicTextSearch as basicTextSearch, sortRepositories } from '../utils/repoSearch';
 import { NO_LICENSE_SENTINEL, normalizeLicense } from '../utils/licenseFilter';
 import { NumberInput } from './ui/NumberInput';
@@ -114,6 +115,36 @@ export const SearchBar: React.FC = () => {
   const [availableLicenses, setAvailableLicenses] = useState<string[]>([]);
   const [isRealTimeSearch, setIsRealTimeSearch] = useState(false);
   const [isComposing, setIsComposing] = useState(false);
+  // S4 全局问答历史入口：徽标显示已保存会话数。
+  const [globalHistoryCount, setGlobalHistoryCount] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    const refreshGlobalHistoryCount = async () => {
+      try {
+        const sessions = await repositoryChatSessionRepository.listRecentSessions(100);
+        if (!cancelled) setGlobalHistoryCount(sessions.length);
+      } catch {
+        if (!cancelled) setGlobalHistoryCount(0);
+      }
+    };
+    void refreshGlobalHistoryCount();
+    // 删除会话时由历史抽屉广播；打开抽屉与窗口重获焦点时也刷新，
+    // 覆盖单仓问答内新建会话导致的计数过期。
+    window.addEventListener('gsm:global-chat-history-changed', refreshGlobalHistoryCount);
+    window.addEventListener('gsm:open-global-chat-history', refreshGlobalHistoryCount);
+    window.addEventListener('focus', refreshGlobalHistoryCount);
+    return () => {
+      cancelled = true;
+      window.removeEventListener('gsm:global-chat-history-changed', refreshGlobalHistoryCount);
+      window.removeEventListener('gsm:open-global-chat-history', refreshGlobalHistoryCount);
+      window.removeEventListener('focus', refreshGlobalHistoryCount);
+    };
+  }, []);
+
+  const openGlobalChatHistory = () => {
+    window.dispatchEvent(new CustomEvent('gsm:open-global-chat-history'));
+  };
   
   const allCategories = useMemo(() => 
     getAllCategories(customCategories, language, hiddenDefaultCategoryIds, defaultCategoryOverrides),
@@ -832,6 +863,23 @@ export const SearchBar: React.FC = () => {
             {activeFiltersCount > 0 && (
               <span className="bg-primary text-primary-foreground rounded-full px-2 py-0.5 text-xs">
                 {activeFiltersCount}
+              </span>
+            )}
+          </Button>
+
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={openGlobalChatHistory}
+            className="linear-filter-toggle flex items-center space-x-2 px-3 py-2 text-sm"
+            aria-label={t('问答历史', 'Chat history')}
+            title={t('查看各仓库的问答历史', 'View chat history across repositories')}
+          >
+            <History className="w-4 h-4" aria-hidden="true" />
+            <span>{t('问答历史', 'Chat history')}</span>
+            {globalHistoryCount > 0 && (
+              <span className="bg-primary text-primary-foreground rounded-full px-2 py-0.5 text-xs">
+                {globalHistoryCount > 99 ? '99+' : globalHistoryCount}
               </span>
             )}
           </Button>

--- a/src/features/repository-chat/hooks/useRepositoryChatSessions.test.ts
+++ b/src/features/repository-chat/hooks/useRepositoryChatSessions.test.ts
@@ -1,0 +1,70 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useRepositoryChatSessions } from './useRepositoryChatSessions';
+import type { Repository } from '../../../types';
+
+vi.mock('../../../store/useAppStore', () => ({
+  useAppStore: (selector: (state: { githubToken: string; repositoryChatSettings: { retainSessionDays: number } }) => unknown) =>
+    selector({ githubToken: 'test-token', repositoryChatSettings: { retainSessionDays: 90 } }),
+}));
+
+const repository = { id: 1, full_name: 'owner/repo-one' } as unknown as Repository;
+
+describe('useRepositoryChatSessions global history notification', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    Object.defineProperty(window, 'indexedDB', { configurable: true, value: undefined });
+  });
+
+  it('创建会话后派发全局历史刷新事件', async () => {
+    const dispatchSpy = vi.fn();
+    window.addEventListener('gsm:global-chat-history-changed', dispatchSpy);
+    try {
+      const { result } = renderHook(() =>
+        useRepositoryChatSessions({
+          repository,
+          language: 'zh',
+          resolveSourceRefSha: async () => 'abc123def456',
+        }),
+      );
+
+      let sessionId: string | null = null;
+      await act(async () => {
+        const session = await result.current.createSession();
+        sessionId = session?.id ?? null;
+      });
+
+      expect(sessionId).toBeTruthy();
+      expect(dispatchSpy).toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('gsm:global-chat-history-changed', dispatchSpy);
+    }
+  });
+
+  it('删除会话后派发全局历史刷新事件', async () => {
+    const dispatchSpy = vi.fn();
+    window.addEventListener('gsm:global-chat-history-changed', dispatchSpy);
+    try {
+      const { result } = renderHook(() =>
+        useRepositoryChatSessions({
+          repository,
+          language: 'zh',
+          resolveSourceRefSha: async () => 'abc123def456',
+        }),
+      );
+
+      let sessionId = '';
+      await act(async () => {
+        sessionId = (await result.current.createSession())?.id ?? '';
+      });
+      dispatchSpy.mockClear();
+
+      await act(async () => {
+        await result.current.deleteSession(sessionId);
+      });
+      expect(dispatchSpy).toHaveBeenCalled();
+    } finally {
+      window.removeEventListener('gsm:global-chat-history-changed', dispatchSpy);
+    }
+  });
+});

--- a/src/features/repository-chat/hooks/useRepositoryChatSessions.ts
+++ b/src/features/repository-chat/hooks/useRepositoryChatSessions.ts
@@ -128,13 +128,13 @@ export const useRepositoryChatSessions = ({
     setError(null);
     try {
       await repositoryChatSessionRepository.permanentlyDeleteSession(sessionId);
+      notifyGlobalHistoryChanged();
       if (operationId !== operationIdRef.current) return;
       const nextSessions = sessions.filter((session) => session.id !== sessionId);
       setSessions(nextSessions);
       const nextActive = activeSession?.id === sessionId ? (nextSessions[0] ?? null) : activeSession;
       setActiveSession(nextActive);
       await loadSessionMessages(nextActive, operationId);
-      notifyGlobalHistoryChanged();
     } catch (unknownError) {
       if (operationId === operationIdRef.current) setError(unknownError instanceof Error ? unknownError.message : 'Unable to delete the repository chat session');
     } finally {

--- a/src/features/repository-chat/hooks/useRepositoryChatSessions.ts
+++ b/src/features/repository-chat/hooks/useRepositoryChatSessions.ts
@@ -12,6 +12,13 @@ const createId = (): string => {
 
 const defaultTitle = (language: 'zh' | 'en') => language === 'zh' ? '新对话' : 'New conversation';
 
+/** 通知全局问答历史入口（SearchBar 徽标、历史抽屉）刷新。 */
+const notifyGlobalHistoryChanged = () => {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent('gsm:global-chat-history-changed'));
+  }
+};
+
 export interface UseRepositoryChatSessionsOptions {
   repository: Repository | null;
   language: 'zh' | 'en';
@@ -98,6 +105,7 @@ export const useRepositoryChatSessions = ({
       setSessions((previous) => [session, ...previous]);
       setActiveSession(session);
       setMessages([]);
+      notifyGlobalHistoryChanged();
       return session;
     } catch (unknownError) {
       if (operationId === operationIdRef.current) setError(unknownError instanceof Error ? unknownError.message : 'Unable to create a repository chat session');
@@ -126,6 +134,7 @@ export const useRepositoryChatSessions = ({
       const nextActive = activeSession?.id === sessionId ? (nextSessions[0] ?? null) : activeSession;
       setActiveSession(nextActive);
       await loadSessionMessages(nextActive, operationId);
+      notifyGlobalHistoryChanged();
     } catch (unknownError) {
       if (operationId === operationIdRef.current) setError(unknownError instanceof Error ? unknownError.message : 'Unable to delete the repository chat session');
     } finally {

--- a/src/features/repository-chat/repositories/sessionRepository.test.ts
+++ b/src/features/repository-chat/repositories/sessionRepository.test.ts
@@ -109,6 +109,28 @@ describe('repositoryChatSessionRepository local fallback', () => {
     await expect(repositoryChatSessionRepository.listEvidence([messageEvidence.id, toolEvidence.id])).resolves.toEqual([]);
   });
 
+  it('lists recent sessions across repositories in recency order with a limit', async () => {
+    await repositoryChatSessionRepository.saveSession(createSession('repo1-older', 1, '2026-08-24T00:00:00.000Z'));
+    await repositoryChatSessionRepository.saveSession(createSession('repo2-newer', 2, '2026-08-26T00:00:00.000Z'));
+    await repositoryChatSessionRepository.saveSession(createSession('repo1-middle', 1, '2026-08-25T00:00:00.000Z'));
+
+    await expect(repositoryChatSessionRepository.listRecentSessions(2)).resolves.toMatchObject([
+      { id: 'repo2-newer', repoId: 2 },
+      { id: 'repo1-middle', repoId: 1 },
+    ]);
+    await expect(repositoryChatSessionRepository.listRecentSessions()).resolves.toMatchObject([
+      { id: 'repo2-newer', repoId: 2 },
+      { id: 'repo1-middle', repoId: 1 },
+      { id: 'repo1-older', repoId: 1 },
+    ]);
+
+    await repositoryChatSessionRepository.softDeleteSession('repo2-newer');
+    await expect(repositoryChatSessionRepository.listRecentSessions()).resolves.toMatchObject([
+      { id: 'repo1-middle', repoId: 1 },
+      { id: 'repo1-older', repoId: 1 },
+    ]);
+  });
+
   it('rejects fallback writes when localStorage persistence is unavailable', async () => {
     // 直接把 window.localStorage 换成抛错桩：不同平台的 jsdom 对 Storage 原型/
     // 实例方法的实现有差异，逐方法 spy 在 CI（Linux）上不可靠。

--- a/src/features/repository-chat/repositories/sessionRepository.ts
+++ b/src/features/repository-chat/repositories/sessionRepository.ts
@@ -198,6 +198,28 @@ export const repositoryChatSessionRepository = {
     }
   },
 
+  async listRecentSessions(limit = 50): Promise<RepositoryChatSession[]> {
+    const count = Math.max(1, Math.floor(limit));
+    const fallback = () => readFallback().sessions
+      .filter((session) => !session.deletedAt)
+      .sort(byUpdatedAtDescending)
+      .slice(0, count);
+    if (useFallbackStorage || !canUseIndexedDb()) {
+      enableFallbackStorage();
+      return fallback();
+    }
+    try {
+      return await withTimeout(runTransaction('sessions', 'readonly', async (stores) => {
+        const records = await requestValue(stores.sessions.getAll()) as RepositoryChatSession[];
+        return records.filter((session) => !session.deletedAt).sort(byUpdatedAtDescending).slice(0, count);
+      }));
+    } catch (error) {
+      console.warn('[repository-chat] recent session list fell back to localStorage', error);
+      if (!await transitionToFallbackStorage()) throw error;
+      return fallback();
+    }
+  },
+
   async getSession(sessionId: string): Promise<RepositoryChatSession | null> {
     const fallback = () => readFallback().sessions.find((session) => session.id === sessionId) ?? null;
     if (useFallbackStorage || !canUseIndexedDb()) {


### PR DESCRIPTION
## 内容

- 仓库页搜索栏过滤器旁新增「问答历史」入口（S4 方案），带会话数徽标，顶栏零改动（#343）
- 新增全局历史抽屉：跨仓会话按更新时间倒序，支持搜索、删除，点击直达对应仓库会话
- 单仓会话支持指定进入 + 「返回历史」回退按钮
- .tmp-chat-entry-demos 选型 demo 已加入 .gitignore，不在提交范围

## 验证

- tsc -b 通过，eslint 干净
- 6 个测试文件 26 项通过（含新增抽屉 3 项、S4 按钮事件 1 项、listRecentSessions 1 项）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增全局问答历史入口，可集中查看不同仓库的最近会话。
  - 支持按标题或仓库名称筛选，并按更新时间倒序展示。
  - 可从历史会话直接返回对应仓库继续对话。
  - 加载失败时显示错误提示，并支持重试。

- **Bug 修复**
  - 修复并发刷新时旧数据覆盖最新结果的问题。
  - 会话创建或删除后，历史列表及数量徽标会及时更新。

- **测试**
  - 补充全局历史排序、筛选、删除、跳转及异常恢复测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->