### PR TITLE
fix(theme): 文字选中态不可见 — 派生 selection/search-highlight token

### DIFF
--- a/scripts/generate-theme-presets.mjs
+++ b/scripts/generate-theme-presets.mjs
@@ -150,6 +150,143 @@ function deriveBorderStrong(triplet, isLightMode) {
   return fmtTriplet({ ...triplet, l });
 }
 
+// ---------- text selection & search highlight derivation ----------
+//
+// The vendored palettes ship selection-hostile accents: zen-inspired light
+// accent (52 23.1% 87.3%) is nearly identical to its card (41.2 42.2% 92.5%),
+// so ::selection rendered invisible (issue #348), and no single palette token
+// is safe everywhere — accent collides with card, while primary/ring can sit
+// mid-tone or near the foreground depending on the preset. Selection and
+// search-highlight are therefore derived per mode into a mid-tone band with
+// two enforced invariants: visible against every surface text can sit on, and
+// body text stays readable on top.
+
+/** Every surface selected or highlighted text can render over. */
+function textSurfaces(t) {
+  return [t.background, t.card, t.popover, t.secondary, t.muted];
+}
+
+/**
+ * Smallest WCAG contrast between a candidate fill and a set of surfaces.
+ *
+ * @param {{ h: number, s: number, l: number }} triplet Candidate fill triplet.
+ * @param {Array<{ h: number, s: number, l: number }>} surfaces Surface triplets.
+ * @returns {number} Minimum contrast ratio across the surfaces.
+ */
+function minSurfaceContrast(triplet, surfaces) {
+  return Math.min(...surfaces.map((surface) => contrastTriplets(triplet, surface)));
+}
+
+/**
+ * Pick the hue source for derived text marks: primary, falling back to
+ * ring/accent when primary is neutral so colorful themes keep their identity
+ * while truly monochrome ones stay achromatic instead of inventing a hue.
+ *
+ * @param {Record<string, { h: number, s: number, l: number }>} t Normalized palette triplets.
+ * @returns {{ h: number, s: number, l: number }} Hue source triplet.
+ */
+function selectionHueSource(t) {
+  if (t.primary.s >= 8) return t.primary;
+  return [t.ring, t.accent].find((candidate) => candidate.s >= 14) ?? t.primary;
+}
+
+/**
+ * Derive the ::selection fill plus its foreground for one palette mode.
+ *
+ * Lightness starts from a mid-tone "highlighter" band and sweeps in both
+ * directions until the fill clears every text surface while the body
+ * foreground stays readable on top; the nearest passing candidate wins so each
+ * preset keeps its own character. Both targets carry a small guard margin so
+ * the one-decimal output rounding cannot land below the audited 1.5/4.5
+ * invariants. When no lightness satisfies both (e.g. dark text over dark
+ * fills), ensureTextOnFill flips the selection foreground toward white/black
+ * instead.
+ *
+ * @param {Record<string, { h: number, s: number, l: number }>} t Normalized palette triplets.
+ * @returns {{ selection: { h: number, s: number, l: number }, selectionForeground: { h: number, s: number, l: number } }} Derived triplets.
+ */
+function deriveSelection(t) {
+  const surfaces = textSurfaces(t);
+  const isLight = relativeLuminance(hslTripletToRgb(t.background)) > 0.35;
+  const hueSource = selectionHueSource(t);
+  const saturation = hueSource.s < 8
+    ? 0
+    : Math.min(62, Math.max(isLight ? 42 : 36, hueSource.s));
+  const [bandLow, bandHigh] = isLight ? [55, 68] : [26, 40];
+  const base = {
+    h: hueSource.h,
+    s: saturation,
+    l: Math.min(bandHigh, Math.max(bandLow, hueSource.l)),
+  };
+  const passes = (candidate) =>
+    minSurfaceContrast(candidate, surfaces) >= 1.55
+    && contrastTriplets(t.foreground, candidate) >= 4.6;
+
+  let selection = base;
+  if (!passes(base)) {
+    let best = base;
+    let bestScore = -1;
+    search: for (let d = 0.5; d <= 40; d += 0.5) {
+      for (const dir of [1, -1]) {
+        const candidate = shiftL(base, dir * d);
+        if (passes(candidate)) {
+          selection = candidate;
+          break search;
+        }
+        const score = minSurfaceContrast(candidate, surfaces)
+          + contrastTriplets(t.foreground, candidate);
+        if (score > bestScore) {
+          bestScore = score;
+          best = candidate;
+        }
+      }
+    }
+    selection = passes(selection) ? selection : best;
+  }
+
+  const pair = ensureTextOnFill(t.foreground, selection, 4.5);
+  return { selection: pair.fill, selectionForeground: pair.fg };
+}
+
+/**
+ * Derive the search-result highlight for one palette mode: the selection hue
+ * pulled halfway toward the closest surface it renders on, so hits stay
+ * visible without competing with an active text selection. Only card,
+ * popover, and canvas count as surfaces — the highlight class is used inside
+ * repository cards, never on chip/secondary fills whose vendored colors can
+ * be extreme outliers (claude dark ships a near-white secondary). Lightness
+ * is swept until the fill clears card and canvas with readable text on top;
+ * targets carry a guard margin over the audited 1.25/4.5 invariants.
+ *
+ * @param {Record<string, { h: number, s: number, l: number }>} t Normalized palette triplets.
+ * @param {{ h: number, s: number, l: number }} selection Derived selection fill.
+ * @returns {{ h: number, s: number, l: number }} Highlight fill triplet.
+ */
+function deriveSearchHighlight(t, selection) {
+  const surfaces = [t.card, t.popover, t.background];
+  const isLight = relativeLuminance(hslTripletToRgb(t.background)) > 0.35;
+  const surfaceL = (isLight ? Math.min : Math.max)(...surfaces.map((surface) => surface.l));
+  const edge = isLight ? surfaceL - 8 : surfaceL + 8;
+  const base = {
+    h: selection.h,
+    s: round(selection.s * 0.6, 1),
+    l: round(selection.l + (edge - selection.l) / 2, 1),
+  };
+  const passes = (candidate) =>
+    contrastTriplets(candidate, t.card) >= 1.3
+    && contrastTriplets(candidate, t.background) >= 1.3
+    && contrastTriplets(t.foreground, candidate) >= 4.6;
+
+  if (passes(base)) return base;
+  for (let d = 0.5; d <= 40; d += 0.5) {
+    for (const dir of isLight ? [-1, 1] : [1, -1]) {
+      const candidate = shiftL(base, dir * d);
+      if (passes(candidate)) return candidate;
+    }
+  }
+  return base;
+}
+
 // ---------- accessibility & surface normalization ----------
 //
 // Vendored tweakcn palettes predate this app's token usage: several fail WCAG
@@ -439,6 +576,15 @@ const presets = Object.entries(source.presets).map(([id, preset]) => {
   lightColors['border-strong'] = deriveBorderStrong(lightTriplets.border, true);
   darkColors['border-strong'] = deriveBorderStrong(darkTriplets.border, false);
 
+  const lightSelection = deriveSelection(normalizedLight);
+  const darkSelection = deriveSelection(normalizedDark);
+  lightColors['selection'] = fmtTriplet(lightSelection.selection);
+  lightColors['selection-foreground'] = fmtTriplet(lightSelection.selectionForeground);
+  lightColors['search-highlight'] = fmtTriplet(deriveSearchHighlight(normalizedLight, lightSelection.selection));
+  darkColors['selection'] = fmtTriplet(darkSelection.selection);
+  darkColors['selection-foreground'] = fmtTriplet(darkSelection.selectionForeground);
+  darkColors['search-highlight'] = fmtTriplet(deriveSearchHighlight(normalizedDark, darkSelection.selection));
+
   const shadow = composeShadow(lightStyles);
 
   return {
@@ -485,6 +631,9 @@ export interface GeneratedThemePalette {
   'border-strong': string;
   input: string;
   ring: string;
+  selection: string;
+  'selection-foreground': string;
+  'search-highlight': string;
 }
 
 export interface GeneratedThemePreset {

--- a/src/constants/themePresets.generated.ts
+++ b/src/constants/themePresets.generated.ts
@@ -25,6 +25,9 @@ export interface GeneratedThemePalette {
   'border-strong': string;
   input: string;
   ring: string;
+  selection: string;
+  'selection-foreground': string;
+  'search-highlight': string;
 }
 
 export interface GeneratedThemePreset {
@@ -70,7 +73,10 @@ export const GENERATED_THEME_PRESETS: GeneratedThemePreset[] = [
       "border": "240 17.1% 92%",
       "input": "0 0% 92.2%",
       "ring": "15.4 90.6% 49.8%",
-      "border-strong": "240 17.1% 81%"
+      "border-strong": "240 17.1% 81%",
+      "selection": "15.4 62% 55%",
+      "selection-foreground": "0 0% 0%",
+      "search-highlight": "15.4 37.2% 72.4%"
     },
     "darkColors": {
       "background": "0 0% 3.9%",
@@ -92,7 +98,10 @@ export const GENERATED_THEME_PRESETS: GeneratedThemePreset[] = [
       "border": "0 0% 12.2%",
       "input": "0 0% 23.1%",
       "ring": "15.4 90.6% 49.8%",
-      "border-strong": "0 0% 23.2%"
+      "border-strong": "0 0% 23.2%",
+      "selection": "15.4 62% 32%",
+      "selection-foreground": "0 0% 94.1%",
+      "search-highlight": "15.4 37.2% 25%"
     },
     "shadowColor": "0 0% 0%",
     "shadowOpacity": 0.1,
@@ -122,7 +131,10 @@ export const GENERATED_THEME_PRESETS: GeneratedThemePreset[] = [
       "border": "50 7.5% 84.3%",
       "input": "50.8 8% 68%",
       "ring": "15.1 55.6% 52.4%",
-      "border-strong": "50 7.5% 73.3%"
+      "border-strong": "50 7.5% 73.3%",
+      "selection": "15.1 55.6% 67%",
+      "selection-foreground": "48 19.6% 20%",
+      "search-highlight": "15.1 33.3% 77.3%"
     },
     "darkColors": {
       "background": "60 2.7% 14.5%",
@@ -144,7 +156,10 @@ export const GENERATED_THEME_PRESETS: GeneratedThemePreset[] = [
       "border": "60 5.1% 23.1%",
       "input": "52.5 5.1% 30.6%",
       "ring": "14.8 63.1% 59.6%",
-      "border-strong": "60 5.1% 34.1%"
+      "border-strong": "60 5.1% 34.1%",
+      "selection": "14.8 62% 31%",
+      "selection-foreground": "46.2 9.8% 73.9%",
+      "search-highlight": "14.8 37.2% 28.7%"
     },
     "shadowColor": "0 0% 0%",
     "shadowOpacity": 0.1,
@@ -177,7 +192,10 @@ export const GENERATED_THEME_PRESETS: GeneratedThemePreset[] = [
       "border": "220 13.1% 91%",
       "input": "220 13.1% 91%",
       "ring": "263 70% 50%",
-      "border-strong": "220 13.1% 80%"
+      "border-strong": "220 13.1% 80%",
+      "selection": "263 62% 61.5%",
+      "selection-foreground": "224 71.1% 4%",
+      "search-highlight": "263 37.2% 75.7%"
     },
     "darkColors": {
       "background": "260 25% 2%",
@@ -199,7 +217,10 @@ export const GENERATED_THEME_PRESETS: GeneratedThemePreset[] = [
       "border": "260 20% 15%",
       "input": "260 20% 15%",
       "ring": "263 85% 65%",
-      "border-strong": "260 20% 26%"
+      "border-strong": "260 20% 26%",
+      "selection": "263 62% 40%",
+      "selection-foreground": "210 40.1% 98%",
+      "search-highlight": "263 37.2% 26.5%"
     },
     "shadowColor": "263 70% 50%",
     "shadowOpacity": 0.08,
@@ -232,7 +253,10 @@ export const GENERATED_THEME_PRESETS: GeneratedThemePreset[] = [
       "border": "240 26.1% 91%",
       "input": "240 26.1% 91%",
       "ring": "219.2 99.2% 52.7%",
-      "border-strong": "240 26.1% 80%"
+      "border-strong": "240 26.1% 80%",
+      "selection": "219.2 62% 56%",
+      "selection-foreground": "240 16.2% 6.1%",
+      "search-highlight": "219.2 37.2% 73.8%"
     },
     "darkColors": {
       "background": "240 9.1% 4.3%",
@@ -254,7 +278,10 @@ export const GENERATED_THEME_PRESETS: GeneratedThemePreset[] = [
       "border": "240 11.6% 18.6%",
       "input": "240 11.6% 18.6%",
       "ring": "251.4 100% 72.2%",
-      "border-strong": "240 11.6% 29.6%"
+      "border-strong": "240 11.6% 29.6%",
+      "selection": "251.4 62% 40%",
+      "selection-foreground": "240 40.2% 98%",
+      "search-highlight": "251.4 37.2% 27.9%"
     },
     "shadowColor": "0 0% 0%",
     "shadowOpacity": 0.15,
@@ -287,7 +314,10 @@ export const GENERATED_THEME_PRESETS: GeneratedThemePreset[] = [
       "border": "214.3 31.8% 91.4%",
       "input": "214.3 31.8% 91.4%",
       "ring": "82.5 88.3% 32.3%",
-      "border-strong": "214.3 31.8% 80.4%"
+      "border-strong": "214.3 31.8% 80.4%",
+      "selection": "82.5 62% 57.8%",
+      "selection-foreground": "222.2 47.3% 11.2%",
+      "search-highlight": "82.5 37.2% 73.9%"
     },
     "darkColors": {
       "background": "228.6 84% 4.9%",
@@ -309,7 +339,10 @@ export const GENERATED_THEME_PRESETS: GeneratedThemePreset[] = [
       "border": "217.2 32.5% 17.4%",
       "input": "217.2 32.5% 17.4%",
       "ring": "82.5 88.3% 59.8%",
-      "border-strong": "217.2 32.5% 28.4%"
+      "border-strong": "217.2 32.5% 28.4%",
+      "selection": "82.5 62% 30%",
+      "selection-foreground": "210 40% 98%",
+      "search-highlight": "82.5 37.2% 24.6%"
     },
     "shadowColor": "0 0% 0%",
     "shadowOpacity": 0.05,
@@ -342,7 +375,10 @@ export const GENERATED_THEME_PRESETS: GeneratedThemePreset[] = [
       "border": "0 0% 89%",
       "input": "0 0% 100%",
       "ring": "223.3 51% 40%",
-      "border-strong": "0 0% 78%"
+      "border-strong": "0 0% 78%",
+      "selection": "223.4 62% 56.5%",
+      "selection-foreground": "0 0% 0.4%",
+      "search-highlight": "223.4 37.2% 72.7%"
     },
     "darkColors": {
       "background": "0 0% 2%",
@@ -364,7 +400,10 @@ export const GENERATED_THEME_PRESETS: GeneratedThemePreset[] = [
       "border": "0 0% 15.7%",
       "input": "0 0% 7.1%",
       "ring": "220.9 58.5% 63.1%",
-      "border-strong": "0 0% 26.7%"
+      "border-strong": "0 0% 26.7%",
+      "selection": "220.9 58.5% 40%",
+      "selection-foreground": "0 0% 98%",
+      "search-highlight": "220.9 35.1% 28.5%"
     },
     "shadowColor": "225.5 35.8% 15.9%",
     "shadowOpacity": 0.05,
@@ -397,7 +436,10 @@ export const GENERATED_THEME_PRESETS: GeneratedThemePreset[] = [
       "border": "0 0% 89.8%",
       "input": "45 14.6% 83.9%",
       "ring": "45.1 90.2% 36%",
-      "border-strong": "0 0% 78.8%"
+      "border-strong": "0 0% 78.8%",
+      "selection": "45.1 62% 55%",
+      "selection-foreground": "0 0% 10.2%",
+      "search-highlight": "45.1 37.2% 73%"
     },
     "darkColors": {
       "background": "0 0% 3.9%",
@@ -419,7 +461,10 @@ export const GENERATED_THEME_PRESETS: GeneratedThemePreset[] = [
       "border": "0 0% 12.9%",
       "input": "0 0% 22%",
       "ring": "45.1 90.2% 52%",
-      "border-strong": "0 0% 23.9%"
+      "border-strong": "0 0% 23.9%",
+      "selection": "45.1 62% 30.5%",
+      "selection-foreground": "0 0% 92.2%",
+      "search-highlight": "45.1 37.2% 24.3%"
     },
     "shadowColor": "0 0% 0%",
     "shadowOpacity": 0.01,
@@ -449,7 +494,10 @@ export const GENERATED_THEME_PRESETS: GeneratedThemePreset[] = [
       "border": "304.8 61% 83.9%",
       "input": "317.4 44.2% 83.1%",
       "ring": "333.3 71.4% 50.6%",
-      "border-strong": "304.8 61% 72.9%"
+      "border-strong": "304.8 61% 72.9%",
+      "selection": "333.3 43% 66%",
+      "selection-foreground": "296 55.6% 21.2%",
+      "search-highlight": "333.3 25.8% 76.8%"
     },
     "darkColors": {
       "background": "270 14.7% 7.8%",
@@ -471,7 +519,10 @@ export const GENERATED_THEME_PRESETS: GeneratedThemePreset[] = [
       "border": "326.7 8.3% 21.4%",
       "input": "312 8.8% 22.4%",
       "ring": "333.3 71.4% 50.6%",
-      "border-strong": "326.7 8.3% 32.4%"
+      "border-strong": "326.7 8.3% 32.4%",
+      "selection": "332 62% 34.5%",
+      "selection-foreground": "272.3 28.3% 82%",
+      "search-highlight": "332 37.2% 29.9%"
     },
     "shadowColor": "0 0% 0%",
     "shadowOpacity": 0.1,
@@ -504,7 +555,10 @@ export const GENERATED_THEME_PRESETS: GeneratedThemePreset[] = [
       "border": "0 0% 89.6%",
       "input": "0 0% 92.1%",
       "ring": "0 0% 0%",
-      "border-strong": "0 0% 78.6%"
+      "border-strong": "0 0% 78.6%",
+      "selection": "0 0% 55%",
+      "selection-foreground": "0 0% 0%",
+      "search-highlight": "0 0% 72.8%"
     },
     "darkColors": {
       "background": "0 0% 0%",
@@ -526,7 +580,10 @@ export const GENERATED_THEME_PRESETS: GeneratedThemePreset[] = [
       "border": "0 0% 14.1%",
       "input": "0 0% 19.9%",
       "ring": "0 0% 64.5%",
-      "border-strong": "0 0% 25.1%"
+      "border-strong": "0 0% 25.1%",
+      "selection": "0 0% 40%",
+      "selection-foreground": "0 0% 100%",
+      "search-highlight": "0 0% 27.4%"
     },
     "shadowColor": "0 0% 0%",
     "shadowOpacity": 0.18,
@@ -559,7 +616,10 @@ export const GENERATED_THEME_PRESETS: GeneratedThemePreset[] = [
       "border": "200 15.8% 92.5%",
       "input": "200 15.8% 92.5%",
       "ring": "142.4 70.2% 36.6%",
-      "border-strong": "200 15.8% 81.5%"
+      "border-strong": "200 15.8% 81.5%",
+      "selection": "173.1 62% 55%",
+      "selection-foreground": "202.5 32% 9.8%",
+      "search-highlight": "173.1 37.2% 71.1%"
     },
     "darkColors": {
       "background": "204 40.5% 7.3%",
@@ -581,7 +641,10 @@ export const GENERATED_THEME_PRESETS: GeneratedThemePreset[] = [
       "border": "202.5 22.2% 21.2%",
       "input": "202.5 22.2% 21.2%",
       "ring": "167.1 100% 32.9%",
-      "border-strong": "202.5 22.2% 32.2%"
+      "border-strong": "202.5 22.2% 32.2%",
+      "selection": "167.1 62% 28.4%",
+      "selection-foreground": "200 15.8% 92.5%",
+      "search-highlight": "167.1 37.2% 26.4%"
     },
     "shadowColor": "0 0% 0%",
     "shadowOpacity": 0.1,
@@ -614,7 +677,10 @@ export const GENERATED_THEME_PRESETS: GeneratedThemePreset[] = [
       "border": "41.7 20.3% 77.9%",
       "input": "41.7 20.3% 77.9%",
       "ring": "0 0% 18%",
-      "border-strong": "41.7 20.3% 66.9%"
+      "border-strong": "41.7 20.3% 66.9%",
+      "selection": "52 42% 48.5%",
+      "selection-foreground": "0 0% 11.8%",
+      "search-highlight": "52 25.2% 64.3%"
     },
     "darkColors": {
       "background": "0 0% 7.8%",
@@ -636,7 +702,10 @@ export const GENERATED_THEME_PRESETS: GeneratedThemePreset[] = [
       "border": "0 0% 17.3%",
       "input": "0 0% 17.3%",
       "ring": "52.9 15.6% 78.6%",
-      "border-strong": "0 0% 28.3%"
+      "border-strong": "0 0% 28.3%",
+      "selection": "52.9 36% 31%",
+      "selection-foreground": "38.6 23.4% 88.2%",
+      "search-highlight": "52.9 21.6% 25%"
     },
     "shadowColor": "0 0% 0%",
     "shadowOpacity": 0.1,

--- a/src/constants/themePresets.test.ts
+++ b/src/constants/themePresets.test.ts
@@ -30,7 +30,41 @@ const PALETTE_KEYS = [
   'border-strong',
   'input',
   'ring',
+  'selection',
+  'selection-foreground',
+  'search-highlight',
 ] as const;
+
+/** HSL triplet ("H S% L%") to sRGB channels in [0, 255]. */
+function tripletToRgb(triplet: string): [number, number, number] {
+  const [h, s, l] = triplet.split(/\s+/).map((part) => Number.parseFloat(part) / (part.includes('%') ? 100 : 360));
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const hue = h * 360;
+  const x = c * (1 - Math.abs(((hue / 60) % 2) - 1));
+  const m = l - c / 2;
+  const rgb: [number, number, number] =
+    hue < 60 ? [c, x, 0]
+    : hue < 120 ? [x, c, 0]
+    : hue < 180 ? [0, c, x]
+    : hue < 240 ? [0, x, c]
+    : hue < 300 ? [x, 0, c]
+    : [c, 0, x];
+  return rgb.map((channel) => (channel + m) * 255) as [number, number, number];
+}
+
+/** WCAG 2.1 relative luminance of an sRGB color. */
+function relativeLuminance(rgb: [number, number, number]): number {
+  const [r, g, b] = rgb.map((channel) => {
+    const v = channel / 255;
+    return v <= 0.04045 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrast(a: string, b: string): number {
+  const [l1, l2] = [relativeLuminance(tripletToRgb(a)), relativeLuminance(tripletToRgb(b))].sort((x, y) => y - x);
+  return (l1 + 0.05) / (l2 + 0.05);
+}
 
 describe('themePresets registry', () => {
   it('starts with the default preset and contains the generated presets', () => {
@@ -63,6 +97,50 @@ describe('themePresets registry', () => {
     expect(isThemePresetId(DEFAULT_THEME_PRESET_ID)).toBe(true);
     expect(isThemePresetId('does-not-exist')).toBe(false);
     expect(isThemePresetId(42)).toBe(false);
+  });
+
+  it('derives selection fills visible on every text surface with readable text on top', () => {
+    // Guards issue #348: zen-inspired light shipped accent ≈ card, rendering
+    // ::selection invisible. The generated fills must keep clearing these
+    // invariants for every preset and mode.
+    const surfaces = ['background', 'card', 'popover', 'secondary', 'muted'] as const;
+    for (const preset of THEME_PRESETS) {
+      for (const [mode, palette] of [
+        ['light', preset.lightColors],
+        ['dark', preset.darkColors],
+      ] as const) {
+        for (const surface of surfaces) {
+          expect(
+            contrast(palette.selection, palette[surface]),
+            `${preset.id}/${mode}: selection vs ${surface}`,
+          ).toBeGreaterThanOrEqual(1.5);
+        }
+        expect(
+          contrast(palette['selection-foreground'], palette.selection),
+          `${preset.id}/${mode}: text on selection`,
+        ).toBeGreaterThanOrEqual(4.5);
+      }
+    }
+  });
+
+  it('derives search highlights visible on card and canvas with readable text', () => {
+    for (const preset of THEME_PRESETS) {
+      for (const [mode, palette] of [
+        ['light', preset.lightColors],
+        ['dark', preset.darkColors],
+      ] as const) {
+        for (const surface of ['card', 'background'] as const) {
+          expect(
+            contrast(palette['search-highlight'], palette[surface]),
+            `${preset.id}/${mode}: highlight vs ${surface}`,
+          ).toBeGreaterThanOrEqual(1.25);
+        }
+        expect(
+          contrast(palette.foreground, palette['search-highlight']),
+          `${preset.id}/${mode}: text on highlight`,
+        ).toBeGreaterThanOrEqual(4.5);
+      }
+    }
   });
 
   it('falls back to the default preset in getThemePreset', () => {

--- a/src/constants/themePresets.ts
+++ b/src/constants/themePresets.ts
@@ -66,6 +66,9 @@ const DEFAULT_LIGHT_COLORS: GeneratedThemePalette = {
   'border-strong': '214.3 25% 80%',
   input: '214.3 31.8% 91.4%',
   ring: '222.2 84% 4.9%',
+  selection: '222.2 47.4% 55.5%',
+  'selection-foreground': '222.2 84% 4.9%',
+  'search-highlight': '222.2 28.4% 72.8%',
 };
 
 const DEFAULT_DARK_COLORS: GeneratedThemePalette = {
@@ -89,6 +92,9 @@ const DEFAULT_DARK_COLORS: GeneratedThemePalette = {
   'border-strong': '217.2 32.6% 28%',
   input: '217.2 32.6% 17.5%',
   ring: '212.7 26.8% 83.9%',
+  selection: '210 40% 40%',
+  'selection-foreground': '210 40% 98%',
+  'search-highlight': '210 24% 29.6%',
 };
 
 const DEFAULT_PRESET: ThemePreset = {

--- a/src/index.css
+++ b/src/index.css
@@ -539,9 +539,16 @@ html:has(body[data-scroll-locked]) {
   --ui-accent-hover: hsl(var(--primary) / 0.9);
   --ui-accent-soft: hsl(var(--accent));
   --ui-accent-ring: hsl(var(--ring));
-  --ui-selection: hsl(var(--accent));
-  --ui-selection-foreground: hsl(var(--accent-foreground));
-  --ui-search-highlight: hsl(var(--primary) / 0.16);
+  /* Text-selection and search-hit fills. Accent/palettes cannot be trusted
+     here (zen-inspired light accent ≈ card made ::selection invisible,
+     issue #348), so each theme ships derived fills with guaranteed surface
+     contrast; values below mirror DEFAULT_*_COLORS in constants/themePresets.ts. */
+  --selection: 222.2 47.4% 55.5%;
+  --selection-foreground: 222.2 84% 4.9%;
+  --search-highlight: 222.2 28.4% 72.8%;
+  --ui-selection: hsl(var(--selection));
+  --ui-selection-foreground: hsl(var(--selection-foreground));
+  --ui-search-highlight: hsl(var(--search-highlight));
   --ui-search-highlight-foreground: hsl(var(--foreground));
   /* Placeholder text must stay above 4.5:1 on the canvas (WCAG 1.4.3), so it
      uses the full muted-foreground token instead of an alpha wash. */
@@ -588,11 +595,14 @@ html.dark {
   --success-foreground: 222.2 47.4% 11.2%;
   --warning-foreground: 222.2 47.4% 11.2%;
 
-  /* Selection tint: solid accent wash in light mode, translucent ring glow in
-     dark mode (mirrors the pre-tokenization visuals). */
-  --ui-selection: hsl(var(--ring) / 0.3);
-  --ui-selection-foreground: hsl(var(--foreground));
-  --ui-search-highlight: hsl(var(--ring) / 0.28);
+  /* Selection and search-hit fills re-derive per mode for the same
+     guaranteed-contrast reasons as the light block above. */
+  --selection: 210 40% 40%;
+  --selection-foreground: 210 40% 98%;
+  --search-highlight: 210 24% 29.6%;
+  --ui-selection: hsl(var(--selection));
+  --ui-selection-foreground: hsl(var(--selection-foreground));
+  --ui-search-highlight: hsl(var(--search-highlight));
   --ui-search-highlight-foreground: hsl(var(--foreground));
   --ui-placeholder: hsl(var(--muted-foreground));
 


### PR DESCRIPTION
## Summary / 摘要

Fixes #348

Vendored 主题调色板的 `accent` 与卡面几乎同色(Zen 素雅亮色:accent `52 23.1% 87.3%` ≈ card `41.2 42.2% 92.5%`),`::selection` 落在卡面上后肉眼不可见——用户反馈 Release 更新日志里选中文字无任何高亮。逐主题 WCAG 审计发现这是系统性问题:**24 个调色板×模式中 12 个选中态不可见**(全部生成主题的亮色 + t3-chat 暗色),搜索高亮在多数主题下同样过弱(<1.25:1)。

### 修复方案

不再复用任何单一 palette token(实测 accent/primary/ring 在不同主题下均可能贴近表面色),改为在 `scripts/generate-theme-presets.mjs` 中**按模式派生**三个 token(沿用 `border-strong` 的派生先例):

- `selection` / `selection-foreground`:从 primary 取色相(无彩主题回退 ring/accent,保持无彩;主题保持自身色相辨识),落入中间调"荧光笔"区间后双向扫描,直到 ①对全部 5 个文字表面(background/card/popover/secondary/muted)WCAG ≥ 1.5 ②正文前景色在选中底色上可读 ≥ 4.5;输出带防取整 guard(1.55/4.6)
- `search-highlight`:同色相,拉到距表面一半处(弱于选中态,避免混淆);表面集限 card/popover/background——该类只用于仓库卡片,且规避 vendored 调色板的离群 secondary(claude 暗色 secondary 近白、logistic-one 亮色 secondary 近黑)
- `index.css` 与默认主题改为消费新 token,移除亮/暗两套特判(原暗色 `ring/0.3` 在 t3-chat 同样不可见)
- 默认主题值由同一算法派生后硬编码,测试守卫防漂移

### 验证

- 审计脚本:24 个调色板全部通过(选中底色 vs 表面 ≥ 1.5,选中文字 ≥ 4.5,高亮 ≥ 1.25/4.5)
- 新增 vitest 对比度守卫测试(独立 WCAG 实现,含默认主题),防止未来预设回归
- 浏览器实测 Zen 亮/暗、默认亮色选中态截图,均清晰可见
- `typecheck` / `lint` / `vitest`(871)/ `build` 全绿

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化文本选择区域的背景色与文字颜色，在浅色和深色模式下提供更清晰、易读的显示效果。
  - 优化搜索结果高亮颜色，提升不同主题和明暗模式下的可见性与对比度。
  - 所有主题预设现已统一支持文本选择和搜索高亮配色。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->