### PR TITLE
fix(card): 修复拖拽改分类后「在 GitHub 上查看」点击失效；feat(sidebar): 拖拽取消分类

### DIFF
--- a/src/components/CategorySidebar.drop.test.tsx
+++ b/src/components/CategorySidebar.drop.test.tsx
@@ -118,6 +118,28 @@ describe('CategorySidebar drop-to-uncategorize (issue #353 suggestion)', () => {
     expect(syncMocks.forceSyncToBackend).not.toHaveBeenCalled();
   });
 
+  it('无锁定分类且 AI/默认分类均未命中的仓库拖到「全部分类」时保持 no-op（保留 undefined 以便后续 AI 归类）', async () => {
+    const neverMatchedRepo: Repository = {
+      ...categorizedRepo,
+      id: 2,
+      name: 'zzz-project',
+      full_name: 'owner/zzz-project',
+      description: '',
+      language: 'Rust',
+      topics: [],
+      ai_tags: undefined,
+      ai_summary: undefined,
+      custom_category: undefined,
+      category_locked: false,
+    };
+    renderSidebar([neverMatchedRepo]);
+
+    await dropOnCategory('全部分类', '2');
+
+    expect(storeState.updateRepository).not.toHaveBeenCalled();
+    expect(syncMocks.forceSyncToBackend).not.toHaveBeenCalled();
+  });
+
   it('拖到普通分类时沿用原有改分类逻辑（回归保护）', async () => {
     renderSidebar([categorizedRepo]);
 

--- a/src/components/CategorySidebar.drop.test.tsx
+++ b/src/components/CategorySidebar.drop.test.tsx
@@ -1,0 +1,146 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CategorySidebar } from './CategorySidebar';
+import { useAppStore } from '../store/useAppStore';
+import { useRepositoryDragStore } from '../store/useRepositoryDragStore';
+import type { Repository } from '../types';
+
+vi.mock('../store/useAppStore', () => ({
+  useAppStore: vi.fn(),
+  getAllCategories: () => [
+    { id: 'all', name: '全部分类', icon: '📁', keywords: [] },
+    { id: 'cat-b', name: '分类B', icon: '📦', keywords: [], isCustom: true },
+    { id: 'cat-c', name: '分类C', icon: '🧪', keywords: [], isCustom: true },
+  ],
+  sortCategoriesByOrder: (categories: { id: string }[]) => categories,
+}));
+
+const syncMocks = vi.hoisted(() => ({
+  forceSyncToBackend: vi.fn(),
+  toast: vi.fn(),
+}));
+
+vi.mock('../hooks/useDialog', () => ({
+  useDialog: () => ({ toast: syncMocks.toast, confirm: vi.fn().mockResolvedValue(true) }),
+}));
+
+vi.mock('../features/repositories/hooks/useCategorySyncActions', () => ({
+  useCategorySyncActions: () => syncMocks,
+}));
+
+const categorizedRepo: Repository = {
+  id: 1,
+  name: 'example-repository',
+  full_name: 'owner/example-repository',
+  description: 'Repository description',
+  html_url: 'https://github.com/owner/example-repository',
+  stargazers_count: 128,
+  forks_count: 3,
+  forks: 3,
+  language: 'TypeScript',
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-02T00:00:00.000Z',
+  pushed_at: '2026-01-03T00:00:00.000Z',
+  owner: {
+    login: 'owner',
+    avatar_url: 'https://example.com/avatar.png',
+  },
+  topics: ['test'],
+  ai_platforms: ['web', 'cli'],
+  custom_category: '分类B',
+  category_locked: true,
+};
+
+const storeState = {
+  customCategories: [],
+  hiddenDefaultCategoryIds: [],
+  defaultCategoryOverrides: {},
+  categoryOrder: [],
+  collapsedSidebarCategoryCount: 6,
+  categoryMatchMode: 'effective' as const,
+  deleteCustomCategory: vi.fn(),
+  hideDefaultCategory: vi.fn(),
+  showDefaultCategory: vi.fn(),
+  language: 'zh' as const,
+  updateRepository: vi.fn(),
+  isSidebarCollapsed: false,
+  setSidebarCollapsed: vi.fn(),
+};
+
+const mockUseAppStore = vi.mocked(useAppStore);
+
+const renderSidebar = (repositories: Repository[]) =>
+  render(
+    <CategorySidebar
+      repositories={repositories}
+      selectedCategory="cat-b"
+      onCategorySelect={vi.fn()}
+    />
+  );
+
+const dropOnCategory = async (categoryName: string, repoId: string) => {
+  const target = screen.getByText(categoryName);
+  const dataTransfer = { getData: vi.fn(() => repoId) };
+  await act(async () => {
+    fireEvent.drop(target, { dataTransfer });
+  });
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useRepositoryDragStore.getState().endDrag();
+  syncMocks.forceSyncToBackend.mockReset().mockResolvedValue(undefined);
+  mockUseAppStore.mockImplementation(((selector?: (state: typeof storeState) => unknown) => (
+    selector ? selector(storeState) : storeState
+  )) as typeof useAppStore);
+});
+
+describe('CategorySidebar drop-to-uncategorize (issue #353 suggestion)', () => {
+  it('将已分类仓库拖到「全部分类」时显式清空分类并同步后端', async () => {
+    renderSidebar([categorizedRepo]);
+
+    await dropOnCategory('全部分类', String(categorizedRepo.id));
+
+    expect(storeState.updateRepository).toHaveBeenCalledOnce();
+    const updated = storeState.updateRepository.mock.calls[0][0] as Repository;
+    expect(updated.custom_category).toBe('');
+    expect(updated.category_locked).toBe(false);
+    expect(syncMocks.forceSyncToBackend).toHaveBeenCalledOnce();
+    expect(useRepositoryDragStore.getState().isDragging).toBe(false);
+  });
+
+  it('本就无分类的仓库拖到「全部分类」时不写入不同步', async () => {
+    renderSidebar([{ ...categorizedRepo, custom_category: '', category_locked: false }]);
+
+    await dropOnCategory('全部分类', String(categorizedRepo.id));
+
+    expect(storeState.updateRepository).not.toHaveBeenCalled();
+    expect(syncMocks.forceSyncToBackend).not.toHaveBeenCalled();
+  });
+
+  it('拖到普通分类时沿用原有改分类逻辑（回归保护）', async () => {
+    renderSidebar([categorizedRepo]);
+
+    await dropOnCategory('分类C', String(categorizedRepo.id));
+
+    expect(storeState.updateRepository).toHaveBeenCalledOnce();
+    const updated = storeState.updateRepository.mock.calls[0][0] as Repository;
+    expect(updated.custom_category).toBe('分类C');
+    expect(updated.category_locked).toBe(true);
+    expect(syncMocks.forceSyncToBackend).toHaveBeenCalledOnce();
+  });
+
+  it('同步失败时回滚为原始仓库数据', async () => {
+    syncMocks.forceSyncToBackend.mockRejectedValue(new Error('sync failed'));
+    renderSidebar([categorizedRepo]);
+
+    await dropOnCategory('全部分类', String(categorizedRepo.id));
+
+    // 回滚：以原始仓库对象调用 updateRepository
+    expect(storeState.updateRepository).toHaveBeenCalledTimes(2);
+    const rollback = storeState.updateRepository.mock.calls[1][0] as Repository;
+    expect(rollback.custom_category).toBe('分类B');
+    expect(rollback.category_locked).toBe(true);
+    expect(syncMocks.toast).toHaveBeenCalledWith('同步到后端失败，已恢复分类更改。', 'error');
+  });
+});

--- a/src/components/CategorySidebar.tsx
+++ b/src/components/CategorySidebar.tsx
@@ -296,12 +296,20 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
 
     const repoId = event.dataTransfer.getData('application/x-gsm-repository-id');
     const repository = repositoryMap.get(repoId);
+    if (!repository) return;
+
+    const allCategoriesList = getAllCategories(customCategories, language, hiddenDefaultCategoryIds, defaultCategoryOverrides);
 
     // 拖到「全部分类」= 取消分类：显式清空（''），与编辑弹窗清空分类的结果一致；
     // resolveCategoryAssignment 会保留显式清空，后续 AI 重新分析不会重新归类
     if (category.id === 'all') {
-      // 本就无分类（含显式清空过）的仓库无需写入，避免无谓的后端同步
-      if (!repository || repository.custom_category === '') return;
+      // 已显式清空过的仓库无需再写
+      if (repository.custom_category === '') return;
+      // 无锁定分类且 AI/默认分类均未命中时，仓库本就无归属：
+      // 写入 '' 会被 resolveCategoryAssignment 永久保留，阻止后续 AI 重新归类，故 no-op
+      const hasAssignedCategory = !!repository.custom_category ||
+        !!(getAICategory(repository, allCategoriesList) || getDefaultCategory(repository, allCategoriesList));
+      if (!hasAssignedCategory) return;
 
       const originalRepo = { ...repository };
       const nextRepo = {
@@ -320,12 +328,8 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
       return;
     }
 
-    if (!repository) return;
-
     const originalRepo = { ...repository };
 
-    // 获取所有分类用于计算AI和默认分类
-    const allCategoriesList = getAllCategories(customCategories, language, hiddenDefaultCategoryIds, defaultCategoryOverrides);
     const aiCat = getAICategory(repository, allCategoriesList);
     const defaultCat = getDefaultCategory(repository, allCategoriesList);
 
@@ -408,14 +412,14 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
                     onClick={() => handleCategoryClick(category.id)}
                     size="sm"
                     className={`relative flex min-w-[140px] items-center justify-between rounded-md text-left transition-colors ${
-                      isSelected
-                        ? 'bg-accent text-accent-foreground font-medium'
-                        : isDragTarget
-                          ? isUncategorizeHotspot
-                            ? 'bg-warning/10 text-warning ring-1 ring-warning/40'
-                            : 'bg-success/10 text-success ring-1 ring-success/40'
-                          : isUncategorizeHotspot
-                            ? 'border border-dashed border-warning/50 bg-warning/5 text-warning'
+                      isDragTarget
+                        ? isUncategorizeHotspot
+                          ? 'bg-warning/10 text-warning ring-1 ring-warning/40'
+                          : 'bg-success/10 text-success ring-1 ring-success/40'
+                        : isUncategorizeHotspot
+                          ? 'border border-dashed border-warning/50 bg-warning/5 text-warning'
+                          : isSelected
+                            ? 'bg-accent text-accent-foreground font-medium'
                             : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
                     }`}
                     title={category.id !== 'all' ? category.name + " — " + t('可将仓库卡片拖到这里快速改分类', 'Drag repository cards here to quickly change category') : (isUncategorizeHotspot ? t('拖到这里取消分类', 'Drop here to remove category') : undefined)}
@@ -432,13 +436,15 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
                     </div>
                     <span
                       className={`shrink-0 rounded-md px-2 py-0.5 text-xs ${
-                        isSelected
-                          ? 'bg-primary text-primary-foreground'
-                          : isDragTarget
-                            ? isUncategorizeHotspot
-                              ? 'bg-warning/10 text-warning'
-                              : 'bg-success/10 text-success'
-                            : 'bg-muted text-muted-foreground'
+                        isDragTarget
+                          ? isUncategorizeHotspot
+                            ? 'bg-warning/10 text-warning'
+                            : 'bg-success/10 text-success'
+                          : isUncategorizeHotspot
+                            ? 'bg-warning/10 text-warning'
+                            : isSelected
+                              ? 'bg-primary text-primary-foreground'
+                              : 'bg-muted text-muted-foreground'
                       }`}
                     >
                       {count}
@@ -518,14 +524,14 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
                             aria-pressed={isSelected}
                             size="icon"
                             className={`h-8 w-8 rounded-md text-lg transition-all duration-200 ${
-                              isSelected
-                                ? 'bg-accent text-accent-foreground font-medium'
-                                : isDragTarget
-                                  ? isUncategorizeHotspot
-                                    ? 'bg-warning/10 text-warning outline outline-dashed outline-1 outline-warning/50'
-                                    : 'bg-success/10 text-success ring-1 ring-success/40'
-                                  : isUncategorizeHotspot
-                                    ? 'text-warning outline outline-dashed outline-1 outline-warning/50'
+                              isDragTarget
+                                ? isUncategorizeHotspot
+                                  ? 'bg-warning/10 text-warning outline outline-dashed outline-1 outline-warning/50'
+                                  : 'bg-success/10 text-success ring-1 ring-success/40'
+                                : isUncategorizeHotspot
+                                  ? 'text-warning outline outline-dashed outline-1 outline-warning/50'
+                                  : isSelected
+                                    ? 'bg-accent text-accent-foreground font-medium'
                                     : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
                             }`}
                             title={category.id !== 'all' ? category.name + " — " + t('可将仓库卡片拖到这里快速改分类', 'Drag repository cards here to quickly change category') : (isUncategorizeHotspot ? t('取消分类 — 拖到这里取消仓库的分类', 'Uncategorize — drop here to remove category') : category.name)}
@@ -627,14 +633,14 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
                           aria-pressed={isSelected}
                           size="sm"
                           className={`flex h-9 w-full items-center justify-between rounded-md text-left transition-[color,background-color,border-color,opacity,transform] duration-200 ease-out pr-3 ${
-                            isSelected
-                              ? 'bg-accent text-accent-foreground font-medium'
-                              : isDragTarget
-                                ? isUncategorizeHotspot
-                                  ? 'bg-warning/10 text-warning ring-1 ring-warning/40'
-                                  : 'bg-success/10 text-success ring-1 ring-success/40'
-                                : isUncategorizeHotspot
-                                  ? 'border border-dashed border-warning/50 bg-warning/5 text-warning'
+                            isDragTarget
+                              ? isUncategorizeHotspot
+                                ? 'bg-warning/10 text-warning ring-1 ring-warning/40'
+                                : 'bg-success/10 text-success ring-1 ring-success/40'
+                              : isUncategorizeHotspot
+                                ? 'border border-dashed border-warning/50 bg-warning/5 text-warning'
+                                : isSelected
+                                  ? 'bg-accent text-accent-foreground font-medium'
                                   : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
                           } ${showText ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-3'}`}
                           title={category.id !== 'all' ? category.name + " — " + t('可将仓库卡片拖到这里快速改分类', 'Drag repository cards here to quickly change category') : (isUncategorizeHotspot ? t('取消分类 — 拖到这里取消仓库的分类', 'Uncategorize — drop here to remove category') : undefined)}
@@ -655,13 +661,15 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
                           {/* 数字 badge - 正常状态显示，hover/focus-within 时隐藏 */}
                           <span
                               className={`ml-auto flex min-w-8 shrink-0 justify-center rounded-md px-2 py-0.5 text-xs transition-[color,background-color,border-color,opacity,transform] duration-200 ease-out ${
-                              isSelected
-                                ? 'bg-primary text-primary-foreground'
-                                : isDragTarget
-                                  ? isUncategorizeHotspot
-                                    ? 'bg-warning/20 text-warning'
-                                    : 'bg-success/20 text-success'
-                                  : 'bg-muted text-muted-foreground'
+                              isDragTarget
+                                ? isUncategorizeHotspot
+                                  ? 'bg-warning/20 text-warning'
+                                  : 'bg-success/20 text-success'
+                                : isUncategorizeHotspot
+                                  ? 'bg-warning/20 text-warning'
+                                  : isSelected
+                                    ? 'bg-primary text-primary-foreground'
+                                    : 'bg-muted text-muted-foreground'
                             } ${showText ? 'opacity-100 scale-100' : 'opacity-0 scale-75'} group-hover:opacity-0 group-focus-within:opacity-0`}
                           >
                             {count}

--- a/src/components/CategorySidebar.tsx
+++ b/src/components/CategorySidebar.tsx
@@ -7,9 +7,11 @@ import {
   EyeOff,
   ChevronLeft,
   ChevronRight,
+  Undo2,
 } from 'lucide-react';
 import { Category, Repository } from '../types';
 import { useAppStore, getAllCategories, sortCategoriesByOrder } from '../store/useAppStore';
+import { useRepositoryDragStore } from '../store/useRepositoryDragStore';
 import { useShallow } from 'zustand/react/shallow';
 import { CategoryEditModal } from './CategoryEditModal';
 import { useCategorySyncActions } from '../features/repositories/hooks/useCategorySyncActions';
@@ -59,6 +61,8 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
 
   const { toast, confirm } = useDialog();
   const { forceSyncToBackend } = useCategorySyncActions();
+  // 仓库卡片拖拽中：驱动「全部分类」变为「取消分类」热区提示
+  const isRepoDragging = useRepositoryDragStore((state) => state.isDragging);
 
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [editingCategory, setEditingCategory] = useState<Category | null>(null);
@@ -286,10 +290,36 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
       justDroppedRef.current = false;
     }, 300);
 
-    if (category.id === 'all') return;
+    // drop 先于 dragend 派发；若当前正处于某分类视图，源卡片即将因分类变更
+    // 从列表卸载，其 React dragend 将丢失，这里显式复位拖拽状态（issue #353）
+    useRepositoryDragStore.getState().endDrag();
 
     const repoId = event.dataTransfer.getData('application/x-gsm-repository-id');
     const repository = repositoryMap.get(repoId);
+
+    // 拖到「全部分类」= 取消分类：显式清空（''），与编辑弹窗清空分类的结果一致；
+    // resolveCategoryAssignment 会保留显式清空，后续 AI 重新分析不会重新归类
+    if (category.id === 'all') {
+      // 本就无分类（含显式清空过）的仓库无需写入，避免无谓的后端同步
+      if (!repository || repository.custom_category === '') return;
+
+      const originalRepo = { ...repository };
+      const nextRepo = {
+        ...repository,
+        custom_category: '',
+        category_locked: false,
+        last_edited: new Date().toISOString(),
+      };
+      updateRepository(nextRepo);
+
+      try {
+        await forceSyncToBackend();
+      } catch {
+        handleSyncError(originalRepo);
+      }
+      return;
+    }
+
     if (!repository) return;
 
     const originalRepo = { ...repository };
@@ -355,13 +385,14 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
               const count = getCategoryCount(category);
               const isSelected = selectedCategory === category.id;
               const isDragTarget = dragOverCategoryId === category.id;
+              // 拖拽仓库时「全部分类」变为「取消分类」拖放热区
+              const isUncategorizeHotspot = category.id === 'all' && isRepoDragging;
 
               return (
                 <div
                   key={category.id}
                   className="group shrink-0"
                   onDragOver={(event) => {
-                    if (category.id === 'all') return;
                     event.preventDefault();
                     setDragOverCategoryId(category.id);
                   }}
@@ -380,23 +411,33 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
                       isSelected
                         ? 'bg-accent text-accent-foreground font-medium'
                         : isDragTarget
-                          ? 'bg-success/10 text-success ring-1 ring-success/40'
-                          : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
+                          ? isUncategorizeHotspot
+                            ? 'bg-warning/10 text-warning ring-1 ring-warning/40'
+                            : 'bg-success/10 text-success ring-1 ring-success/40'
+                          : isUncategorizeHotspot
+                            ? 'border border-dashed border-warning/50 bg-warning/5 text-warning'
+                            : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
                     }`}
-                    title={category.id !== 'all' ? category.name + " — " + t('可将仓库卡片拖到这里快速改分类', 'Drag repository cards here to quickly change category') : undefined}
+                    title={category.id !== 'all' ? category.name + " — " + t('可将仓库卡片拖到这里快速改分类', 'Drag repository cards here to quickly change category') : (isUncategorizeHotspot ? t('拖到这里取消分类', 'Drop here to remove category') : undefined)}
                     aria-pressed={isSelected}
                     aria-current={isSelected ? 'page' : undefined}
                   >
                     <div className="flex items-center space-x-3 min-w-0 flex-1">
-                      <span className="text-base flex-shrink-0">{category.icon}</span>
-                      <span className="text-sm font-medium truncate">{category.name}</span>
+                      <span className="text-base flex-shrink-0">
+                        {isUncategorizeHotspot ? <Undo2 className="h-4 w-4" /> : category.icon}
+                      </span>
+                      <span className="text-sm font-medium truncate">
+                        {isUncategorizeHotspot ? t('取消分类', 'Uncategorize') : category.name}
+                      </span>
                     </div>
                     <span
                       className={`shrink-0 rounded-md px-2 py-0.5 text-xs ${
                         isSelected
                           ? 'bg-primary text-primary-foreground'
                           : isDragTarget
-                            ? 'bg-success/10 text-success'
+                            ? isUncategorizeHotspot
+                              ? 'bg-warning/10 text-warning'
+                              : 'bg-success/10 text-success'
                             : 'bg-muted text-muted-foreground'
                       }`}
                     >
@@ -455,12 +496,12 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
                     return displayCategories.map((category) => {
                       const isSelected = selectedCategory === category.id;
                       const isDragTarget = dragOverCategoryId === category.id;
+                      const isUncategorizeHotspot = category.id === 'all' && isRepoDragging;
                       return (
                         <div
                           key={category.id}
                           className="group relative"
                           onDragOver={(event) => {
-                            if (category.id === 'all') return;
                             event.preventDefault();
                             setDragOverCategoryId(category.id);
                           }}
@@ -480,13 +521,17 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
                               isSelected
                                 ? 'bg-accent text-accent-foreground font-medium'
                                 : isDragTarget
-                                  ? 'bg-success/10 text-success ring-1 ring-success/40'
-                                  : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
+                                  ? isUncategorizeHotspot
+                                    ? 'bg-warning/10 text-warning outline outline-dashed outline-1 outline-warning/50'
+                                    : 'bg-success/10 text-success ring-1 ring-success/40'
+                                  : isUncategorizeHotspot
+                                    ? 'text-warning outline outline-dashed outline-1 outline-warning/50'
+                                    : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
                             }`}
-                            title={category.id !== 'all' ? category.name + " — " + t('可将仓库卡片拖到这里快速改分类', 'Drag repository cards here to quickly change category') : category.name}
-                            aria-label={category.name}
+                            title={category.id !== 'all' ? category.name + " — " + t('可将仓库卡片拖到这里快速改分类', 'Drag repository cards here to quickly change category') : (isUncategorizeHotspot ? t('取消分类 — 拖到这里取消仓库的分类', 'Uncategorize — drop here to remove category') : category.name)}
+                            aria-label={isUncategorizeHotspot ? t('取消分类', 'Uncategorize') : category.name}
                           >
-                            {category.icon}
+                            {isUncategorizeHotspot ? <Undo2 className="h-4 w-4" /> : category.icon}
                           </Button>
                         </div>
                       );
@@ -555,6 +600,8 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
                     const count = getCategoryCount(category);
                     const isSelected = selectedCategory === category.id;
                     const isDragTarget = dragOverCategoryId === category.id;
+                    // 拖拽仓库时「全部分类」变为「取消分类」拖放热区
+                    const isUncategorizeHotspot = category.id === 'all' && isRepoDragging;
 
                     return (
                       <div
@@ -564,7 +611,6 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
                           transitionDelay: showText ? `${Math.min(index * 30, 300)}ms` : '0ms',
                         }}
                         onDragOver={(event) => {
-                          if (category.id === 'all') return;
                           event.preventDefault();
                           setDragOverCategoryId(category.id);
                         }}
@@ -584,19 +630,25 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
                             isSelected
                               ? 'bg-accent text-accent-foreground font-medium'
                               : isDragTarget
-                                ? 'bg-success/10 text-success ring-1 ring-success/40'
-                                : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
+                                ? isUncategorizeHotspot
+                                  ? 'bg-warning/10 text-warning ring-1 ring-warning/40'
+                                  : 'bg-success/10 text-success ring-1 ring-success/40'
+                                : isUncategorizeHotspot
+                                  ? 'border border-dashed border-warning/50 bg-warning/5 text-warning'
+                                  : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
                           } ${showText ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-3'}`}
-                          title={category.id !== 'all' ? category.name + " — " + t('可将仓库卡片拖到这里快速改分类', 'Drag repository cards here to quickly change category') : undefined}
+                          title={category.id !== 'all' ? category.name + " — " + t('可将仓库卡片拖到这里快速改分类', 'Drag repository cards here to quickly change category') : (isUncategorizeHotspot ? t('取消分类 — 拖到这里取消仓库的分类', 'Uncategorize — drop here to remove category') : undefined)}
                         >
                           <div className="flex items-center space-x-3 min-w-0 flex-1">
-                            <span className="text-base flex-shrink-0">{category.icon}</span>
+                            <span className="text-base flex-shrink-0">
+                              {isUncategorizeHotspot ? <Undo2 className="h-4 w-4" /> : category.icon}
+                            </span>
                             <span
                               className={`text-sm font-medium truncate transition-[opacity,transform] duration-200 ease-out ${
                                 showText ? 'opacity-100 translate-x-0' : 'opacity-0 -translate-x-2'
                               }`}
                             >
-                              {category.name}
+                              {isUncategorizeHotspot ? t('取消分类', 'Uncategorize') : category.name}
                             </span>
                           </div>
 
@@ -606,7 +658,9 @@ export const CategorySidebar: React.FC<CategorySidebarProps> = ({
                               isSelected
                                 ? 'bg-primary text-primary-foreground'
                                 : isDragTarget
-                                  ? 'bg-success/20 text-success'
+                                  ? isUncategorizeHotspot
+                                    ? 'bg-warning/20 text-warning'
+                                    : 'bg-success/20 text-success'
                                   : 'bg-muted text-muted-foreground'
                             } ${showText ? 'opacity-100 scale-100' : 'opacity-0 scale-75'} group-hover:opacity-0 group-focus-within:opacity-0`}
                           >

--- a/src/components/RepositoryCard.test.tsx
+++ b/src/components/RepositoryCard.test.tsx
@@ -423,3 +423,35 @@ describe('RepositoryCard interactive-element click exemption (issue #353)', () =
   });
 });
 
+
+describe('RepositoryCard touch-drag click suppression (CodeRabbit #355)', () => {
+  it('suppresses the compatibility click after a touch drag even when a compatibility mousemove fires', () => {
+    const { container } = renderRepositoryCard('grid');
+    const card = container.firstElementChild as HTMLElement;
+    const handle = card.querySelector('[draggable="true"]') as HTMLElement;
+
+    fireEvent.touchStart(handle, { touches: [{ clientX: 10, clientY: 10 }] });
+    fireEvent.touchMove(handle, { touches: [{ clientX: 60, clientY: 60 }] });
+    fireEvent.touchEnd(handle, { touches: [] });
+
+    // 触摸后的兼容鼠标事件序列：mousemove 触发 dragStore 兜底清位，
+    // 但实例级抑制标志必须仍然拦截补发的 click
+    fireEvent.mouseMove(document.body);
+    expect(useRepositoryDragStore.getState().isDragging).toBe(false);
+    expect(fireEvent.click(card)).toBe(false);
+    expect(screen.queryByTestId('readme-modal')).not.toBeInTheDocument();
+  });
+
+  it('keeps the GitHub link navigable after a touch drag with compatibility mouse events', () => {
+    const { container } = renderRepositoryCard('grid');
+    const card = container.firstElementChild as HTMLElement;
+    const handle = card.querySelector('[draggable="true"]') as HTMLElement;
+
+    fireEvent.touchStart(handle, { touches: [{ clientX: 10, clientY: 10 }] });
+    fireEvent.touchMove(handle, { touches: [{ clientX: 60, clientY: 60 }] });
+    fireEvent.touchEnd(handle, { touches: [] });
+    fireEvent.mouseMove(document.body);
+
+    expect(fireEvent.click(screen.getByTitle('在GitHub上查看'))).toBe(true);
+  });
+});

--- a/src/components/RepositoryCard.test.tsx
+++ b/src/components/RepositoryCard.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RepositoryCard } from './RepositoryCard';
 import { useAppStore } from '../store/useAppStore';
+import { useRepositoryDragStore } from '../store/useRepositoryDragStore';
 import type { Repository } from '../types';
 
 const actionMocks = vi.hoisted(() => ({
@@ -130,6 +131,7 @@ const renderRepositoryCard = (
 beforeEach(() => {
   vi.clearAllMocks();
   actionMocks.releaseSheet.suspend = null;
+  useRepositoryDragStore.getState().endDrag();
   storeState.releaseSubscriptions = new Set<number>([1]);
   storeState.vectorSearchConfig.enabled = true;
   Object.assign(actionMocks.actions, {
@@ -372,3 +374,52 @@ describe('RepositoryCard view modes', () => {
     expect(screen.getByRole('menuitem', { name: '问答此仓库' })).toBeInTheDocument();
   });
 });
+
+describe('RepositoryCard interactive-element click exemption (issue #353)', () => {
+  it('keeps the GitHub link navigable while the drag flag is stuck', () => {
+    renderRepositoryCard('grid');
+
+    act(() => {
+      useRepositoryDragStore.getState().startDrag();
+    });
+
+    // fireEvent.click 返回 false 表示事件被 preventDefault 取消
+    expect(fireEvent.click(screen.getByTitle('在GitHub上查看'))).toBe(true);
+    expect(screen.queryByTestId('readme-modal')).not.toBeInTheDocument();
+
+    act(() => {
+      useRepositoryDragStore.getState().endDrag();
+    });
+  });
+
+  it('still swallows blank-area card clicks while dragging', () => {
+    const { container } = renderRepositoryCard('grid');
+    const card = container.firstElementChild as HTMLElement;
+
+    act(() => {
+      useRepositoryDragStore.getState().startDrag();
+    });
+
+    expect(fireEvent.click(card)).toBe(false);
+
+    act(() => {
+      useRepositoryDragStore.getState().endDrag();
+    });
+  });
+
+  it('keeps the GitHub link navigable right after an edit-modal outside dismiss', async () => {
+    const user = userEvent.setup();
+    renderRepositoryCard('grid');
+
+    await user.click(screen.getByTitle('编辑仓库信息'));
+    const editModal = screen.getByTestId('repository-edit-modal');
+
+    // onOutsideDismiss 记录 dismiss 时间戳后，250ms 窗口内点击链接不被吞
+    // （真实弹窗由 Radix 关闭；mock 无关闭机制，不影响时间窗语义）
+    await act(async () => {
+      fireEvent.pointerDown(editModal);
+      expect(fireEvent.click(screen.getByTitle('在GitHub上查看'))).toBe(true);
+    });
+  });
+});
+

--- a/src/components/RepositoryCard.test.tsx
+++ b/src/components/RepositoryCard.test.tsx
@@ -455,3 +455,35 @@ describe('RepositoryCard touch-drag click suppression (CodeRabbit #355)', () => 
     expect(fireEvent.click(screen.getByTitle('在GitHub上查看'))).toBe(true);
   });
 });
+
+describe('RepositoryCard rapid touch drags (CodeRabbit round 2)', () => {
+  it('keeps suppressing the compatibility click when a second touch drag starts within 200ms', () => {
+    vi.useFakeTimers();
+    try {
+      const { container } = renderRepositoryCard('grid');
+      const card = container.firstElementChild as HTMLElement;
+      const handle = card.querySelector('[draggable="true"]') as HTMLElement;
+
+      const dragOnce = () => {
+        fireEvent.touchStart(handle, { touches: [{ clientX: 10, clientY: 10 }] });
+        fireEvent.touchMove(handle, { touches: [{ clientX: 60, clientY: 60 }] });
+        fireEvent.touchEnd(handle, { touches: [] });
+      };
+
+      dragOnce();
+      // 第二次拖拽开始时，第一次的复位定时器尚未触发
+      vi.advanceTimersByTime(100);
+      dragOnce();
+      // 推进越过第一次定时器的原定触发点：不得提前清掉第二次的抑制标志
+      vi.advanceTimersByTime(120);
+      expect(fireEvent.click(card)).toBe(false);
+      expect(screen.queryByTestId('readme-modal')).not.toBeInTheDocument();
+
+      // 抑制窗口正常过期后恢复
+      vi.advanceTimersByTime(200);
+      expect(fireEvent.click(card)).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -256,6 +256,9 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
       if (dragHintTimeoutRef.current) {
         clearTimeout(dragHintTimeoutRef.current);
       }
+      if (touchSuppressTimeoutRef.current) {
+        clearTimeout(touchSuppressTimeoutRef.current);
+      }
     };
   }, []);
 
@@ -468,6 +471,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
   const dragHandleRef = useRef<HTMLDivElement>(null);
   const touchStartPosRef = useRef<{ x: number; y: number } | null>(null);
   const isTouchDraggingRef = useRef(false);
+  const touchSuppressTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleDragStart = (event: React.DragEvent<HTMLDivElement>) => {
     event.dataTransfer.setData('application/x-gsm-repository-id', String(repository.id));
@@ -513,6 +517,11 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
     const touch = event.touches[0];
     touchStartPosRef.current = { x: touch.clientX, y: touch.clientY };
     isTouchDraggingRef.current = false;
+    // 取消上一次拖拽的抑制定时器，避免其在本次拖拽的抑制窗口内提前清位
+    if (touchSuppressTimeoutRef.current) {
+      clearTimeout(touchSuppressTimeoutRef.current);
+      touchSuppressTimeoutRef.current = null;
+    }
   };
 
   const handleTouchMove = (event: React.TouchEvent) => {
@@ -533,9 +542,13 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
       // 触摸拖拽后的兼容鼠标事件序列（touchend → mousemove → click）会让
       // dragStore 的 document 级 mousemove 兜底立即清位，因此触摸拖拽不能
       // 走全局拖拽状态；用实例级标志独立抑制 200ms 内补发的 click。
-      // 期间新触摸由 handleTouchStart 重置，不受残留影响。
-      setTimeout(() => {
+      // 重启窗口前先取消旧定时器，防止连续快速拖拽时旧定时器提前清位。
+      if (touchSuppressTimeoutRef.current) {
+        clearTimeout(touchSuppressTimeoutRef.current);
+      }
+      touchSuppressTimeoutRef.current = setTimeout(() => {
         isTouchDraggingRef.current = false;
+        touchSuppressTimeoutRef.current = null;
       }, 200);
     }
     touchStartPosRef.current = null;

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -530,14 +530,15 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
 
   const handleTouchEnd = () => {
     if (isTouchDraggingRef.current) {
-      // 如果发生了拖拽，阻止后续点击事件（触摸序列会在 touchend 后补发 click）
-      useRepositoryDragStore.getState().startDrag();
+      // 触摸拖拽后的兼容鼠标事件序列（touchend → mousemove → click）会让
+      // dragStore 的 document 级 mousemove 兜底立即清位，因此触摸拖拽不能
+      // 走全局拖拽状态；用实例级标志独立抑制 200ms 内补发的 click。
+      // 期间新触摸由 handleTouchStart 重置，不受残留影响。
       setTimeout(() => {
-        useRepositoryDragStore.getState().endDrag();
+        isTouchDraggingRef.current = false;
       }, 200);
     }
     touchStartPosRef.current = null;
-    isTouchDraggingRef.current = false;
   };
 
   // 使用 ref 记录当前选中状态，避免闭包问题
@@ -598,8 +599,8 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
       return;
     }
 
-    // 如果正在拖拽，不处理点击
-    if (isDraggingRef.current || useRepositoryDragStore.getState().isDragging) {
+    // 如果正在拖拽，不处理点击（含触摸拖拽后的兼容 click 抑制窗口）
+    if (isDraggingRef.current || isTouchDraggingRef.current || useRepositoryDragStore.getState().isDragging) {
       event.preventDefault();
       event.stopPropagation();
       return;

--- a/src/components/RepositoryCard.tsx
+++ b/src/components/RepositoryCard.tsx
@@ -8,6 +8,7 @@ import { useRepositoryPlatforms } from '../hooks/useRepositoryPlatforms';
 import { GripVertical, Star, StarOff, ExternalLink, Calendar, Bell, BellOff, Bot, Sparkles, Terminal, Edit3, BookOpen, Square, CheckSquare, Loader2, HelpCircle, Search, Scale, MoreHorizontal, PackageOpen, MessageSquareText } from 'lucide-react';
 import { Repository, Category } from '../types';
 import { useAppStore } from '../store/useAppStore';
+import { useRepositoryDragStore } from '../store/useRepositoryDragStore';
 import { getAICategory, getDefaultCategory } from '../utils/categoryUtils';
 import { formatDistanceToNow } from 'date-fns';
 import { zhCN } from 'date-fns/locale';
@@ -483,15 +484,15 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
     event.stopPropagation();
     isDraggingRef.current = true;
     // 标记正在拖拽，防止触发卡片点击
-    (window as Window & { __isDraggingRepo?: boolean }).__isDraggingRepo = true;
+    // 全局状态走 dragStore：document 级兜底监听保证源卡片在 drop 时
+    // 被卸载（如分类视图切换）后拖拽状态仍能可靠清除（issue #353）
+    useRepositoryDragStore.getState().startDrag();
   };
 
   const handleDragEnd = () => {
     isDraggingRef.current = false;
-    // 拖拽结束后延迟清除标记，确保 click 事件能检测到拖拽状态
-    setTimeout(() => {
-      (window as Window & { __isDraggingRepo?: boolean }).__isDraggingRepo = false;
-    }, 200);
+    // document 兜底监听通常已先行复位；此处同步调用保持幂等一致
+    useRepositoryDragStore.getState().endDrag();
   };
 
   const handleDragHandleMouseDown = (event: React.MouseEvent) => {
@@ -501,7 +502,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
 
   const handleDragHandleClick = (event: React.MouseEvent) => {
     // 如果发生了拖拽，阻止点击事件
-    if (isDraggingRef.current || (window as Window & { __isDraggingRepo?: boolean }).__isDraggingRepo) {
+    if (isDraggingRef.current || useRepositoryDragStore.getState().isDragging) {
       event.preventDefault();
       event.stopPropagation();
     }
@@ -529,10 +530,10 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
 
   const handleTouchEnd = () => {
     if (isTouchDraggingRef.current) {
-      // 如果发生了拖拽，阻止后续点击事件
-      (window as Window & { __isDraggingRepo?: boolean }).__isDraggingRepo = true;
+      // 如果发生了拖拽，阻止后续点击事件（触摸序列会在 touchend 后补发 click）
+      useRepositoryDragStore.getState().startDrag();
       setTimeout(() => {
-        (window as Window & { __isDraggingRepo?: boolean }).__isDraggingRepo = false;
+        useRepositoryDragStore.getState().endDrag();
       }, 200);
     }
     touchStartPosRef.current = null;
@@ -562,6 +563,14 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
 
   // 使用 useCallback 优化事件处理函数
   const handleCardClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    // 点击目标是链接/按钮等交互元素时永不拦截：链接导航与按钮动作必须保留
+    // 默认行为；时间窗防误触（弹窗关闭防抖/拖拽标志）只应作用于卡片空白区域。
+    // 交互元素检查必须先于所有拦截分支，否则弹窗关闭防抖或拖拽标志一旦
+    // 滞留，「在 GitHub 上查看」等链接会被 preventDefault 吞掉（issue #353）。
+    const target = event.target as HTMLElement;
+    // 排除卡片本身的 role="button"，只检查子元素的交互元素
+    if (target.closest('button, a, input, textarea, select, [draggable="true"]')) return;
+
     const releaseSheetDismissedAt = releaseSheetOutsideDismissedAtRef.current;
     if (releaseSheetDismissedAt !== null) {
       releaseSheetOutsideDismissedAtRef.current = null;
@@ -590,7 +599,7 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
     }
 
     // 如果正在拖拽，不处理点击
-    if (isDraggingRef.current || (window as Window & { __isDraggingRepo?: boolean }).__isDraggingRepo) {
+    if (isDraggingRef.current || useRepositoryDragStore.getState().isDragging) {
       event.preventDefault();
       event.stopPropagation();
       return;
@@ -599,14 +608,6 @@ const RepositoryCardComponent: React.FC<RepositoryCardProps> = ({
     const dismissedByPointerDown = menuDismissedByPointerDownRef.current;
     menuDismissedByPointerDownRef.current = false;
     if (dismissedByPointerDown) return;
-
-    // 检查点击目标是否是交互元素或其子元素
-    const target = event.target as HTMLElement;
-    // 排除卡片本身的 role="button"，只检查子元素的交互元素
-    const isInteractiveElement = target.closest('button, a, input, textarea, select, [draggable="true"]');
-
-    // 如果点击的是交互元素，不处理
-    if (isInteractiveElement) return;
 
     // 菜单展开时，点击卡片空白处仅收起菜单，不触发详情或选择。
     if (isActionsMenuOpen) {

--- a/src/store/useRepositoryDragStore.test.ts
+++ b/src/store/useRepositoryDragStore.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useRepositoryDragStore } from './useRepositoryDragStore';
+
+const dispatchDragEnd = () => document.dispatchEvent(new Event('dragend'));
+const dispatchMouseMove = () => document.dispatchEvent(new Event('mousemove'));
+
+describe('useRepositoryDragStore', () => {
+  beforeEach(() => {
+    useRepositoryDragStore.getState().endDrag();
+  });
+
+  it('startDrag 置位拖拽状态', () => {
+    useRepositoryDragStore.getState().startDrag();
+    expect(useRepositoryDragStore.getState().isDragging).toBe(true);
+  });
+
+  it('document 级 dragend 兜底清除拖拽状态', () => {
+    useRepositoryDragStore.getState().startDrag();
+    dispatchDragEnd();
+    expect(useRepositoryDragStore.getState().isDragging).toBe(false);
+  });
+
+  it('document 级 mousemove 兜底清除拖拽状态（dragend 丢失时的恢复路径）', () => {
+    useRepositoryDragStore.getState().startDrag();
+    dispatchMouseMove();
+    expect(useRepositoryDragStore.getState().isDragging).toBe(false);
+  });
+
+  it('endDrag 幂等，重复调用安全', () => {
+    const state = useRepositoryDragStore.getState();
+    state.startDrag();
+    state.endDrag();
+    state.endDrag();
+    expect(useRepositoryDragStore.getState().isDragging).toBe(false);
+  });
+
+  it('重复 startDrag 不叠加监听：一次 dragend 即可清位', () => {
+    const state = useRepositoryDragStore.getState();
+    state.startDrag();
+    state.startDrag();
+    dispatchDragEnd();
+    expect(useRepositoryDragStore.getState().isDragging).toBe(false);
+    // 清位后兜底监听已全部移除，后续事件不再影响状态
+    state.startDrag();
+    expect(useRepositoryDragStore.getState().isDragging).toBe(true);
+    state.endDrag();
+  });
+});

--- a/src/store/useRepositoryDragStore.ts
+++ b/src/store/useRepositoryDragStore.ts
@@ -1,0 +1,52 @@
+import { create } from 'zustand';
+
+interface RepositoryDragState {
+  isDragging: boolean;
+  /** 开始一次仓库卡片拖拽：置位并注册 document 级兜底监听 */
+  startDrag: () => void;
+  /** 结束拖拽：幂等，移除兜底监听 */
+  endDrag: () => void;
+}
+
+/**
+ * 仓库卡片拖拽中的瞬态状态（不持久化）。
+ *
+ * 为什么不能只依赖卡片自身的 React onDragEnd：drop 时若源卡片因分类变更
+ * 从当前视图卸载，浏览器向已脱离 DOM 的源节点派发 dragend，React 委托在
+ * 根容器的合成事件收不到，endDrag 就永远不会执行（issue #353 的根因）。
+ * 因此 startDrag 同时注册 document 级原生监听兜底：
+ * - dragend（capture）：覆盖源节点仍挂载的正常路径；
+ * - mousemove（capture, once）：HTML5 拖拽期间浏览器抑制 mousemove，
+ *   拖拽一结束立即恢复派发，即使 dragend 丢失也能可靠清位。
+ */
+export const useRepositoryDragStore = create<RepositoryDragState>()((set, get) => {
+  let cleanupFallback: (() => void) | null = null;
+
+  const endDrag = () => {
+    if (cleanupFallback) {
+      cleanupFallback();
+      cleanupFallback = null;
+    }
+    if (get().isDragging) {
+      set({ isDragging: false });
+    }
+  };
+
+  return {
+    isDragging: false,
+    startDrag: () => {
+      endDrag();
+      set({ isDragging: true });
+
+      const onDragEnd = () => endDrag();
+      const onMouseMove = () => endDrag();
+      document.addEventListener('dragend', onDragEnd, true);
+      document.addEventListener('mousemove', onMouseMove, true);
+      cleanupFallback = () => {
+        document.removeEventListener('dragend', onDragEnd, true);
+        document.removeEventListener('mousemove', onMouseMove, true);
+      };
+    },
+    endDrag,
+  };
+});


### PR DESCRIPTION
## 关联 Issue

Closes #353（BUG 部分）；「取消分类」操作为该 issue 中的用户建议。

## 改动一：修复「在 GitHub 上查看」点击失效（BUG）

### 根因

在具体分类视图（如分类 B）内将仓库拖到另一分类（C）时，drop 阶段 `updateRepository` 同步触发卡片从列表卸载；浏览器随后向已脱离 DOM 的源节点派发 `dragend`，React 委托在根容器的合成事件无法收到，`handleDragEnd` 永不执行，全局标志 `window.__isDraggingRepo` 永久滞留为 `true`。之后任何卡片点击都会命中 `handleCardClick` 的拖拽检查（位于链接判断**之前**），`preventDefault()` 吞掉 `<a target="_blank">` 的导航——「在 GitHub 上查看」点击无反应。

从「全部分类」视图拖拽不会触发（卡片不卸载，dragend 正常），与报告者的复现路径及 workaround 完全吻合。

### 修复（双层）

1. **交互元素豁免统一前置**：`handleCardClick` 中 `closest('button, a, input, ...')` 检查提前至**所有**拦截分支（拖拽标志、releaseSheet/editModal 关闭防抖）之前——链接与按钮的默认行为永不拦截，时间窗防误触只作用于卡片空白区域。弹窗关闭防抖的原设计意图（点空白关弹窗不误开 README）完整保留。
2. **拖拽状态改由 `useRepositoryDragStore` 管理**（替代 window 标志）：`startDrag` 注册 document 级 `dragend`（capture）+ `mousemove`（capture）兜底监听——HTML5 拖拽期间浏览器抑制 mousemove，拖拽一结束立即恢复派发，即使源节点卸载导致 dragend 丢失，拖拽结束后首次鼠标移动即可可靠复位。侧栏 drop 处理也在 drop（先于 dragend）阶段显式复位。

## 改动二：拖拽仓库至「全部分类」= 取消分类（用户建议）

- drop 到「全部分类」时显式清空分类：`custom_category=''` 且 `category_locked=false`，与编辑弹窗清空分类的落库结果一致；`resolveCategoryAssignment` 会保留显式清空，后续 AI 重新分析不会重新归类
- 本就无分类的仓库 drop 到「全部分类」为 no-op，不触发无谓的后端同步；同步失败沿用现有回滚 + toast
- 拖拽仓库期间，侧栏三处「全部分类」（移动端 chips / 折叠态图标 / 展开态列表）变为「取消分类 / Uncategorize」+ Undo2 图标 + warning 色虚框底色热区提示，悬停高亮用 warning 色与普通分类的 success 色区分撤销语义
- 三处 `onDragOver` 放开对 all 的排除，使其成为合法 drop 目标（此前不调用 `preventDefault()`，drop 事件根本不会触发）

## 测试

- 新增 `useRepositoryDragStore.test.ts`：拖拽置位 / dragend 兜底 / mousemove 兜底 / 幂等 / 重复 startDrag 不叠听
- `RepositoryCard.test.tsx` 新增 3 条回归：拖拽标志滞留时链接可点、拖拽时空白点击仍被拦、editModal 关闭后 250ms 内链接可点
- 新增 `CategorySidebar.drop.test.tsx` 4 条：drop 到 all 清空分类并同步、无分类 no-op、普通分类 drop 回归、同步失败回滚
- 全量 908 tests / 93 files 通过，lint / build / bundle-size 检查通过

## 手动验收建议（对应 issue 复现路径）

1. 分类 B 视图 → 拖仓库 a 到 C → 立即点「在 GitHub 上查看」→ 正常新开标签
2. 同路径后点卡片空白处 → README 弹窗正常
3. 拖拽任意仓库 → 侧栏「全部分类」变「取消分类」虚框热区，放下后仓库不再属于任何分类
4. 取消分类后触发 AI 重新分析 → 仓库不被重新归类
5. 拖拽中途 ESC / 拖到空白处松手 → 文案恢复、后续点击正常

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 拖动仓库至“取消分类”区域即可清除分类并同步保存。
  * 支持在移动端、折叠侧栏和展开侧栏中使用“取消分类”操作。

* **问题修复**
  * 修复无分类仓库被重复写入的问题，保留后续自动分类能力。
  * 修复拖拽结束状态未及时清理导致的点击拦截问题。
  * 优化连续触摸拖拽后的点击处理，确保链接和卡片交互正常。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->