### PR TITLE
fix(repoSearch): 修正按更新排序优先pushed_at

### DIFF
--- a/src/utils/repoSearch.test.ts
+++ b/src/utils/repoSearch.test.ts
@@ -95,14 +95,34 @@ describe('applyRepoFilters', () => {
     expect(hits.map((r) => r.id)).toEqual([1, 3, 2]);
   });
 
-  it('sorts recently updated repositories by GitHub updated_at rather than last pushed_at', () => {
+  it('sorts recently updated repositories by GitHub pushed_at (last code change)', () => {
     const repositories = [
-      makeRepo({ id: 10, name: 'older-update', full_name: 'acme/older-update', updated_at: '2026-01-01T00:00:00Z', pushed_at: '2026-06-01T00:00:00Z' }),
-      makeRepo({ id: 11, name: 'newer-update', full_name: 'acme/newer-update', updated_at: '2026-05-01T00:00:00Z', pushed_at: '2026-02-01T00:00:00Z' }),
+      makeRepo({ id: 10, name: 'older-push', full_name: 'acme/older-push', updated_at: '2026-05-01T00:00:00Z', pushed_at: '2026-01-01T00:00:00Z' }),
+      makeRepo({ id: 11, name: 'newer-push', full_name: 'acme/newer-push', updated_at: '2026-02-01T00:00:00Z', pushed_at: '2026-06-01T00:00:00Z' }),
     ];
 
     const hits = applyRepoFilters(repositories, { sortBy: 'updated', sortOrder: 'desc' });
     expect(hits.map((repository) => repository.id)).toEqual([11, 10]);
+  });
+
+  it('falls back to updated_at when pushed_at is missing', () => {
+    const repositories = [
+      makeRepo({ id: 20, name: 'no-push', full_name: 'acme/no-push', updated_at: '2026-06-01T00:00:00Z', pushed_at: '' }),
+      makeRepo({ id: 21, name: 'has-push', full_name: 'acme/has-push', updated_at: '2026-01-01T00:00:00Z', pushed_at: '2026-02-01T00:00:00Z' }),
+    ];
+
+    const hits = applyRepoFilters(repositories, { sortBy: 'updated', sortOrder: 'desc' });
+    expect(hits.map((repository) => repository.id)).toEqual([20, 21]);
+  });
+
+  it('falls back to updated_at when pushed_at is invalid', () => {
+    const repositories = [
+      makeRepo({ id: 30, name: 'bad-push', full_name: 'acme/bad-push', updated_at: '2026-06-01T00:00:00Z', pushed_at: 'not-a-date' }),
+      makeRepo({ id: 31, name: 'has-push', full_name: 'acme/has-push', updated_at: '2026-01-01T00:00:00Z', pushed_at: '2026-02-01T00:00:00Z' }),
+    ];
+
+    const hits = applyRepoFilters(repositories, { sortBy: 'updated', sortOrder: 'desc' });
+    expect(hits.map((repository) => repository.id)).toEqual([30, 31]);
   });
 
   it('filters by SPDX id license', () => {

--- a/src/utils/repoSearch.ts
+++ b/src/utils/repoSearch.ts
@@ -42,6 +42,16 @@ const toSortableTimestamp = (value?: string): number => {
   return Number.isFinite(timestamp) ? timestamp : 0;
 };
 
+/**
+ * “按更新排序”按最近代码变更排序：优先用 pushed_at（缺失/非法时回退 updated_at），
+ * 与仓库卡片“最近提交”及搜索统计近期更新口径保持一致（#45，#342）。
+ */
+const toUpdatedSortValue = (repo: Repository): number => {
+  const pushed = toSortableTimestamp(repo.pushed_at);
+  if (pushed > 0) return pushed;
+  return toSortableTimestamp(repo.updated_at);
+};
+
 function getSortValue(repo: Repository, sortBy: SearchFilters['sortBy']): number | string {
   switch (sortBy) {
     case 'stars': {
@@ -49,15 +59,14 @@ function getSortValue(repo: Repository, sortBy: SearchFilters['sortBy']): number
       return Number.isFinite(stars) ? stars : 0;
     }
     case 'updated':
-      // The control is labelled “recently updated”, so use GitHub's updated_at
-      // rather than pushed_at (which drives the separate “last pushed” card label).
-      return toSortableTimestamp(repo.updated_at || repo.pushed_at);
+      // “按更新排序”按最近代码变更（push）排序，用 GitHub 的 pushed_at。
+      return toUpdatedSortValue(repo);
     case 'name':
       return repo.name.toLocaleLowerCase();
     case 'starred':
       return toSortableTimestamp(repo.starred_at);
     default:
-      return toSortableTimestamp(repo.updated_at || repo.pushed_at);
+      return toUpdatedSortValue(repo);
   }
 }
 

--- a/src/utils/repoSearch.ts
+++ b/src/utils/repoSearch.ts
@@ -43,8 +43,14 @@ const toSortableTimestamp = (value?: string): number => {
 };
 
 /**
- * “按更新排序”按最近代码变更排序：优先用 pushed_at（缺失/非法时回退 updated_at），
- * 与仓库卡片“最近提交”及搜索统计近期更新口径保持一致（#45，#342）。
+ * Resolve the sort key for "recently updated" ordering.
+ *
+ * Prefers `pushed_at` (last code push) and falls back to `updated_at` when
+ * `pushed_at` is missing or unparsable, keeping list sorting consistent with
+ * the card "Last pushed" label and stats (#45, #342).
+ *
+ * @param repo Repository to score.
+ * @returns Milliseconds since epoch, or 0 when neither timestamp parses.
  */
 const toUpdatedSortValue = (repo: Repository): number => {
   const pushed = toSortableTimestamp(repo.pushed_at);
@@ -52,6 +58,13 @@ const toUpdatedSortValue = (repo: Repository): number => {
   return toSortableTimestamp(repo.updated_at);
 };
 
+/**
+ * Resolve the comparable sort value for a repository.
+ *
+ * @param repo Repository to score.
+ * @param sortBy Active sort mode; `updated`/default prefer last push time.
+ * @returns Numeric timestamp, star count, or lowercase name for comparison.
+ */
 function getSortValue(repo: Repository, sortBy: SearchFilters['sortBy']): number | string {
   switch (sortBy) {
     case 'stars': {


### PR DESCRIPTION
复活 #342 首 commit 3c6d452（sche11），丢弃该 PR 后续无关的 server/Vercel 变更（6dfa5fc/b747c09）。

## 背景
- #45 已定语义：卡片“最近提交”与统计近期更新均用 `pushed_at || updated_at`。
- 251984a 把 `repoSearch.ts` 的 `case updated` 翻转为 `updated_at || pushed_at`，导致列表排序与展示口径不一致。
- 3c6d452 改回 `pushed_at` 优先，方向正确。

## 本 PR 内容（仅 2 文件）
- `src/utils/repoSearch.ts`：`case updated` 与 `default` 改用 `toUpdatedSortValue`（优先 pushed_at，缺失/非法回退 updated_at）。比原 3c6d452 多处理了 `pushed_at` 为 truthy 非法字符串时 `||` 失效直接得 0 的问题。
- `src/utils/repoSearch.test.ts`：改回 pushed_at 胜出断言；补 CodeRabbit 在 #342 首 commit 上的意见：pushed_at 缺失/非法时回退 updated_at 用例。

## 验证
- `npx vitest run src/utils/repoSearch.test.ts`：14 passed
- `npx tsc --noEmit`：通过

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **错误修复**
  - 优化仓库“更新时间”排序：优先按最近代码推送时间排序。
  - 当推送时间缺失或无效时，自动回退使用仓库更新时间，提升排序结果的稳定性与准确性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->